### PR TITLE
removed redundant HDF5 library linking

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,8 +51,6 @@ target_link_libraries(test_geqdsk_tools.x
 add_executable(test_hdf5_tools.x source/test_hdf5_tools.f90)
 target_link_libraries(test_hdf5_tools.x
   ${HDF5_TOOLS_LIB}
-  ${HDF5_LIBRARIES}
-  ${HDF5_HL_LIBRARIES}
 )
 
 add_executable(test_mympilib.x


### PR DESCRIPTION
A redundant linking of the `HDF5` libraries caused issues when compiling. The problem was that `HDF5_TOOLS` already has the standard `hdf5` libraries linked into it. Linking them again into an executable that causes error when trying to reference symbols.