### PR TITLE
change util_for_test to library

### DIFF
--- a/test/util_for_test/CMakeLists.txt
+++ b/test/util_for_test/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_library(util_for_test OBJECT util_for_test.f90)
+add_library(util_for_test util_for_test.f90)


### PR DESCRIPTION
So that the same test syntax for FORTRAN can be used also outside from libneo