### PR TITLE
Unify test output directories to build/test with subdirectories

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,10 +83,13 @@ target_link_libraries(test_geqdsk_tools.x
 )
 
 if(LIBNEO_TESTING_ENABLED)
-  set(TEST_DATA_DIR ${CMAKE_BINARY_DIR}/test_data)
-  file(MAKE_DIRECTORY ${TEST_DATA_DIR})
-  set(TEST_ARTIFACT_DIR ${CMAKE_BINARY_DIR}/test_artifacts)
-  file(MAKE_DIRECTORY ${TEST_ARTIFACT_DIR})
+  set(TEST_OUTPUT_DIR ${CMAKE_BINARY_DIR}/test)
+  file(MAKE_DIRECTORY ${TEST_OUTPUT_DIR})
+  # Create subdirectories for different test types
+  file(MAKE_DIRECTORY ${TEST_OUTPUT_DIR}/source)
+  file(MAKE_DIRECTORY ${TEST_OUTPUT_DIR}/scripts)
+  file(MAKE_DIRECTORY ${TEST_OUTPUT_DIR}/python)
+  file(MAKE_DIRECTORY ${TEST_OUTPUT_DIR}/poincare)
 
   add_executable(test_geoflux.x source/test_geoflux.f90)
   target_link_libraries(test_geoflux.x
@@ -176,9 +179,10 @@ add_test(
   NAME test_ascot5_compare
   COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/test/scripts/test_ascot5_compare.py
           --build-dir ${CMAKE_BINARY_DIR}
+          --output-dir ${CMAKE_BINARY_DIR}/test/scripts
 )
 set_tests_properties(test_ascot5_compare PROPERTIES
-  ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/test/ascot5_compare/ascot5/build:$ENV{LD_LIBRARY_PATH}"
+  ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/test/scripts/ascot5/build:$ENV{LD_LIBRARY_PATH}"
 )
 
 if(LIBNEO_TESTING_ENABLED)
@@ -186,14 +190,14 @@ if(LIBNEO_TESTING_ENABLED)
     NAME test_geoflux
     COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/test/scripts/run_geoflux_test.py
             --exe $<TARGET_FILE:test_geoflux.x>
-            --data-dir ${TEST_DATA_DIR}
+            --data-dir ${TEST_OUTPUT_DIR}/scripts
   )
 
   add_test(
     NAME test_geqdsk_plot
     COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/test/scripts/geqdsk_plot.py
-            --data-dir ${TEST_DATA_DIR}
-            --output-dir ${TEST_ARTIFACT_DIR}
+            --data-dir ${TEST_OUTPUT_DIR}/scripts
+            --output-dir ${TEST_OUTPUT_DIR}/scripts
             --basename geqdsk
   )
   set_tests_properties(test_geqdsk_plot PROPERTIES DEPENDS test_geoflux)
@@ -202,8 +206,8 @@ if(LIBNEO_TESTING_ENABLED)
     NAME test_geoflux_plot
     COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/test/scripts/geoflux_plot.py
             --exe $<TARGET_FILE:geoflux_coord_dump.x>
-            --data-dir ${TEST_DATA_DIR}
-            --output-dir ${TEST_ARTIFACT_DIR}
+            --data-dir ${TEST_OUTPUT_DIR}/scripts
+            --output-dir ${TEST_OUTPUT_DIR}/scripts
             --basename geoflux
   )
   set_tests_properties(test_geoflux_plot PROPERTIES DEPENDS test_geoflux)

--- a/test/python/test_coordinate_converter.py
+++ b/test/python/test_coordinate_converter.py
@@ -56,19 +56,25 @@ def test_MarsCoord2StorThetageom_stor2sqrtspol():
     assert np.allclose(sqrtspol, stor2sqrtspol(stor),atol=1e-2)
 
 def test_MarsCoords2StorThetageom_visual_check():
+    from pathlib import Path
     converter = StorGeom2MarsCoords(mars_dir)
     test_stor = np.linspace(0.0, 1, 5)
     test_theta_geom = np.linspace(-np.pi, np.pi, 800)
-    plt.figure()
+    fig = plt.figure()
     for stor in test_stor:
         sqrtspol, chi = converter(stor, test_theta_geom)
         plt.plot(test_theta_geom, chi, '.', label=f"stor={stor}")
     plt.xlabel('theta_geom [1]')
     plt.ylabel('chi [1]')
     plt.legend()
+    output = Path("build/test/python/mars_coords_visual.png")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, dpi=150, bbox_inches='tight')
     plt.show()
+    plt.close(fig)
 
 def test_MarsCoords2StorThetageom_coords_domain_visual_check():
+    from pathlib import Path
     converter = StorGeom2MarsCoords(mars_dir)
     mars_coords = converter.mars_coords
     stor_geom_coords = converter.stor_geom_coords
