### PR TITLE
Add development infrastructure and code coverage

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -25,10 +25,9 @@ jobs:
 
       - name: Build with coverage flags
         run: |
-          mkdir -p build
-          cd build
-          cmake .. -DCMAKE_Fortran_FLAGS="-cpp -g -Og -fPIC -fcheck=all -fbacktrace -fno-realloc-lhs -fopenmp -Wall -Wextra -Werror -Wno-unused-function -Wno-external-argument-mismatch -fmax-errors=1 -fprofile-arcs -ftest-coverage" -DCMAKE_BUILD_TYPE=Debug
-          make -j$(nproc)
+          # Modify CMakeLists.txt to add coverage flags
+          sed -i 's/-fmax-errors=1"/-fmax-errors=1 -fprofile-arcs -ftest-coverage"/' CMakeLists.txt
+          make
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -23,16 +23,9 @@ jobs:
           apt-get update
           apt-get install -y gcovr
 
-      - name: Build with coverage flags
+      - name: Build and test with coverage
         run: |
-          # Modify CMakeLists.txt to add coverage flags
-          sed -i 's/-fmax-errors=1"/-fmax-errors=1 -fprofile-arcs -ftest-coverage"/' CMakeLists.txt
-          make
-
-      - name: Run tests with coverage
-        run: |
-          cd build
-          ctest --output-on-failure
+          make coverage-build
 
       - name: Generate coverage report
         if: always()

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,51 @@
+name: Test Coverage
+
+on: [push, pull_request]
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/itpplasma/devel:latest
+      options: --user root
+
+    name: Test Coverage
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fix permissions
+        run: |
+          git config --global --add safe.directory `pwd`
+
+      - name: Install gcovr
+        run: |
+          apt-get update
+          apt-get install -y gcovr
+
+      - name: Build with coverage flags
+        run: |
+          mkdir -p build
+          cd build
+          cmake .. -DCMAKE_Fortran_FLAGS="-cpp -g -Og -fPIC -fcheck=all -fbacktrace -fno-realloc-lhs -fopenmp -Wall -Wextra -Werror -Wno-unused-function -Wno-external-argument-mismatch -fmax-errors=1 -fprofile-arcs -ftest-coverage" -DCMAKE_BUILD_TYPE=Debug
+          make -j$(nproc)
+
+      - name: Run tests with coverage
+        run: |
+          cd build
+          ctest --output-on-failure
+
+      - name: Generate coverage report
+        if: always()
+        run: |
+          gcovr --root . --exclude 'build/*' --exclude 'doc/*' --exclude 'example/*' --exclude 'test/*' --exclude 'tools/*' --exclude 'src/contrib/*' --exclude 'matlab/*' --exclude 'python/*' --exclude 'extra/*' --xml -o coverage.xml --print-summary
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+libneo is a Fortran library containing common code for plasma physics codes at ITPcp, particularly for NEO-2 versions. It provides magnetic field representations, transport calculations, collision operators, and coordinate transformations for fusion plasma physics.
+
+## Build Commands
+
+### Standard Build
+```bash
+# Simple build with CMake/Ninja (recommended)
+make
+
+# Alternative: using fpm
+fpm build
+```
+
+### Run Tests
+```bash
+# Run all tests
+make test
+
+# Or directly with ctest
+cd build && ctest
+```
+
+### Install Python Interface
+```bash
+# Activate your virtual environment first
+pip install -e .
+```
+
+### Clean Build
+```bash
+make clean
+```
+
+## Architecture Overview
+
+### Core Structure
+The library follows an object-oriented Fortran design with abstract types and interfaces:
+
+- **Abstract Field Interface**: `field_t` in `src/field/field_base.f90` defines the interface for all magnetic field implementations
+- **Modular Components**: Each major functionality (transport, collisions, species) is in its own module
+- **Python Bindings**: F2PY and f90wrap interfaces in `src/f2py_interfaces/` and `python/`
+
+### Key Components
+
+1. **Magnetic Fields** (`src/field/`): Various field representations (VMEC, EFIT, mesh-based)
+2. **MAGFIE** (`src/magfie/`): Magnetic field interpolation engine
+3. **Transport** (`src/transport/`): Neoclassical transport coefficient calculations
+4. **Collisions** (`src/collisions/`): Collision frequency calculations
+5. **Coordinate Transformations** (`src/efit_to_boozer/`): EFIT to Boozer coordinate conversion
+6. **HDF5 Tools** (`src/hdf5_tools/`): Simplified HDF5 I/O interface
+
+### Dependencies
+- CMake 3.18+, Ninja, GCC/GFortran
+- MPI (OpenMPI)
+- BLAS/LAPACK (OpenBLAS or MKL)
+- FFTW3, NetCDF, HDF5
+- Python with numpy and f90wrap (for Python interface)
+
+### Testing Structure
+Tests are organized by component in `test/`:
+- Unit tests for each module
+- Integration tests for field computations
+- Python tests for bindings
+- Test utilities in `test/util_for_test/`
+
+### Fortran Conventions
+- Modern Fortran (2003/2008) with OOP features
+- Precision defined in `libneo_kinds` module (`dp` for double)
+- Type naming: `typename_t` for derived types
+- Strict 88-character line limit
+- 4-space indentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,31 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 libneo is a Fortran library containing common code for plasma physics codes at ITPcp, particularly for NEO-2 versions. It provides magnetic field representations, transport calculations, collision operators, and coordinate transformations for fusion plasma physics.
 
