### PR TITLE
Prepare for GCC 14

### DIFF
--- a/src/collisions/CMakeLists.txt
+++ b/src/collisions/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT fortran_stdlib_FOUND)
 
     set(prefix "${CMAKE_BINARY_DIR}/fortran_stdlib")
     set(FORTRAN_STDLIB_LIBRARY ${prefix}/install/lib/libfortran_stdlib.a)
-    set(FORTRAN_STDLIB_INCLUDE_DIR ${prefix}/install/include/fortran_stdlib/GNU-12.2.0/)
+    set(FORTRAN_STDLIB_INCLUDE_DIR ${prefix}/install/include/fortran_stdlib/${CMAKE_Fortran_COMPILER_ID}-${CMAKE_Fortran_COMPILER_VERSION}/)
 
     execute_process(
     COMMAND ${CMAKE_COMMAND} -E make_directory ${FORTRAN_STDLIB_INCLUDE_DIR}

--- a/src/magfie/coil_tools.f90
+++ b/src/magfie/coil_tools.f90
@@ -39,7 +39,11 @@ contains
     omit_hi = 0
     if (present(excl_hi)) omit_hi = excl_hi
     step = (hi - lo) / dble(cnt - 1 + omit_lo + omit_hi)
-    linspace = lo + [(k * step, k = omit_lo, cnt - 1 + omit_lo)]
+    ! gfortran 14.2.1 thinks that the equivalent
+    ! implied do loop may be uninitialized here
+    do k = omit_lo, cnt - 1 + omit_lo
+      linspace(k) = lo + k * step
+    end do
     if (omit_hi == 0) linspace(cnt) = hi
   end function linspace
 


### PR DESCRIPTION
Since warnings are treated as errors, a maybe uninitialized value leads to failure, hence the change to an explicit loop. More importantly, the compiler version is selected dynamically.