### PR TITLE
Put core subroutines into modules

### DIFF
--- a/src/magfie/bdivfree.f90
+++ b/src/magfie/bdivfree.f90
@@ -1730,6 +1730,7 @@ subroutine smear_formfactors(nmodes_ff,nsqpsi_ff,sqpsimin_ff,sqpsimax_ff, &
   use inthecore_mod, only : psi_sep,psi_cut
   use libneo_kinds, only : complex_kind, real_kind
   use theta_rz_mod,  only : psiaxis
+  use field_sub,   only : inthecore,localizer
 
   implicit none
 

--- a/src/magfie/bdivfree.f90
+++ b/src/magfie/bdivfree.f90
@@ -7,6 +7,7 @@ subroutine vector_potentials(nr_in,np_in,nz_in,ntor_in,      &
     rpoi,zpoi,apav,rbpav_coef,aznre,aznim,arnre,arnim
   use libneo_kinds, only : complex_kind, real_kind
   use math_constants, only : PI
+  use field_sub, only : stretch_coords
 
   implicit none
 
@@ -1581,6 +1582,7 @@ subroutine field_fourier_derivs(r,phi,z,Br,Bp,Bz,dBrdR,dBrdp,dBrdZ    &
   ! for the field components computed by "field_fourier".
 
   use libneo_kinds, only : real_kind
+  use field_sub, only : field_eq, inthecore, stretch_coords
 
   implicit none
 

--- a/src/magfie/coil_tools.f90
+++ b/src/magfie/coil_tools.f90
@@ -382,6 +382,8 @@ contains
       fftw_alloc_real, fftw_alloc_complex, fftw_plan_dft_r2c_1d, FFTW_PATIENT, &
       FFTW_DESTROY_INPUT, fftw_execute_dft_r2c, fftw_destroy_plan, fftw_free
     use math_constants, only: pi
+    use field_sub, only: read_field_input, stretch_coords
+
     type(coil_t), intent(in), dimension(:) :: coils
     integer, intent(in) :: nmax
     real(dp), intent(in) :: min_distance, max_eccentricity
@@ -526,7 +528,7 @@ contains
     Z = linspace(Zmin, Zmax, nZ, 0, 0)
     coil_number = [(k, k = 1, ncoil)]
     ntor = [(k, k = 0, nmax)]
-    
+
     status = nf90_create(filename, NF90_NETCDF4, ncid)
     call nc_check(status, 'open')
 

--- a/src/magfie/field_divB0.f90
+++ b/src/magfie/field_divB0.f90
@@ -1,3 +1,9 @@
+module field_sub
+
+implicit none
+
+contains
+
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 subroutine read_field_input
   use input_files, only : iunit, gfile, pfile, convexfile, fluxdatapath, ieqfile
@@ -637,6 +643,7 @@ subroutine read_field0(rad,phi,zet,rmin,pmin,zmin,hrm1,hpm1,hzm1,Br,Bp,Bz)
   implicit real(8) (a-h, o-z)
 
   integer, parameter :: nr=64, np=37, nz=64
+  integer :: i, j, k, icall
 
   dimension Bz(nr,np,nz)
   dimension Br(nr,np,nz),Bp(nr,np,nz)
@@ -1279,3 +1286,5 @@ subroutine add_scaled(Br, Bp, Bz, dBrdR, dBrdp, dBrdZ, dBpdR, dBpdp, dBpdZ, dBzd
   dBzdp=dBzdp+scale*dBzdp1
   dBzdZ=dBzdZ+scale*dBzdZ1
 end subroutine add_scaled
+
+end module field_sub

--- a/src/magfie/magfie_cyl.f90
+++ b/src/magfie/magfie_cyl.f90
@@ -25,6 +25,7 @@ subroutine magfie(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
 
   use field_eq_mod, only : psi_axis,psi_sep,psif,ierrfield
   use libneo_kinds, only : real_kind
+  use field_sub,    only : field
 
   implicit none
 


### PR DESCRIPTION
@pazathoth do you think we can pull this through and avoid the array temporaries altogether?