+## Development Approach
+
+### Test-Driven Development (STRICT REQUIREMENT)
+**ALWAYS follow the RED-GREEN-REFACTOR cycle:**
+
+1. **RED**: Write a failing test first - never write code without a failing test
+2. **GREEN**: Write minimal code to make the test pass - only enough to pass
+3. **REFACTOR**: Clean up code while keeping tests green
+
+**Rules:**
+- Write tests before any implementation code
+- Run tests after each step
+- Keep the cycle short and focused
+
+### Coding Standards
+See `CODING_STANDARD.md` for complete details. Key points:
+- Code is simple and self-explaining without comments
+- Break large constructs into small, single-responsibility units
+- Use `pure` procedures without side effects when possible
+- Prefer structs (`type`) over classes for data bundling
+- Use abstract types with factory pattern for polymorphism
+- Arrays indexed starting from 1
+- 88-character line limit, 4-space indentation
+- `implicit none` in all modules and programs
+
 ## Build Commands
 
 ### Standard Build
@@ -69,9 +94,4 @@ Tests are organized by component in `test/`:
 - Python tests for bindings
 - Test utilities in `test/util_for_test/`
 
-### Fortran Conventions
-- Modern Fortran (2003/2008) with OOP features
-- Precision defined in `libneo_kinds` module (`dp` for double)
-- Type naming: `typename_t` for derived types
-- Strict 88-character line limit
-- 4-space indentation
+**Remember**: Always write tests BEFORE implementation code (TDD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ set (libneo_VERSION_PATCH 3)
 enable_language(C Fortran)
 enable_testing()
 
+# Coverage configuration
+option(ENABLE_COVERAGE "Enable coverage flags" OFF)
+
 find_program (BASH_PROGRAM bash)
 
 find_package (MPI REQUIRED COMPONENTS Fortran)
@@ -35,8 +38,14 @@ if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
                             -Wno-unused-function -Wno-external-argument-mismatch \
                             -fmax-errors=1")
 
+  # Add coverage flags if enabled
+  if(ENABLE_COVERAGE)
+    set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fprofile-arcs -ftest-coverage")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
+  endif()
+
   # https://github.com/numpy/numpy/issues/25777
-  set (CMAKE_C_FLAGS "-Wno-error=incompatible-pointer-types")
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=incompatible-pointer-types")
 
 elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
 

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,8 @@ clean:
 coverage: coverage-build coverage-report
 
 coverage-build:
-	mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && cmake .. -DENABLE_COVERAGE=ON
-	cd $(BUILD_DIR) && ninja
+	cmake --preset default -DENABLE_COVERAGE=ON
+	cmake --build --preset default
 	cd $(BUILD_DIR) && ctest --output-on-failure
 
 coverage-report:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILD_DIR := build
 BUILD_NINJA := $(BUILD_DIR)/build.ninja
 
-.PHONY: all ninja test install clean
+.PHONY: all ninja test install clean coverage coverage-build coverage-report
 all: ninja tools/h5merge/build/h5merge.x
 
 tools/h5merge/build/h5merge.x:
@@ -29,3 +29,18 @@ fpm:
 clean:
 	rm -rf $(BUILD_DIR)
 	rm -rf tools/h5merge/build
+
+# Coverage targets
+coverage: coverage-build coverage-report
+
+coverage-build:
+	mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && cmake .. -DENABLE_COVERAGE=ON
+	cd $(BUILD_DIR) && ninja
+	cd $(BUILD_DIR) && ctest --output-on-failure
+
+coverage-report:
+	gcovr --root . --exclude 'build/*' --exclude 'doc/*' --exclude 'example/*' \
+	      --exclude 'test/*' --exclude 'tools/*' --exclude 'src/contrib/*' \
+	      --exclude 'matlab/*' --exclude 'python/*' --exclude 'extra/*' \
+	      --html --html-details -o coverage.html --print-summary


### PR DESCRIPTION
### **User description**
## Summary

- Added CLAUDE.md for Claude Code guidance with TDD requirements and coding standards
- Implemented clean code coverage configuration with CMake and Make targets
- Added GitHub Actions workflow for automated coverage reporting

## Changes

### Development Documentation
- **CLAUDE.md**: Comprehensive guidance for Claude Code instances including:
  - Strict test-driven development (RED-GREEN-REFACTOR cycle)
  - Build commands and architecture overview
  - Reference to CODING_STANDARD.md with key points summary

### Code Coverage Infrastructure
- **CMake Configuration**: Added `ENABLE_COVERAGE` option for clean coverage flag management
- **Make Targets**: 
  - `make coverage`: Complete coverage workflow
  - `make coverage-build`: Build and test with coverage
  - `make coverage-report`: Generate HTML coverage report
- **GitHub Actions**: New `test-coverage.yml` workflow for automated coverage reporting to Codecov

## Test Plan

- [x] Verify coverage build works with new Make targets
- [x] Confirm GitHub Actions workflow builds successfully
- [x] Validate coverage report generation
- [x] Test documentation accuracy for Claude Code usage

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add comprehensive development infrastructure for code coverage

- Create Claude Code guidance documentation with TDD requirements

- Implement GitHub Actions workflow for automated coverage reporting

- Add CMake configuration and Make targets for coverage builds


___

### **Changes diagram**

```mermaid
flowchart LR
  A["CLAUDE.md"] --> B["Development Guidance"]
  C["CMakeLists.txt"] --> D["Coverage Configuration"]
  E["Makefile"] --> F["Coverage Targets"]
  G[".github/workflows/test-coverage.yml"] --> H["Automated Coverage"]
  D --> I["Build with Coverage"]
  F --> I
  I --> J["Coverage Reports"]
  H --> J
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Create Claude Code development guidance documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<li>Add comprehensive guidance for Claude Code instances<br> <li> Include strict TDD requirements with RED-GREEN-REFACTOR cycle<br> <li> Document build commands and architecture overview<br> <li> Reference coding standards with key points summary


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/111/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+97/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Add CMake coverage configuration option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakeLists.txt

<li>Add <code>ENABLE_COVERAGE</code> CMake option for coverage configuration<br> <li> Add coverage compiler flags for GNU compiler when enabled<br> <li> Modify C flags to append rather than overwrite existing flags


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/111/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Add Make targets for coverage builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<li>Add <code>coverage</code>, <code>coverage-build</code>, and <code>coverage-report</code> targets<br> <li> Implement complete coverage workflow with CMake and gcovr<br> <li> Configure coverage exclusions for non-source directories


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/111/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test-coverage.yml</strong><dd><code>Add GitHub Actions coverage workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/test-coverage.yml

<li>Create GitHub Actions workflow for automated coverage reporting<br> <li> Install gcovr and build with coverage flags<br> <li> Generate XML coverage report and upload to Codecov<br> <li> Configure appropriate directory exclusions for coverage analysis


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/111/files#diff-10e59ddf73e82826c3d03b454c5235d8e9e810617506db80bced27ee2e1f6c9c">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>