@@ -100,7 +106,11 @@ def test_MarsCoords2StorThetageom_coords_domain_visual_check():
     ax[1].set_xlabel('chi [1]')
     ax[1].set_ylabel('theta_geom [1]')
     ax[1].legend()
+    output = Path("build/test/python/mars_coords_domain.png")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, dpi=150, bbox_inches='tight')
     plt.show()
+    plt.close(fig)
 
 def test_MarsCoord2StorThetageom_performance_profile():
     import cProfile

--- a/test/python/test_fourier_utils.py
+++ b/test/python/test_fourier_utils.py
@@ -1,9 +1,17 @@
 # %% Standard imports
 import numpy as np
 import matplotlib.pyplot as plt
+from pathlib import Path
 
 # modules to test
 from libneo import fourier_coefs_half, fourier_coefs_full, get_half_fft
+
+def save_plot(fig, filename):
+    """Helper to save plots to build/test/python directory"""
+    output = Path(f"build/test/python/{filename}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, dpi=150, bbox_inches='tight')
+    return output
 
 def test_fourier_coefs_half():
     x = np.linspace(0, 2*np.pi, 100)
@@ -97,7 +105,7 @@ def test_get_half_fft_phaseshift_visual_check():
     f_minus_pi = get_fft_series_lambda_function(trial_func, grid - np.pi)
     f_plus_pi = get_fft_series_lambda_function(trial_func, grid + np.pi)
     grid_eval = add_intermediate_steps(grid)
-    plt.figure()
+    fig = plt.figure()
     plt.plot(grid_eval, trial_func(grid_eval), 'ro-', label='base function')
     plt.plot(grid_eval, f(grid_eval), 'D-', label='no shift')
     plt.plot(grid_eval, f_plus_pi(grid_eval), 'x-', label='+pi shifted')
@@ -106,7 +114,9 @@ def test_get_half_fft_phaseshift_visual_check():
     plt.xlabel('x [1]')
     plt.ylabel('f(x) [1]')
     plt.title('Reconstruction of trial function from ffts on shifted intervals')
+    save_plot(fig, "fourier_phaseshift_visual.png")
     plt.show()
+    plt.close(fig)
 
 def test_get_half_fft_even_odd_grid_visual_check():
     even_grid = np.linspace(-np.pi, np.pi, 10)
@@ -114,7 +124,7 @@ def test_get_half_fft_even_odd_grid_visual_check():
     f_even = get_fft_series_lambda_function(trial_func, even_grid)
     f_odd = get_fft_series_lambda_function(trial_func, odd_grid)
     grid_eval = np.sort(np.concatenate([even_grid, odd_grid]))
-    plt.figure()
+    fig = plt.figure()
     plt.plot(grid_eval, trial_func(grid_eval), 'D-', label='base function')
     plt.plot(grid_eval, f_even(grid_eval), 'x-', label='fft on even grid')
     plt.plot(grid_eval, f_odd(grid_eval), '+-', label='fft on odd grid')
@@ -122,7 +132,9 @@ def test_get_half_fft_even_odd_grid_visual_check():
     plt.xlabel('x [1]')
     plt.ylabel('f(x) [1]')
     plt.title('Reconstruction of trial function from ffts on even and odd grid')
+    save_plot(fig, "fourier_even_odd_grid_visual.png")
     plt.show()
+    plt.close(fig)
 
 def get_fft_series_lambda_function(func, grid):
     fm, m = get_half_fft(func(grid), grid)
@@ -143,7 +155,7 @@ def test_fourier_coefs_visual_check():
     x_rand = np.sort(np.random.uniform(0, 2*np.pi, 20))
     f_eval = np.real(fm.dot(np.exp(1.0j * np.outer(m, x_rand))))
     f_eval_half = np.real(fm_half.dot(np.exp(1.0j * np.outer(m_half, x_rand))))
-    plt.figure()
+    fig = plt.figure()
     plt.plot(x, trial_trigonometric_func(x), label='trial function')
     plt.plot(x_rand, f_eval, 'o', label='full fourier eval')
     plt.plot(x_rand, f_eval_half, 'x', label='half fourier eval')
@@ -151,7 +163,9 @@ def test_fourier_coefs_visual_check():
     plt.xlabel('x [1]')
     plt.ylabel('f(x) [1]')
     plt.title('Reconstruction of trial function from fourier coef computation')
+    save_plot(fig, "fourier_coefs_visual.png")
     plt.show()
+    plt.close(fig)
 
 def test_get_half_fft_visual_check():
     make_visual_check_get_half_fft_on(trial_trigonometric_func)
@@ -162,26 +176,31 @@ def make_visual_check_get_half_fft_on(func):
     fm, m = get_half_fft(func(grid), grid)
     grid_eval = np.sort(np.concatenate([grid,grid[:-1] + 0.5*np.diff(grid)]))
     fourier_eval = fm.dot(np.exp(1.0j * np.outer(m, grid_eval)))
-    plt.figure()
+    fig = plt.figure()
     plt.plot(grid, func(grid), 'D', label='trial data')
     plt.plot(grid_eval, np.real(fourier_eval), '-x', label='half fft eval')
     plt.legend()
     plt.xlabel('x [1]')
     plt.ylabel('f(x) [1]')
     plt.title('Reconstruction of trial function from fft results')
+    func_name = func.__name__
+    save_plot(fig, f"fourier_half_fft_{func_name}_visual.png")
     plt.show()
+    plt.close(fig)
 
 def test_get_half_fft_coefficients_visual_check():
     grid = np.linspace(0, 2*np.pi, 20)
     fm, m = get_half_fft(trial_trigonometric_func(grid), grid)
-    plt.figure()
+    fig = plt.figure()
     plt.plot(m, fm.real, '-D', label='real-part fft coefs')
     plt.plot(m, fm.imag, '-x', label='imag-part fft coefs')
     plt.legend()
     plt.xlabel('modenumber m [1]')
     plt.ylabel('fm [1]')
     plt.title('Fourier coefficients of trigonometric function from FFT')
+    save_plot(fig, "fourier_coefficients_visual.png")
     plt.show()
+    plt.close(fig)
 
 def trial_trigonometric_func(x):
     return np.sin(x)*np.sin(x)*np.cos(x) + 1
@@ -234,7 +253,9 @@ def test_angle_conversion_example_visual_check():
     ax[0].legend()
     ax[0].axis('equal')
     plt.suptitle('Conversion between geom and chi angle functions')
+    save_plot(fig, "fourier_angle_conversion_visual.png")
     plt.show()
+    plt.close(fig)
 
 def trial_geom_func(x, boundary: float=-np.pi):
     angle = (x - np.pi - boundary) + np.sin((x - np.pi - boundary)) + 0.3*np.sin(2*(x - np.pi - boundary))

--- a/test/python/test_semi_periodic_fourier_spline.py
+++ b/test/python/test_semi_periodic_fourier_spline.py
@@ -2,10 +2,18 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import pytest
+from pathlib import Path
 
 # modules to test
 from libneo import SemiPeriodicFourierSpline
 from libneo import SemiPeriodicFourierSpline_ExceedingNyquistLimit
+
+def save_plot(fig, filename):
+    """Helper to save plots to build/test/python directory"""
+    output = Path(f"build/test/python/{filename}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, dpi=150, bbox_inches='tight')
+    return output
 
 s = np.linspace(0, 1, 5)
 angle = np.linspace(-np.pi, np.pi, 10)
@@ -51,7 +59,7 @@ def test_get_fourier_coefs_visual_check():
     Angle, S = np.meshgrid(angle, s)
     F = trial_trigonometric_func(S, Angle)
     spline = SemiPeriodicFourierSpline(s, angle, F)
-    plt.figure()
+    fig = plt.figure()
     r_plot = np.linspace(0, 1, 30)
     coefs_plot = spline._fourier_coefs_splines(r_plot)
     for i,m in enumerate(spline._modenumbers):
@@ -61,14 +69,16 @@ def test_get_fourier_coefs_visual_check():
     plt.ylabel('fm [1]')
     plt.title('Fourier coefficients of trigonometric trial function depending on s')
     plt.legend()
+    save_plot(fig, "spline_fourier_coefs_visual.png")
     plt.show()
+    plt.close(fig)
 
 def test_trial_theta_geom_func_visual_check():
     angle = np.linspace(-np.pi, np.pi, 100)
     Angle, S = np.meshgrid(angle, s)
     Theta_geom = theta_geom_func(S, Angle)
     spline = SemiPeriodicFourierSpline(s, angle, Theta_geom)
-    plt.figure()
+    fig = plt.figure()
     angle_plot = np.linspace(-np.pi, np.pi,19)
     s_plot = np.linspace(0, 1, 9)
     Angle_plot, S_plot = np.meshgrid(angle_plot, s_plot)
@@ -80,7 +90,9 @@ def test_trial_theta_geom_func_visual_check():
     plt.ylabel('Z [1]')
     plt.legend()
     plt.title('Theta_geom rays as function of equidistant input angle \n splined form uniform datapoints N='+str(len(angle))+'x'+str(len(s))+' [angle x s]')
+    save_plot(fig, "spline_theta_geom_uniform_visual.png")
     plt.show()
+    plt.close(fig)
 
 def test_trial_theta_geom_func_different_angle_per_surface_visual_check():
     angle = np.linspace(-np.pi, np.pi, 100)
@@ -88,7 +100,7 @@ def test_trial_theta_geom_func_different_angle_per_surface_visual_check():
     Angle[:,1:-1] = Angle[:,1:-1]*(S[:,1:-1] + 1)/2 # uneven distributed angles, but same endpoints
     Theta_geom = theta_geom_func(S, Angle)
     spline = SemiPeriodicFourierSpline(s, Angle, Theta_geom)
-    plt.figure()
+    fig = plt.figure()
     angle_plot = np.linspace(-np.pi, np.pi,19)
     s_plot = np.linspace(0, 1, 9)
     Angle_plot, S_plot = np.meshgrid(angle_plot, s_plot)
@@ -100,7 +112,9 @@ def test_trial_theta_geom_func_different_angle_per_surface_visual_check():
     plt.ylabel('Z [1]')
     plt.legend()
     plt.title('Theta_geom rays as function of equidistant input angle \n splined from uneven distributed datapoints N='+str(len(angle))+'x'+str(len(s))+' [angle x s]')
+    save_plot(fig, "spline_theta_geom_uneven_visual.png")
     plt.show()
+    plt.close(fig)
 
 def trial_trigonometric_func(s,angle):
     return s*np.cos(angle)*np.sin(angle)

--- a/test/python/test_vmec_coords.py
+++ b/test/python/test_vmec_coords.py
@@ -83,13 +83,12 @@ def test_vmec_plot_surfaces_visual_check(tmp_path):
             ax.set_ylabel("Z [m]")
             ax.axis("equal")
 
-        # Save to both tmp_path and build directory for artifact collection
-        outfile = tmp_path / "vmec_surfaces.png"
+        # Save to build directory for artifact collection
         build_artifact = Path("build/test/python/vmec_surfaces.png")
         build_artifact.parent.mkdir(parents=True, exist_ok=True)
 
-        fig.savefig(outfile)
         fig.savefig(build_artifact)
+        outfile = build_artifact
         # Show interactively; in headless backends this is a no-op
         plt.show()
         plt.close(fig)


### PR DESCRIPTION
### **User description**
## Summary
Replace separate `test_data` and `test_artifacts` directories with a unified `build/test` directory structure organized by test type:
- `build/test/source/` - for source tests
- `build/test/scripts/` - for script test outputs (geqdsk, geoflux, ascot5)
- `build/test/python/` - for Python test outputs (vmec plots)
- `build/test/poincare/` - for poincare test outputs

This simplifies test artifact management and makes it easier to find test outputs, as they are now organized by their test subdirectory in the test/ tree, matching the source structure.

## Changes
- Update `test/CMakeLists.txt` to create `build/test` subdirectories instead of `test_data` and `test_artifacts`
- Update all test commands to use the new `TEST_OUTPUT_DIR` structure
- Update `test_vmec_coords.py` to output PNG directly to `build/test/python`
- Update `test_ascot5_compare` configuration to use `build/test/scripts`

## Test plan
- [x] Verified `test_poincare` outputs to `build/test/poincare/circular_tok_poincare.dat`
- [x] Verified `test_vmec_coords.py` will output to `build/test/python/vmec_surfaces.png`
- [x] Verified CMake configuration creates all required subdirectories
- [x] All test paths updated to use unified structure


___

### **PR Type**
Enhancement


___

### **Description**
- Unify test output directories under `build/test` structure

- Replace separate `test_data` and `test_artifacts` with organized subdirectories

- Update test commands to use new directory structure

- Simplify test artifact management and organization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Structure"] --> B["test_data/"]
  A --> C["test_artifacts/"]
  D["New Structure"] --> E["build/test/source/"]
  D --> F["build/test/scripts/"]
  D --> G["build/test/python/"]
  D --> H["build/test/poincare/"]
  A -- "Replace with" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Restructure test directories and update commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/CMakeLists.txt

<ul><li>Replace <code>TEST_DATA_DIR</code> and <code>TEST_ARTIFACT_DIR</code> with unified <br><code>TEST_OUTPUT_DIR</code><br> <li> Create subdirectories for source, scripts, python, and poincare tests<br> <li> Update test commands to use new directory structure<br> <li> Modify environment variables for ascot5 test paths</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/142/files#diff-33394812ba204689144fd2f80832db83853ba1cb32403edb4e15fe4893e675fd">+14/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_vmec_coords.py</strong><dd><code>Update VMEC plot output to unified directory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/python/test_vmec_coords.py

<ul><li>Remove duplicate file saving to <code>tmp_path</code><br> <li> Save PNG output directly to <code>build/test/python/vmec_surfaces.png</code><br> <li> Update <code>outfile</code> variable to point to build artifact location</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/142/files#diff-a991540dd28c6e7a80da27bbd0937a502d935933ce4a241b71283d0d620629ef">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

