### PR TITLE
correct bounding box in GEQDSK 2D plots

### DIFF
--- a/matlab/EFIT/efit.m
+++ b/matlab/EFIT/efit.m
@@ -392,7 +392,7 @@ classdef efit < handle
             %##############################################################
             
             %calculate contours
-            x = linspace(obj.rcentr - obj.rdim / 2, obj.rcentr + obj.rdim / 2, obj.nw);
+            x = linspace(obj.rleft, obj.rleft + obj.rdim, obj.nw);
             y = linspace(obj.zmid - obj.zdim / 2, obj.zmid + obj.zdim / 2, obj.nh);
             [X, Y] = meshgrid(x, y);
             


### PR DESCRIPTION
For equilibria like `/proj/plasma/DATA/MAST-U/david_ryan/ModPack2/47046/g_EPQ_p47046_t0.57200` the position of the psi contours is clearly shifted compared to the positions of the magnetic axis, the separatrix and the vacuum vessel, all of which are retrieved from different data sets in the GEQDSK file. The computational box has extents `RDIM` and `ZDIM`, and should be centered vertically around `ZMID` and extend to the right of `RLEFT`.