### PR TITLE
Fix field_eq reinit and restore Boozer tests (#143)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,8 +46,12 @@ jobs:
           pip install --break-system-packages -e .
 
       - name: Run Python tests (pytest)
+        env:
+          PYTHONFAULTHANDLER: "1"
+          LIBNEO_DEBUG_BOOZER: "1"
         run: |
-          pytest -q
+          pytest test/python -q
+          pytest python/tests -vv -s
 
       - name: Compare with ASCOT5 reference
         run: |

--- a/python/tests/field_divB0.inp
+++ b/python/tests/field_divB0.inp
@@ -4,9 +4,9 @@
 72                                ntor         ! number of toroidal harmonics
 0.99                              cutoff       ! inner cutoff in psi/psi_a units
 4                                 icftype      ! type of coil file
-'test.geqdsk'                     gfile        ! equilibrium file
+'../../test/resources/input_efit_file.dat' gfile        ! equilibrium file
 'unused'                          pfile        ! coil        file
-'convexwall.dat'                  convexfile   ! convex file for stretchcoords
+'../../test/resources/convexwall.dat'          convexfile   ! convex file for stretchcoords
 'unused'                          fluxdatapath ! directory with data in flux coord.
 0                                 window size for filtering of psi array over R
 0                                 window size for filtering of psi array over Z

--- a/src/efit_to_boozer/CMakeLists.txt
+++ b/src/efit_to_boozer/CMakeLists.txt
@@ -132,12 +132,13 @@ add_custom_command(
   VERBATIM
   COMMAND "${Python_EXECUTABLE}" -m numpy.f2py
   "${CMAKE_CURRENT_SOURCE_DIR}/f2py_interfaces/f2py_efit_to_boozer.f90"
-  ../../libneo/magfie/field_divB0.f90
+  "${CMAKE_SOURCE_DIR}/src/magfie/field_divB0.f90"
+  "${CMAKE_SOURCE_DIR}/src/magfie/field_eq_mod.f90"
   "${CMAKE_CURRENT_SOURCE_DIR}/efit_to_boozer_mod.f90"
-  ../../libneo/spl_three_to_five.f90
+  "${CMAKE_SOURCE_DIR}/src/spl_three_to_five.f90"
   "${CMAKE_CURRENT_SOURCE_DIR}/field_line_integration_for_Boozer.f90"
-  ../../libneo/plag_coeff.f90
-  ../../libneo/binsrc.f90
+  "${CMAKE_SOURCE_DIR}/src/plag_coeff.f90"
+  "${CMAKE_SOURCE_DIR}/src/binsrc.f90"
   "${CMAKE_CURRENT_SOURCE_DIR}/rhs.f90"
   "${CMAKE_CURRENT_SOURCE_DIR}/spline_and_interpolate_magdata.f90"
   -m _efit_to_boozer --lower skip: oddorderspline polleg binomial odeint_allroutines', alloc_odeint odeint rkck rkqs :

--- a/src/efit_to_boozer/f2py_interfaces/f2py_efit_to_boozer.f90
+++ b/src/efit_to_boozer/f2py_interfaces/f2py_efit_to_boozer.f90
@@ -1,123 +1,120 @@
 module efit_to_boozer
 
-    use efit_to_boozer_mod, only : psimax, nlabel, ntheta, nspl, twopi, rbeg, &
-        rsmall, qsaf, psi_pol, psi_tor_vac, psi_tor, C_const, R_spl, Z_spl, &
-        bmod_spl, sqgnorm_spl, Gfunc_spl, rmn, rmx, zmn, zmx, raxis, zaxis
-    use input_files, only : gfile
-    use field_mod, only : icall
-    use field_c_mod, only : icall_c
-    use field_eq_mod, only : icall_eq
+   use efit_to_boozer_mod, only: psimax, nlabel, ntheta, nspl, twopi, rbeg, &
+                                 rsmall, qsaf, psi_pol, psi_tor_vac, psi_tor, C_const, R_spl, Z_spl, &
+                                 bmod_spl, sqgnorm_spl, Gfunc_spl, rmn, rmx, zmn, zmx, raxis, zaxis
+   use input_files, only: gfile
+   use field_mod, only: icall
+   use field_c_mod, only: icall_c
+   use field_eq_mod, only: reset_field_eq_state
 
-    implicit none
+   implicit none
 
-    double precision, dimension(:), allocatable :: R_oft, Z_oft, al_oft, B_oft
-    double precision, dimension(:), allocatable :: Rmn_c, Rmn_s, Zmn_c, Zmn_s, almn_c, almn_s, Bmn_c, Bmn_s
-    double complex,   dimension(:), allocatable :: calE, calEm_times_Jb
+   double precision, dimension(:), allocatable :: R_oft, Z_oft, al_oft, B_oft
+   double precision, dimension(:), allocatable :: Rmn_c, Rmn_s, Zmn_c, Zmn_s, almn_c, almn_s, Bmn_c, Bmn_s
+   double complex, dimension(:), allocatable :: calE, calEm_times_Jb
 
-    contains
+contains
 
-    subroutine init
+   subroutine init
 
-        integer :: nstep, nsurfmax, nsurf, nt, mpol, inp_label
-        double precision :: hs, htheta, oneovernt, twoovernt, sigma
+      integer :: nstep, nsurfmax, nsurf, nt, mpol, inp_label
+      double precision :: hs, htheta, oneovernt, twoovernt, sigma
 
-        call deinit
+      call deinit
 
-        open(1, file='efit_to_boozer.inp', status='old', action='read')
-        read (1, *) nstep    !number of integration steps
-        read (1, *) nlabel   !grid size over radial variable
-        read (1, *) ntheta   !grid size over poloidal angle
-        read (1, *) nsurfmax !number of starting points between the
-                            !magnetic axis and right box boundary
-                            !when searching for the separatrix
-        read (1, *) nsurf    !number of flux surfaces in Boozer file
-        read (1, *) mpol     !number of poloidal modes in Boozer file
-        read (1, *) psimax   !psi at plasma boundary
-        close(1)
+      open (1, file='efit_to_boozer.inp', status='old', action='read')
+      read (1, *) nstep    !number of integration steps
+      read (1, *) nlabel   !grid size over radial variable
+      read (1, *) ntheta   !grid size over poloidal angle
+      read (1, *) nsurfmax !number of starting points between the
+      !magnetic axis and right box boundary
+      !when searching for the separatrix
+      read (1, *) nsurf    !number of flux surfaces in Boozer file
+      read (1, *) mpol     !number of poloidal modes in Boozer file
+      read (1, *) psimax   !psi at plasma boundary
+      close (1)
 
+      allocate (rbeg(nlabel), rsmall(nlabel), qsaf(nlabel), psi_pol(0:nlabel))
+      allocate (psi_tor_vac(nlabel), psi_tor(0:nlabel), C_const(nlabel))
+      allocate (R_spl(0:nspl, 0:ntheta, nlabel), Z_spl(0:nspl, 0:ntheta, nlabel), bmod_spl(0:nspl, 0:ntheta, nlabel))
+      allocate (sqgnorm_spl(0:nspl, 0:ntheta, nlabel), Gfunc_spl(0:nspl, 0:ntheta, nlabel))
 
-        allocate(rbeg(nlabel), rsmall(nlabel), qsaf(nlabel), psi_pol(0:nlabel))
-        allocate(psi_tor_vac(nlabel), psi_tor(0:nlabel), C_const(nlabel))
-        allocate(R_spl(0:nspl, 0:ntheta, nlabel), Z_spl(0:nspl, 0:ntheta, nlabel), bmod_spl(0:nspl, 0:ntheta, nlabel))
-        allocate(sqgnorm_spl(0:nspl, 0:ntheta, nlabel), Gfunc_spl(0:nspl, 0:ntheta, nlabel))
-
-        call flint_for_Boozer(nstep, nsurfmax, nlabel, ntheta,       &
+      call flint_for_Boozer(nstep, nsurfmax, nlabel, ntheta, &
                             rmn, rmx, zmn, zmx, raxis, zaxis, sigma, &
-                            rbeg, rsmall, qsaf,                      &
-                            psi_pol(1:nlabel), psi_tor_vac,          &
-                            psi_tor(1:nlabel), C_const,              &
-                            R_spl(0, 1:ntheta, :),                   &
-                            Z_spl(0, 1:ntheta, :),                   &
-                            bmod_spl(0, 1:ntheta, :),                &
-                            sqgnorm_spl(0, 1:ntheta, :),             &
+                            rbeg, rsmall, qsaf, &
+                            psi_pol(1:nlabel), psi_tor_vac, &
+                            psi_tor(1:nlabel), C_const, &
+                            R_spl(0, 1:ntheta, :), &
+                            Z_spl(0, 1:ntheta, :), &
+                            bmod_spl(0, 1:ntheta, :), &
+                            sqgnorm_spl(0, 1:ntheta, :), &
                             Gfunc_spl(0, 1:ntheta, :))
 
-        call spline_magdata_in_symfluxcoord
+      call spline_magdata_in_symfluxcoord
 
-        print *, 'Splining done'
+      print *, 'Splining done'
 
-        nt=ntheta
+      nt = ntheta
 
-        inp_label = 1
-        hs = 1.d0/dfloat(nsurf)
-        oneovernt = 1.d0/dfloat(nt)
-        twoovernt = 2.d0*oneovernt
-        htheta = twopi*oneovernt
-        allocate(calE(nt), calEm_times_Jb(nt))
-        allocate(R_oft(nt), Z_oft(nt), al_oft(nt), B_oft(nt))
-        allocate(Rmn_c(0:mpol), Rmn_s(0:mpol), Zmn_c(0:mpol), Zmn_s(0:mpol))
-        allocate(almn_c(0:mpol), almn_s(0:mpol), Bmn_c(0:mpol), Bmn_s(0:mpol))
+      inp_label = 1
+      hs = 1.d0/dfloat(nsurf)
+      oneovernt = 1.d0/dfloat(nt)
+      twoovernt = 2.d0*oneovernt
+      htheta = twopi*oneovernt
+      allocate (calE(nt), calEm_times_Jb(nt))
+      allocate (R_oft(nt), Z_oft(nt), al_oft(nt), B_oft(nt))
+      allocate (Rmn_c(0:mpol), Rmn_s(0:mpol), Zmn_c(0:mpol), Zmn_s(0:mpol))
+      allocate (almn_c(0:mpol), almn_s(0:mpol), Bmn_c(0:mpol), Bmn_s(0:mpol))
 
-    end subroutine init
+   end subroutine init
 
+   subroutine deinit
 
-    subroutine deinit
+      icall = 0
+      icall_c = 0
+      call reset_field_eq_state()
 
-        icall = 0
-        icall_c = 0
-        icall_eq = 0
+      if (allocated(rbeg)) deallocate (rbeg)
+      if (allocated(rsmall)) deallocate (rsmall)
+      if (allocated(qsaf)) deallocate (qsaf)
+      if (allocated(psi_pol)) deallocate (psi_pol)
+      if (allocated(psi_tor_vac)) deallocate (psi_tor_vac)
+      if (allocated(psi_tor)) deallocate (psi_tor)
+      if (allocated(C_const)) deallocate (C_const)
+      if (allocated(R_spl)) deallocate (R_spl)
+      if (allocated(Z_spl)) deallocate (Z_spl)
+      if (allocated(bmod_spl)) deallocate (bmod_spl)
+      if (allocated(sqgnorm_spl)) deallocate (sqgnorm_spl)
+      if (allocated(Gfunc_spl)) deallocate (Gfunc_spl)
+      if (allocated(calE)) deallocate (calE)
+      if (allocated(calEm_times_Jb)) deallocate (calEm_times_Jb)
+      if (allocated(R_oft)) deallocate (R_oft)
+      if (allocated(Z_oft)) deallocate (Z_oft)
+      if (allocated(al_oft)) deallocate (al_oft)
+      if (allocated(B_oft)) deallocate (B_oft)
+      if (allocated(Rmn_c)) deallocate (Rmn_c)
+      if (allocated(Rmn_s)) deallocate (Rmn_s)
+      if (allocated(Zmn_c)) deallocate (Zmn_c)
+      if (allocated(Zmn_s)) deallocate (Zmn_s)
+      if (allocated(almn_c)) deallocate (almn_c)
+      if (allocated(almn_s)) deallocate (almn_s)
+      if (allocated(Bmn_c)) deallocate (Bmn_c)
+      if (allocated(Bmn_s)) deallocate (Bmn_s)
 
-        if (allocated(rbeg)) deallocate(rbeg)
-        if (allocated(rsmall)) deallocate(rsmall)
-        if (allocated(qsaf)) deallocate(qsaf)
-        if (allocated(psi_pol)) deallocate(psi_pol)
-        if (allocated(psi_tor_vac)) deallocate(psi_tor_vac)
-        if (allocated(psi_tor)) deallocate(psi_tor)
-        if (allocated(C_const)) deallocate(C_const)
-        if (allocated(R_spl)) deallocate(R_spl)
-        if (allocated(Z_spl)) deallocate(Z_spl)
-        if (allocated(bmod_spl)) deallocate(bmod_spl)
-        if (allocated(sqgnorm_spl)) deallocate(sqgnorm_spl)
-        if (allocated(Gfunc_spl)) deallocate(Gfunc_spl)
-        if (allocated(calE)) deallocate(calE)
-        if (allocated(calEm_times_Jb)) deallocate(calEm_times_Jb)
-        if (allocated(R_oft)) deallocate(R_oft)
-        if (allocated(Z_oft)) deallocate(Z_oft)
-        if (allocated(al_oft)) deallocate(al_oft)
-        if (allocated(B_oft)) deallocate(B_oft)
-        if (allocated(Rmn_c)) deallocate(Rmn_c)
-        if (allocated(Rmn_s)) deallocate(Rmn_s)
-        if (allocated(Zmn_c)) deallocate(Zmn_c)
-        if (allocated(Zmn_s)) deallocate(Zmn_s)
-        if (allocated(almn_c)) deallocate(almn_c)
-        if (allocated(almn_s)) deallocate(almn_s)
-        if (allocated(Bmn_c)) deallocate(Bmn_c)
-        if (allocated(Bmn_s)) deallocate(Bmn_s)
+   end subroutine deinit
 
-    end subroutine deinit
+   subroutine magdata(inp_label, s, psi, theta, q, dq_ds, C_norm, dC_norm_ds, &
+                      sqrtg, bmod, dbmod_dtheta, R, dR_ds, dR_dtheta, &
+                      Z, dZ_ds, dZ_dtheta, G, dG_ds, dG_dtheta)
 
+      integer, intent(in) :: inp_label
+      double precision, intent(inout) :: s, psi, theta
+      double precision, intent(out) :: q, dq_ds, C_norm, dC_norm_ds, sqrtg, bmod, &
+         dbmod_dtheta, R, dR_ds, dR_dtheta, Z, dZ_ds, dZ_dtheta, G, dG_ds, dG_dtheta
 
-    subroutine magdata(inp_label, s, psi, theta, q, dq_ds, C_norm, dC_norm_ds, &
-        sqrtg, bmod, dbmod_dtheta, R, dR_ds, dR_dtheta,       &
-        Z, dZ_ds, dZ_dtheta, G, dG_ds, dG_dtheta)
-
-        integer, intent(in) :: inp_label
-        double precision, intent(inout) :: s, psi, theta
-        double precision, intent(out) :: q, dq_ds, C_norm, dC_norm_ds, sqrtg, bmod, &
-        dbmod_dtheta, R, dR_ds, dR_dtheta, Z, dZ_ds, dZ_dtheta, G, dG_ds,dG_dtheta
-
-        call magdata_in_symfluxcoord_ext(inp_label, s, psi, theta, q, dq_ds, C_norm, dC_norm_ds, &
-        sqrtg, bmod, dbmod_dtheta, R, dR_ds, dR_dtheta, Z, dZ_ds, dZ_dtheta, G, dG_ds, dG_dtheta)
-    end subroutine magdata
+      call magdata_in_symfluxcoord_ext(inp_label, s, psi, theta, q, dq_ds, C_norm, dC_norm_ds, &
+                                       sqrtg, bmod, dbmod_dtheta, R, dR_ds, dR_dtheta, Z, dZ_ds, dZ_dtheta, G, dG_ds, dG_dtheta)
+   end subroutine magdata
 
 end module efit_to_boozer

--- a/src/magfie/field_eq_mod.f90
+++ b/src/magfie/field_eq_mod.f90
@@ -1,27 +1,50 @@
 module field_eq_mod
-  implicit none
+   implicit none
 
-  integer, parameter :: dp = kind(1.0d0)
+   integer, parameter :: dp = kind(1.0d0)
 
-  logical :: use_fpol = .true.                                      !<=18.12.18
-  logical :: skip_read = .false.
-  integer :: icall_eq=0
-  integer :: nrad,nzet,icp,nwindow_r,nwindow_z
-  integer :: ierrfield
+   logical :: use_fpol = .true.                                      !<=18.12.18
+   logical :: skip_read = .false.
+   integer :: icall_eq = 0
+   integer :: nrad, nzet, icp, nwindow_r, nwindow_z
+   integer :: ierrfield
 
-  real(dp) :: psib,btf,rtf,hrad,hzet
-  real(dp) :: psi_axis,psi_sep,hfpol                            !<=18.12.18
-  real(dp), dimension(:,:), allocatable    :: psi, psi0
-  real(dp), dimension(:,:), allocatable    :: splfpol           !<=18.12.18
-  real(dp), dimension(:,:,:), allocatable  :: splpsi
-  real(dp), dimension(:), allocatable      :: rad, zet, xi,f
-  integer, dimension(:), allocatable           :: imi,ima,jmi,jma
-  integer, dimension(:,:), allocatable         :: ipoint
-  
-  ! Field variables for POTATO integration
-  real(dp) :: psif,dpsidr,dpsidz,d2psidr2,d2psidrdz,d2psidz2
-  
-  ! Make temporary variables threadprivate
-  !$omp threadprivate(psif,dpsidr,dpsidz,d2psidr2,d2psidrdz,d2psidz2)
-  
+   real(dp) :: psib, btf, rtf, hrad, hzet
+   real(dp) :: psi_axis, psi_sep, hfpol                            !<=18.12.18
+   real(dp), dimension(:, :), allocatable :: psi, psi0
+   real(dp), dimension(:, :), allocatable :: splfpol               !<=18.12.18
+   real(dp), dimension(:, :, :), allocatable :: splpsi
+   real(dp), dimension(:), allocatable :: rad, zet, xi, f
+   integer, dimension(:), allocatable :: imi, ima, jmi, jma
+   integer, dimension(:, :), allocatable :: ipoint
+
+   ! Field variables for POTATO integration
+   real(dp) :: psif, dpsidr, dpsidz, d2psidr2, d2psidrdz, d2psidz2
+
+   ! Make temporary variables threadprivate
+   !$omp threadprivate(psif,dpsidr,dpsidz,d2psidr2,d2psidrdz,d2psidz2)
+
+contains
+
+   subroutine reset_field_eq_state()
+      implicit none
+
+      if (allocated(psi)) deallocate (psi)
+      if (allocated(psi0)) deallocate (psi0)
+      if (allocated(splfpol)) deallocate (splfpol)
+      if (allocated(splpsi)) deallocate (splpsi)
+      if (allocated(rad)) deallocate (rad)
+      if (allocated(zet)) deallocate (zet)
+      if (allocated(xi)) deallocate (xi)
+      if (allocated(f)) deallocate (f)
+      if (allocated(imi)) deallocate (imi)
+      if (allocated(ima)) deallocate (ima)
+      if (allocated(jmi)) deallocate (jmi)
+      if (allocated(jma)) deallocate (jma)
+      if (allocated(ipoint)) deallocate (ipoint)
+
+      skip_read = .false.
+      icall_eq = 0
+   end subroutine reset_field_eq_state
+
 end module field_eq_mod

--- a/src/magfie/geoflux_field.f90
+++ b/src/magfie/geoflux_field.f90
@@ -1,92 +1,91 @@
 module geoflux_field
 
-    use, intrinsic :: iso_fortran_env, only : dp => real64
-    use geoflux_coordinates, only : init_geoflux_coordinates, geoflux_to_cyl, geoflux_get_axis
-    use field_sub, only : field_eq, psif
-    use field_eq_mod, only : psi_axis, icall_eq, skip_read
-    use input_files, only : gfile
+   use, intrinsic :: iso_fortran_env, only: dp => real64
+   use geoflux_coordinates, only: init_geoflux_coordinates, geoflux_to_cyl, geoflux_get_axis
+   use field_sub, only: field_eq, psif
+   use field_eq_mod, only: psi_axis, reset_field_eq_state
+   use input_files, only: gfile
 
-    implicit none
+   implicit none
 
-    real(dp), save :: axis_R = 0.0_dp
-    real(dp), save :: axis_Z = 0.0_dp
-    logical,  save :: initialized = .false.
+   real(dp), save :: axis_R = 0.0_dp
+   real(dp), save :: axis_Z = 0.0_dp
+   logical, save :: initialized = .false.
 
 contains
 
-    subroutine spline_geoflux_data(geqdsk_file, ns_cache, ntheta_cache)
-        character(len=*), intent(in) :: geqdsk_file
-        integer, intent(in), optional :: ns_cache, ntheta_cache
+   subroutine spline_geoflux_data(geqdsk_file, ns_cache, ntheta_cache)
+      character(len=*), intent(in) :: geqdsk_file
+      integer, intent(in), optional :: ns_cache, ntheta_cache
 
-        gfile = trim(geqdsk_file)
-        skip_read = .false.
-        icall_eq = 0
+      call reset_field_eq_state()
+      gfile = trim(geqdsk_file)
 
-        call init_geoflux_coordinates(geqdsk_file, ns_cache, ntheta_cache)
-        call geoflux_get_axis(axis_R, axis_Z)
+      call init_geoflux_coordinates(geqdsk_file, ns_cache, ntheta_cache)
+      call geoflux_get_axis(axis_R, axis_Z)
 
-        initialized = .true.
-    end subroutine spline_geoflux_data
+      initialized = .true.
+   end subroutine spline_geoflux_data
 
-    subroutine splint_geoflux_field(s_tor, theta_geo, phi, Acov, hcov, Bmod, sqgBctr)
-        real(dp), intent(in) :: s_tor, theta_geo, phi
-        real(dp), intent(out) :: Acov(3), hcov(3), Bmod
-        real(dp), intent(out), optional :: sqgBctr(3)
+   subroutine splint_geoflux_field(s_tor, theta_geo, phi, Acov, hcov, Bmod, sqgBctr)
+      real(dp), intent(in) :: s_tor, theta_geo, phi
+      real(dp), intent(out) :: Acov(3), hcov(3), Bmod
+      real(dp), intent(out), optional :: sqgBctr(3)
 
-        real(dp) :: x_geo(3)
-        real(dp) :: x_cyl(3)
-        real(dp) :: jac(3,3)
-        real(dp) :: dRds, dRdt, dZds, dZdt
-        real(dp) :: det_s_theta, sqrtg
-        real(dp) :: Br, Bphi, Bz
-        real(dp) :: dBrdR, dBrdp, dBrdZ
-        real(dp) :: dBpdR, dBpdp, dBpdZ
-        real(dp) :: dBzdR, dBzdp, dBzdZ
-        real(dp) :: Bcov_s, Bcov_theta, Bcov_phi
-        real(dp) :: psi_local
+      real(dp) :: x_geo(3)
+      real(dp) :: x_cyl(3)
+      real(dp) :: jac(3, 3)
+      real(dp) :: dRds, dRdt, dZds, dZdt
+      real(dp) :: det_s_theta, sqrtg
+      real(dp) :: Br, Bphi, Bz
+      real(dp) :: dBrdR, dBrdp, dBrdZ
+      real(dp) :: dBpdR, dBpdp, dBpdZ
+      real(dp) :: dBzdR, dBzdp, dBzdZ
+      real(dp) :: Bcov_s, Bcov_theta, Bcov_phi
+      real(dp) :: psi_local
 
-        if (.not. initialized) then
-            error stop "geoflux_field: call spline_geoflux_data before splint_geoflux_field"
-        end if
+      if (.not. initialized) then
+         error stop "geoflux_field: call spline_geoflux_data before splint_geoflux_field"
+      end if
 
-        x_geo = [s_tor, theta_geo, phi]
-        call geoflux_to_cyl(x_geo, x_cyl, jac)
+      x_geo = [s_tor, theta_geo, phi]
+      call geoflux_to_cyl(x_geo, x_cyl, jac)
 
-        call field_eq(x_cyl(1), x_cyl(2), x_cyl(3), Br, Bphi, Bz, &
-                      dBrdR, dBrdp, dBrdZ, dBpdR, dBpdp, dBpdZ, dBzdR, dBzdp, dBzdZ)
+      call field_eq(x_cyl(1), x_cyl(2), x_cyl(3), Br, Bphi, Bz, &
+                    dBrdR, dBrdp, dBrdZ, dBpdR, dBpdp, dBpdZ, dBzdR, dBzdp, dBzdZ)
 
-        psi_local = psif
+      psi_local = psif
 
-        Bmod = sqrt(Br*Br + Bphi*Bphi + Bz*Bz)
+      Bmod = sqrt(Br*Br + Bphi*Bphi + Bz*Bz)
 
-        dRds = jac(1,1)
-        dRdt = jac(1,2)
-        dZds = jac(3,1)
-        dZdt = jac(3,2)
+      dRds = jac(1, 1)
+      dRdt = jac(1, 2)
+      dZds = jac(3, 1)
+      dZdt = jac(3, 2)
 
-        det_s_theta = dRds*dZdt - dRdt*dZds
-        sqrtg = abs(x_cyl(1) * det_s_theta)
+      det_s_theta = dRds*dZdt - dRdt*dZds
+      sqrtg = abs(x_cyl(1)*det_s_theta)
 
-        Bcov_s     = Br*dRds + Bz*dZds
-        Bcov_theta = Br*dRdt + Bz*dZdt
-        Bcov_phi   = Bphi * x_cyl(1)
+      Bcov_s = Br*dRds + Bz*dZds
+      Bcov_theta = Br*dRdt + Bz*dZdt
+      Bcov_phi = Bphi*x_cyl(1)
 
-        if (Bmod > 0.0_dp) then
-            hcov(1) = Bcov_s / Bmod
-            hcov(2) = Bcov_theta / Bmod
-            hcov(3) = Bcov_phi / Bmod
-        else
-            hcov = 0.0_dp
-        end if
+      if (Bmod > 0.0_dp) then
+         hcov(1) = Bcov_s/Bmod
+         hcov(2) = Bcov_theta/Bmod
+         hcov(3) = Bcov_phi/Bmod
+      else
+         hcov = 0.0_dp
+      end if
 
-        Acov(1) = 0.0_dp
-        Acov(2) = 0.0_dp
-        Acov(3) = psi_local - psi_axis
+      Acov(1) = 0.0_dp
+      Acov(2) = 0.0_dp
+      Acov(3) = psi_local - psi_axis
 
-        if (present(sqgBctr)) then
-            sqgBctr = 0.0_dp
-            sqgBctr(1) = sqrtg
-        end if
-    end subroutine splint_geoflux_field
+      if (present(sqgBctr)) then
+         sqgBctr = 0.0_dp
+         sqgBctr(1) = sqrtg
+      end if
+   end subroutine splint_geoflux_field
 
 end module geoflux_field

--- a/test/python/test_coordinate_converter.py
+++ b/test/python/test_coordinate_converter.py
@@ -1,5 +1,7 @@
 # %% Standard imports
 import os
+from pathlib import Path
+
 import pytest
 import numpy as np
 import matplotlib.pyplot as plt
@@ -9,108 +11,117 @@ from libneo import StorGeom2MarsCoords
 from libneo import order_monotonically
 
 mars_dir = "/proj/plasma/DATA/DEMO/MARS/MARSQ_KNTV10_NEO2profs_KEYTORQ_1/"
-# Skip this module if the MARS data directory is not available in the environment
 pytestmark = pytest.mark.skipif(not os.path.exists(mars_dir), reason="MARS data not available on this system")
-sqrtspol = np.linspace(0,1,5)
-chi = np.linspace(-np.pi,np.pi,10)
+
+sqrtspol = np.linspace(0, 1, 5)
+chi = np.linspace(-np.pi, np.pi, 10)
 chi[-1] = chi[-1] - 0.1
 coordsystem = {'radius': sqrtspol.tolist(), 'angle': np.meshgrid(chi, sqrtspol)[0].tolist()}
-new_coordsystem = {'radius': (1/2*sqrtspol).tolist(), 'angle': np.mod(np.meshgrid(chi, sqrtspol)[0], 2*np.pi).tolist()}
+new_coordsystem = {'radius': (0.5 * sqrtspol).tolist(), 'angle': np.mod(np.meshgrid(chi, sqrtspol)[0], 2 * np.pi).tolist()}
+
+
+def _figure_path(name: str) -> Path:
+    repo_root = Path(__file__).resolve().parents[2]
+    target = repo_root / "build" / "test" / "python"
+    target.mkdir(parents=True, exist_ok=True)
+    return target / name
+
+
+def _save_current_figure(name: str) -> None:
+    plt.savefig(_figure_path(name), dpi=150, bbox_inches="tight")
+    plt.close()
+
 
 def test_order_monotonically():
-    coordsystem = {'radius': [1, 3, 2], 'angle': [[3, 1, 2], [7, 9, 8], [4, 5 ,6]]}
-    new_coordsystem = {'radius': [1, 2, 3], 'angle': [[1, 2, 3], [4, 5, 6], [7, 8 ,9]]}
-    coordsystem, new_coordsystem = order_monotonically(coordsystem, new_coordsystem)
-    assert is_monotonically_increasing(coordsystem['radius'])
-    assert not is_monotonically_increasing(new_coordsystem['radius'])
-    assert is_monotonically_increasing(coordsystem['angle'])
-    assert not is_monotonically_increasing(new_coordsystem['angle'])
-    assert np.concatenate(coordsystem['angle']).tolist() == [1, 2, 3, 4, 5, 6, 7, 8, 9]
-    assert np.concatenate(new_coordsystem['angle']).tolist() == [2, 3, 1, 7, 8, 9, 4, 6, 5]
+    input_coords = {'radius': [1, 3, 2], 'angle': [[3, 1, 2], [7, 9, 8], [4, 5, 6]]}
+    new_coords = {'radius': [1, 2, 3], 'angle': [[1, 2, 3], [4, 5, 6], [7, 8, 9]]}
+    coordsystem_sorted, new_coordsystem_sorted = order_monotonically(input_coords, new_coords)
+    assert is_monotonically_increasing(coordsystem_sorted['radius'])
+    assert not is_monotonically_increasing(new_coordsystem_sorted['radius'])
+    assert is_monotonically_increasing(coordsystem_sorted['angle'])
+    assert not is_monotonically_increasing(new_coordsystem_sorted['angle'])
+    assert np.concatenate(coordsystem_sorted['angle']).tolist() == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert np.concatenate(new_coordsystem_sorted['angle']).tolist() == [2, 3, 1, 7, 8, 9, 4, 6, 5]
+
 
 def is_monotonically_increasing(arr):
     return np.all(np.diff(arr) > 0)
+
 
 def test_MarsCoords2StorThetageom_init():
     mars = StorGeom2MarsCoords(mars_dir)
     assert mars is not None
 
+
 def test_MarsCoords2StorThetageom_load_points_from():
-    mars_coords, stor_geom_coords = StorGeom2MarsCoords.load_points_from(
-        mars_dir)
+    mars_coords, stor_geom_coords = StorGeom2MarsCoords.load_points_from(mars_dir)
     assert len(mars_coords['angle']) == len(mars_coords['radius'])
     assert len(mars_coords['radius']) == len(stor_geom_coords['radius'])
     for i in range(len(mars_coords['radius'])):
-        assert isinstance(mars_coords['radius'][i],float)
+        assert isinstance(mars_coords['radius'][i], float)
         assert len(mars_coords['angle'][i]) == len(stor_geom_coords['angle'][i])
+
 
 def test_MarsCoord2StorThetageom_stor2sqrtspol():
     converter = StorGeom2MarsCoords(mars_dir)
     stor2sqrtspol = converter._stor2sqrtspol
     assert stor2sqrtspol(0) == 0
     assert stor2sqrtspol(1) == 1
-    assert not stor2sqrtspol(0.5) == 0.5
+    assert stor2sqrtspol(0.5) != 0.5
     from neo2_mars import mars_sqrtspol2stor
-    sqrtspol = np.linspace(0, 1, 100)
-    stor = mars_sqrtspol2stor(mars_dir, sqrtspol)
-    assert np.allclose(sqrtspol, stor2sqrtspol(stor),atol=1e-2)
+    sqrtspol_values = np.linspace(0, 1, 100)
+    stor = mars_sqrtspol2stor(mars_dir, sqrtspol_values)
+    assert np.allclose(sqrtspol_values, stor2sqrtspol(stor), atol=1e-2)
+
 
 def test_MarsCoords2StorThetageom_visual_check():
-    from pathlib import Path
     converter = StorGeom2MarsCoords(mars_dir)
     test_stor = np.linspace(0.0, 1, 5)
     test_theta_geom = np.linspace(-np.pi, np.pi, 800)
-    fig = plt.figure()
+    plt.figure()
     for stor in test_stor:
-        sqrtspol, chi = converter(stor, test_theta_geom)
-        plt.plot(test_theta_geom, chi, '.', label=f"stor={stor}")
+        sqrtspol_val, chi_val = converter(stor, test_theta_geom)
+        plt.plot(test_theta_geom, chi_val, '.', label=f"stor={stor}")
     plt.xlabel('theta_geom [1]')
     plt.ylabel('chi [1]')
     plt.legend()
-    output = Path("build/test/python/mars_coords_visual.png")
-    output.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(output, dpi=150, bbox_inches='tight')
-    plt.show()
-    plt.close(fig)
+    _save_current_figure('coordinate_converter_chi_vs_theta_geom.png')
+
 
 def test_MarsCoords2StorThetageom_coords_domain_visual_check():
-    from pathlib import Path
     converter = StorGeom2MarsCoords(mars_dir)
     mars_coords = converter.mars_coords
     stor_geom_coords = converter.stor_geom_coords
-    fig, ax = plt.subplots(1,2, figsize=(10,5))
-    color = ['b', 'y', 'g', 'r']
+    fig, ax = plt.subplots(1, 2, figsize=(10, 5), constrained_layout=True)
+    colors = ['b', 'y', 'g', 'r']
 
-    stor_geom_coords, mars_coords = order_monotonically(stor_geom_coords, mars_coords)
-    color_count = 0
-    for i in range(0,len(mars_coords['radius']),100):
-        ax[0].plot(stor_geom_coords['angle'][i], mars_coords['angle'][i], '.' + color[color_count], label=f"sqrtspol={mars_coords['radius'][i]}")
-        discontinuity = np.where(np.abs(np.diff(mars_coords['angle'][i])) > np.pi)[0]
+    stor_geom_sorted, mars_sorted = order_monotonically(stor_geom_coords, mars_coords)
+    for idx, i in enumerate(range(0, len(mars_sorted['radius']), 100)):
+        ax[0].plot(stor_geom_sorted['angle'][i], mars_sorted['angle'][i], '.' + colors[idx % len(colors)],
+                   label=f"sqrtspol={mars_sorted['radius'][i]:.2f}")
+        discontinuity = np.where(np.abs(np.diff(mars_sorted['angle'][i])) > np.pi)[0]
         if len(discontinuity) > 0:
-            ax[0].axvline(x=stor_geom_coords['angle'][i][discontinuity[0]], color=color[color_count], linestyle='--', label='discontinuity by data')
-            ax[0].axvline(x=stor_geom_coords['angle'][i][discontinuity[0]+1], color=color[color_count], linestyle='--')
-        color_count += 1
+            ax[0].axvline(x=stor_geom_sorted['angle'][i][discontinuity[0]], color=colors[idx % len(colors)], linestyle='--',
+                          label='discontinuity by data')
+            ax[0].axvline(x=stor_geom_sorted['angle'][i][discontinuity[0] + 1], color=colors[idx % len(colors)], linestyle='--')
     ax[0].set_xlabel('theta_geom [1]')
     ax[0].set_ylabel('chi [1]')
     ax[0].legend()
 
-    mars_coords, stor_geom_coords = order_monotonically(mars_coords, stor_geom_coords)
-    color_count = 0
-    for i in range(0,len(mars_coords['radius']),100):
-        ax[1].plot(mars_coords['angle'][i], stor_geom_coords['angle'][i], '.' + color[color_count], label=f"stor={stor_geom_coords['radius'][i]}")
-        discontinuity = np.where(np.abs(np.diff(stor_geom_coords['angle'][i])) > np.pi)[0]
+    mars_sorted, stor_geom_sorted = order_monotonically(mars_coords, stor_geom_coords)
+    for idx, i in enumerate(range(0, len(mars_sorted['radius']), 100)):
+        ax[1].plot(mars_sorted['angle'][i], stor_geom_sorted['angle'][i], '.' + colors[idx % len(colors)],
+                   label=f"stor={stor_geom_sorted['radius'][i]:.2f}")
+        discontinuity = np.where(np.abs(np.diff(stor_geom_sorted['angle'][i])) > np.pi)[0]
         if len(discontinuity) > 0:
-            ax[1].axvline(x=mars_coords['angle'][i][discontinuity[0]], color=color[color_count], linestyle='--', label='discontinuity by data')
-            ax[1].axvline(x=mars_coords['angle'][i][discontinuity[0]+1], color=color[color_count], linestyle='--')
-        color_count += 1
+            ax[1].axvline(x=mars_sorted['angle'][i][discontinuity[0]], color=colors[idx % len(colors)], linestyle='--',
+                          label='discontinuity by data')
+            ax[1].axvline(x=mars_sorted['angle'][i][discontinuity[0] + 1], color=colors[idx % len(colors)], linestyle='--')
     ax[1].set_xlabel('chi [1]')
     ax[1].set_ylabel('theta_geom [1]')
     ax[1].legend()
-    output = Path("build/test/python/mars_coords_domain.png")
-    output.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(output, dpi=150, bbox_inches='tight')
-    plt.show()
-    plt.close(fig)
+    _save_current_figure('coordinate_converter_coordinate_domains.png')
+
 
 def test_MarsCoord2StorThetageom_performance_profile():
     import cProfile
@@ -119,13 +130,14 @@ def test_MarsCoord2StorThetageom_performance_profile():
     p = pstats.Stats('mars_coords2stor_thetageom.profile')
     p.strip_dirs().sort_stats('cumulative').print_stats(20)
 
+
 def test_MarsCoords2StorThetageom_performance():
     converter = StorGeom2MarsCoords(mars_dir)
     test_stor = np.linspace(0.0, 1, 100)
     test_theta_geom = np.linspace(-np.pi, np.pi, 100)
     for _ in range(20):
         for stor in test_stor:
-            sqrtspol, chi = converter(stor, test_theta_geom)
+            converter(stor, test_theta_geom)
 
 
 if __name__ == "__main__":
@@ -133,8 +145,5 @@ if __name__ == "__main__":
     test_MarsCoords2StorThetageom_load_points_from()
     test_MarsCoord2StorThetageom_stor2sqrtspol()
     print("All tests passed!")
-
-    #test_MarsCoord2StorThetageom_performance_profile()
-
     test_MarsCoords2StorThetageom_visual_check()
     test_MarsCoords2StorThetageom_coords_domain_visual_check()

--- a/test/python/test_fourier_utils.py
+++ b/test/python/test_fourier_utils.py
@@ -1,17 +1,24 @@
 # %% Standard imports
+from pathlib import Path
+
 import numpy as np
 import matplotlib.pyplot as plt
-from pathlib import Path
 
 # modules to test
 from libneo import fourier_coefs_half, fourier_coefs_full, get_half_fft
 
-def save_plot(fig, filename):
-    """Helper to save plots to build/test/python directory"""
-    output = Path(f"build/test/python/{filename}")
-    output.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(output, dpi=150, bbox_inches='tight')
-    return output
+
+def _figure_path(name: str) -> Path:
+    repo_root = Path(__file__).resolve().parents[2]
+    target = repo_root / "build" / "test" / "python"
+    target.mkdir(parents=True, exist_ok=True)
+    return target / name
+
+
+def _save_current_figure(name: str) -> None:
+    plt.savefig(_figure_path(name), dpi=150, bbox_inches="tight")
+    plt.close()
+
 
 def test_fourier_coefs_half():
     x = np.linspace(0, 2*np.pi, 100)
@@ -23,6 +30,7 @@ def test_fourier_coefs_half():
     assert not is_imag_part_vanisching(f_eval)
     assert np.allclose(np.real(f_eval), trial_trigonometric_func(new_x))
 
+
 def test_fourier_coefs_full():
     x = np.linspace(0, 2*np.pi, 100)
     m = np.arange(-4, 5)
@@ -32,6 +40,7 @@ def test_fourier_coefs_full():
     assert is_complex(f_eval)
     assert is_imag_part_vanisching(f_eval)
     assert np.allclose(np.real(f_eval), trial_trigonometric_func(new_x))
+
 
 def test_fourier_coefs_half_on_complex_function():
     x = np.linspace(0, 2*np.pi, 100)
@@ -44,6 +53,7 @@ def test_fourier_coefs_half_on_complex_function():
     assert not np.allclose(np.real(f_eval), np.real(complex_trial_func(new_x)))
     assert not np.allclose(np.imag(f_eval), np.imag(complex_trial_func(new_x)))
 
+
 def test_fourier_coefs_full_on_complex_function():
     x = np.linspace(0, 2*np.pi, 100)
     m = np.arange(-4, 5)
@@ -55,12 +65,14 @@ def test_fourier_coefs_full_on_complex_function():
     assert np.allclose(np.real(fft_eval), np.real(complex_trial_func(new_x)))
     assert np.allclose(np.imag(fft_eval), np.imag(complex_trial_func(new_x)))
 
+
 def test_get_half_fft_coefficients_on_trigonometric_func():
     grid = np.linspace(0, 2*np.pi, 20)
     fm, m = get_half_fft(trial_trigonometric_func(grid), grid)
     # The coefficients from the trial function sin(x)*sin(x)*cos(x) + 1
-    assert np.allclose(fm.real, np.array([1,0.25,0,-0.25,0,0,0,0,0,0]))
-    assert np.allclose(fm.imag, np.array([0,0,0,0,0,0,0,0,0,0]))
+    assert np.allclose(fm.real, np.array([1, 0.25, 0, -0.25, 0, 0, 0, 0, 0, 0]))
+    assert np.allclose(fm.imag, np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
+
 
 def test_get_half_fft_even_odd_grid():
     even_grid = np.linspace(-np.pi, np.pi, 20)
@@ -72,6 +84,7 @@ def test_get_half_fft_even_odd_grid():
     assert np.allclose(f_odd(odd_grid), trial_func(odd_grid))
     assert not np.allclose(f_odd(even_grid), trial_func(even_grid))
 
+
 def test_get_half_fft_on_trigonometric_func():
     grid = np.linspace(0, 2*np.pi, 20)
     fm, m = get_half_fft(trial_trigonometric_func(grid), grid)
@@ -81,12 +94,14 @@ def test_get_half_fft_on_trigonometric_func():
     assert not is_imag_part_vanisching(fft_eval)
     assert np.allclose(np.real(fft_eval), trial_trigonometric_func(grid_eval))
 
+
 def test_get_half_fft_on_func():
     grid = np.linspace(-np.pi, np.pi, 20)
     between_grid = grid[:-1] + 0.5*np.diff(grid)
     fft_series = get_fft_series_lambda_function(trial_func, grid)
     assert np.allclose(fft_series(grid), trial_func(grid))
     assert not np.allclose(fft_series(between_grid), trial_func(between_grid))
+
 
 def test_get_half_fft_phaseshift():
     grid = np.linspace(0, 2*np.pi, 10)
@@ -97,7 +112,8 @@ def test_get_half_fft_phaseshift():
     grid_plus_pi = grid + np.pi
     assert np.allclose(f_plus_pi(grid_plus_pi), trial_func(grid_plus_pi))
     grid_plus_pi_between = get_intermediate_steps(grid_plus_pi)
-    assert not np.allclose(f_plus_pi(grid_plus_pi_between), trial_func(grid_plus_pi_between))   
+    assert not np.allclose(f_plus_pi(grid_plus_pi_between), trial_func(grid_plus_pi_between))
+
 
 def test_get_half_fft_phaseshift_visual_check():
     grid = np.linspace(0, 2*np.pi, 10)
@@ -105,18 +121,17 @@ def test_get_half_fft_phaseshift_visual_check():
     f_minus_pi = get_fft_series_lambda_function(trial_func, grid - np.pi)
     f_plus_pi = get_fft_series_lambda_function(trial_func, grid + np.pi)
     grid_eval = add_intermediate_steps(grid)
-    fig = plt.figure()
+    plt.figure()
     plt.plot(grid_eval, trial_func(grid_eval), 'ro-', label='base function')
     plt.plot(grid_eval, f(grid_eval), 'D-', label='no shift')
     plt.plot(grid_eval, f_plus_pi(grid_eval), 'x-', label='+pi shifted')
-    plt.plot(grid_eval, f_minus_pi(grid_eval),'+--', label='-pi shifted')
+    plt.plot(grid_eval, f_minus_pi(grid_eval), '+--', label='-pi shifted')
     plt.legend()
     plt.xlabel('x [1]')
     plt.ylabel('f(x) [1]')
     plt.title('Reconstruction of trial function from ffts on shifted intervals')
-    save_plot(fig, "fourier_phaseshift_visual.png")
-    plt.show()
-    plt.close(fig)
+    _save_current_figure('fourier_utils_phaseshift.png')
+
 
 def test_get_half_fft_even_odd_grid_visual_check():
     even_grid = np.linspace(-np.pi, np.pi, 10)
@@ -124,7 +139,7 @@ def test_get_half_fft_even_odd_grid_visual_check():
     f_even = get_fft_series_lambda_function(trial_func, even_grid)
     f_odd = get_fft_series_lambda_function(trial_func, odd_grid)
     grid_eval = np.sort(np.concatenate([even_grid, odd_grid]))
-    fig = plt.figure()
+    plt.figure()
     plt.plot(grid_eval, trial_func(grid_eval), 'D-', label='base function')
     plt.plot(grid_eval, f_even(grid_eval), 'x-', label='fft on even grid')
     plt.plot(grid_eval, f_odd(grid_eval), '+-', label='fft on odd grid')
@@ -132,19 +147,21 @@ def test_get_half_fft_even_odd_grid_visual_check():
     plt.xlabel('x [1]')
     plt.ylabel('f(x) [1]')
     plt.title('Reconstruction of trial function from ffts on even and odd grid')
-    save_plot(fig, "fourier_even_odd_grid_visual.png")
-    plt.show()
-    plt.close(fig)
+    _save_current_figure('fourier_utils_even_odd.png')
+
 
 def get_fft_series_lambda_function(func, grid):
     fm, m = get_half_fft(func(grid), grid)
     return lambda x: np.real(fm.dot(np.exp(1.0j * np.outer(m, x))))
 
+
 def add_intermediate_steps(grid):
-    return np.sort(np.concatenate([grid,get_intermediate_steps(grid)]))
+    return np.sort(np.concatenate([grid, get_intermediate_steps(grid)]))
+
 
 def get_intermediate_steps(grid):
     return grid[:-1] + 0.5*np.diff(grid)
+
 
 def test_fourier_coefs_visual_check():
     x = np.linspace(0, 2*np.pi, 100)
@@ -153,69 +170,69 @@ def test_fourier_coefs_visual_check():
     m_half = np.arange(0, 5)
     fm_half = fourier_coefs_half(trial_trigonometric_func(x)[:-1], x, m_half)
     x_rand = np.sort(np.random.uniform(0, 2*np.pi, 20))
-    f_eval = np.real(fm.dot(np.exp(1.0j * np.outer(m, x_rand))))
-    f_eval_half = np.real(fm_half.dot(np.exp(1.0j * np.outer(m_half, x_rand))))
-    fig = plt.figure()
+    plt.figure()
     plt.plot(x, trial_trigonometric_func(x), label='trial function')
-    plt.plot(x_rand, f_eval, 'o', label='full fourier eval')
-    plt.plot(x_rand, f_eval_half, 'x', label='half fourier eval')
+    plt.plot(x_rand, np.real(fm.dot(np.exp(1.0j * np.outer(m, x_rand)))), 'o', label='full fourier eval')
+    plt.plot(x_rand, np.real(fm_half.dot(np.exp(1.0j * np.outer(m_half, x_rand)))), 'x', label='half fourier eval')
     plt.legend()
     plt.xlabel('x [1]')
     plt.ylabel('f(x) [1]')
     plt.title('Reconstruction of trial function from fourier coef computation')
-    save_plot(fig, "fourier_coefs_visual.png")
-    plt.show()
-    plt.close(fig)
+    _save_current_figure('fourier_utils_fourier_coefs.png')
+
 
 def test_get_half_fft_visual_check():
-    make_visual_check_get_half_fft_on(trial_trigonometric_func)
-    make_visual_check_get_half_fft_on(trial_func)
+    make_visual_check_get_half_fft_on(trial_trigonometric_func, 'trig')
+    make_visual_check_get_half_fft_on(trial_func, 'ramp')
 
-def make_visual_check_get_half_fft_on(func):
+
+def make_visual_check_get_half_fft_on(func, label: str):
     grid = np.linspace(0, 2*np.pi, 20)
     fm, m = get_half_fft(func(grid), grid)
-    grid_eval = np.sort(np.concatenate([grid,grid[:-1] + 0.5*np.diff(grid)]))
+    grid_eval = np.sort(np.concatenate([grid, grid[:-1] + 0.5*np.diff(grid)]))
     fourier_eval = fm.dot(np.exp(1.0j * np.outer(m, grid_eval)))
-    fig = plt.figure()
+    plt.figure()
     plt.plot(grid, func(grid), 'D', label='trial data')
     plt.plot(grid_eval, np.real(fourier_eval), '-x', label='half fft eval')
     plt.legend()
     plt.xlabel('x [1]')
     plt.ylabel('f(x) [1]')
     plt.title('Reconstruction of trial function from fft results')
-    func_name = func.__name__
-    save_plot(fig, f"fourier_half_fft_{func_name}_visual.png")
-    plt.show()
-    plt.close(fig)
+    _save_current_figure(f'fourier_utils_half_fft_{label}.png')
+
 
 def test_get_half_fft_coefficients_visual_check():
     grid = np.linspace(0, 2*np.pi, 20)
     fm, m = get_half_fft(trial_trigonometric_func(grid), grid)
-    fig = plt.figure()
+    plt.figure()
     plt.plot(m, fm.real, '-D', label='real-part fft coefs')
     plt.plot(m, fm.imag, '-x', label='imag-part fft coefs')
     plt.legend()
     plt.xlabel('modenumber m [1]')
     plt.ylabel('fm [1]')
     plt.title('Fourier coefficients of trigonometric function from FFT')
-    save_plot(fig, "fourier_coefficients_visual.png")
-    plt.show()
-    plt.close(fig)
+    _save_current_figure('fourier_utils_coefficients.png')
+
 
 def trial_trigonometric_func(x):
-    return np.sin(x)*np.sin(x)*np.cos(x) + 1
+    return np.sin(x) * np.sin(x) * np.cos(x) + 1
+
 
 def trial_func(x):
     return np.mod(x, 2*np.pi)
 
+
 def complex_trial_func(x):
-    return np.sin(x) + np.sin(x)*np.cos(x)*1.0j
+    return np.sin(x) + np.sin(x) * np.cos(x) * 1.0j
+
 
 def is_imag_part_vanisching(x):
     return np.allclose(np.imag(x), 0)
 
+
 def is_complex(x):
     return np.iscomplexobj(x)
+
 
 def test_angle_conversion_example_visual_check():
     chi = np.linspace(-np.pi, np.pi, 50)
@@ -253,13 +270,15 @@ def test_angle_conversion_example_visual_check():
     ax[0].legend()
     ax[0].axis('equal')
     plt.suptitle('Conversion between geom and chi angle functions')
-    save_plot(fig, "fourier_angle_conversion_visual.png")
-    plt.show()
-    plt.close(fig)
+    _save_current_figure('fourier_utils_geom_vs_chi.png')
 
-def trial_geom_func(x, boundary: float=-np.pi):
-    angle = (x - np.pi - boundary) + np.sin((x - np.pi - boundary)) + 0.3*np.sin(2*(x - np.pi - boundary))
-    return np.mod(angle + np.pi, 2*np.pi) - np.pi
+
+def trial_geom_func(x, boundary: float = -np.pi):
+    angle = (x - np.pi - boundary) + np.sin((x - np.pi - boundary)) + 0.3 * np.sin(
+        2 * (x - np.pi - boundary)
+    )
+    return np.mod(angle + np.pi, 2 * np.pi) - np.pi
+
 
 def sort_by_first_list(list1, list2):
     if isinstance(list1, np.ndarray):
@@ -284,8 +303,3 @@ if __name__ == '__main__':
     test_get_half_fft_phaseshift()
     print("All tests passed!")
     test_get_half_fft_phaseshift_visual_check()
-    test_get_half_fft_even_odd_grid_visual_check()
-    test_fourier_coefs_visual_check()
-    test_get_half_fft_visual_check()
-    test_get_half_fft_coefficients_visual_check()
-    test_angle_conversion_example_visual_check()

--- a/test/python/test_semi_periodic_fourier_spline.py
+++ b/test/python/test_semi_periodic_fourier_spline.py
@@ -1,33 +1,43 @@
 # %% Standard imports
+from pathlib import Path
+
 import numpy as np
 import matplotlib.pyplot as plt
 import pytest
-from pathlib import Path
 
 # modules to test
 from libneo import SemiPeriodicFourierSpline
 from libneo import SemiPeriodicFourierSpline_ExceedingNyquistLimit
 
-def save_plot(fig, filename):
-    """Helper to save plots to build/test/python directory"""
-    output = Path(f"build/test/python/{filename}")
-    output.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(output, dpi=150, bbox_inches='tight')
-    return output
+
+def _figure_path(name: str) -> Path:
+    repo_root = Path(__file__).resolve().parents[2]
+    target = repo_root / "build" / "test" / "python"
+    target.mkdir(parents=True, exist_ok=True)
+    return target / name
+
+
+def _save_current_figure(name: str) -> None:
+    plt.savefig(_figure_path(name), dpi=150, bbox_inches="tight")
+    plt.close()
+
 
 s = np.linspace(0, 1, 5)
 angle = np.linspace(-np.pi, np.pi, 10)
+
 
 def test_init():
     Angle, S = np.meshgrid(angle, s)
     F = trial_trigonometric_func(S, Angle)
     spline = SemiPeriodicFourierSpline(s, angle, F)
 
+
 def test_SemiPeriodicFourierSpline_ExceedingNyquistLimit():
     Angle, S = np.meshgrid(angle, s)
     F = trial_trigonometric_func(S, Angle)
     with pytest.raises(SemiPeriodicFourierSpline_ExceedingNyquistLimit):
-        spline = SemiPeriodicFourierSpline(s, angle, F, max_modenumber=len(angle))
+        SemiPeriodicFourierSpline(s, angle, F, max_modenumber=len(angle))
+
 
 def test_fourier_coefs_shape():
     max_m = 4
@@ -35,7 +45,8 @@ def test_fourier_coefs_shape():
     F = trial_trigonometric_func(S, Angle)
     spline = SemiPeriodicFourierSpline(s, angle, F, max_modenumber=max_m)
     coefs = spline._fourier_coefs
-    assert coefs.shape == (len(s), max_m+1)
+    assert coefs.shape == (len(s), max_m + 1)
+
 
 def test_get_fourier_coefs_splines():
     Angle, S = np.meshgrid(angle, s)
@@ -44,42 +55,43 @@ def test_get_fourier_coefs_splines():
     assert np.allclose(spline._fourier_coefs_splines(s), spline._fourier_coefs)
     assert spline._fourier_coefs_splines(s).shape == (len(s), len(spline._modenumbers))
 
+
 def test_call():
     Angle, S = np.meshgrid(angle, s)
     F = trial_trigonometric_func(S, Angle)
     spline = SemiPeriodicFourierSpline(s, angle, F)
     assert np.allclose(spline(s, angle), F)
-    assert np.allclose(spline(s, angle+2*np.pi), spline(s, angle))
-    assert np.allclose(spline(s, angle-2*np.pi), spline(s, angle))
+    assert np.allclose(spline(s, angle + 2 * np.pi), spline(s, angle))
+    assert np.allclose(spline(s, angle - 2 * np.pi), spline(s, angle))
     r_new = np.random.uniform(0, 1, 5)
     angle_new = np.random.uniform(-np.pi, np.pi, 5)
-    assert np.allclose(spline(r_new, angle_new,grid=False), trial_trigonometric_func(r_new, angle_new))
+    assert np.allclose(spline(r_new, angle_new, grid=False), trial_trigonometric_func(r_new, angle_new))
+
 
 def test_get_fourier_coefs_visual_check():
     Angle, S = np.meshgrid(angle, s)
     F = trial_trigonometric_func(S, Angle)
     spline = SemiPeriodicFourierSpline(s, angle, F)
-    fig = plt.figure()
+    plt.figure()
     r_plot = np.linspace(0, 1, 30)
     coefs_plot = spline._fourier_coefs_splines(r_plot)
-    for i,m in enumerate(spline._modenumbers):
-        plt.plot(r_plot, coefs_plot[:,i].real, '-', label=f'real m={m}')
-        plt.plot(r_plot, coefs_plot[:,i].imag, '.--', label=f'imag m={m}')
+    for i, m in enumerate(spline._modenumbers):
+        plt.plot(r_plot, coefs_plot[:, i].real, '-', label=f'real m={m}')
+        plt.plot(r_plot, coefs_plot[:, i].imag, '.--', label=f'imag m={m}')
     plt.xlabel('s [1]')
     plt.ylabel('fm [1]')
     plt.title('Fourier coefficients of trigonometric trial function depending on s')
     plt.legend()
-    save_plot(fig, "spline_fourier_coefs_visual.png")
-    plt.show()
-    plt.close(fig)
+    _save_current_figure('semi_periodic_fourier_coefs.png')
+
 
 def test_trial_theta_geom_func_visual_check():
-    angle = np.linspace(-np.pi, np.pi, 100)
-    Angle, S = np.meshgrid(angle, s)
+    local_angle = np.linspace(-np.pi, np.pi, 100)
+    Angle, S = np.meshgrid(local_angle, s)
     Theta_geom = theta_geom_func(S, Angle)
-    spline = SemiPeriodicFourierSpline(s, angle, Theta_geom)
-    fig = plt.figure()
-    angle_plot = np.linspace(-np.pi, np.pi,19)
+    spline = SemiPeriodicFourierSpline(s, local_angle, Theta_geom)
+    plt.figure()
+    angle_plot = np.linspace(-np.pi, np.pi, 19)
     s_plot = np.linspace(0, 1, 9)
     Angle_plot, S_plot = np.meshgrid(angle_plot, s_plot)
     R, Z = polar2cart(S_plot, theta_geom_func(S_plot, Angle_plot))
@@ -89,19 +101,18 @@ def test_trial_theta_geom_func_visual_check():
     plt.xlabel('R [1]')
     plt.ylabel('Z [1]')
     plt.legend()
-    plt.title('Theta_geom rays as function of equidistant input angle \n splined form uniform datapoints N='+str(len(angle))+'x'+str(len(s))+' [angle x s]')
-    save_plot(fig, "spline_theta_geom_uniform_visual.png")
-    plt.show()
-    plt.close(fig)
+    plt.title('Theta_geom rays (uniform grid)')
+    _save_current_figure('semi_periodic_theta_geom_uniform.png')
+
 
 def test_trial_theta_geom_func_different_angle_per_surface_visual_check():
-    angle = np.linspace(-np.pi, np.pi, 100)
-    Angle, S = np.meshgrid(angle, s)
-    Angle[:,1:-1] = Angle[:,1:-1]*(S[:,1:-1] + 1)/2 # uneven distributed angles, but same endpoints
+    local_angle = np.linspace(-np.pi, np.pi, 100)
+    Angle, S = np.meshgrid(local_angle, s)
+    Angle[:, 1:-1] = Angle[:, 1:-1] * (S[:, 1:-1] + 1) / 2
     Theta_geom = theta_geom_func(S, Angle)
     spline = SemiPeriodicFourierSpline(s, Angle, Theta_geom)
-    fig = plt.figure()
-    angle_plot = np.linspace(-np.pi, np.pi,19)
+    plt.figure()
+    angle_plot = np.linspace(-np.pi, np.pi, 19)
     s_plot = np.linspace(0, 1, 9)
     Angle_plot, S_plot = np.meshgrid(angle_plot, s_plot)
     R, Z = polar2cart(S_plot, theta_geom_func(S_plot, Angle_plot))
@@ -111,22 +122,23 @@ def test_trial_theta_geom_func_different_angle_per_surface_visual_check():
     plt.xlabel('R [1]')
     plt.ylabel('Z [1]')
     plt.legend()
-    plt.title('Theta_geom rays as function of equidistant input angle \n splined from uneven distributed datapoints N='+str(len(angle))+'x'+str(len(s))+' [angle x s]')
-    save_plot(fig, "spline_theta_geom_uneven_visual.png")
-    plt.show()
-    plt.close(fig)
+    plt.title('Theta_geom rays (uneven grid)')
+    _save_current_figure('semi_periodic_theta_geom_uneven.png')
 
-def trial_trigonometric_func(s,angle):
-    return s*np.cos(angle)*np.sin(angle)
 
-def theta_geom_func(s,chi):
-    theta_geom = chi
-    return theta_geom
+def trial_trigonometric_func(s_val, angle_val):
+    return s_val * np.cos(angle_val) * np.sin(angle_val)
 
-def polar2cart(rho,theta):
-    x = rho*np.cos(theta)
-    y = rho*np.sin(theta)
-    return x,y
+
+def theta_geom_func(s_val, chi):
+    return chi
+
+
+def polar2cart(rho, theta):
+    x = rho * np.cos(theta)
+    y = rho * np.sin(theta)
+    return x, y
+
 
 if __name__ == '__main__':
     test_init()
@@ -134,7 +146,6 @@ if __name__ == '__main__':
     test_fourier_coefs_shape()
     test_get_fourier_coefs_splines()
     test_call()
-    print("All tests passed.")
+    test_get_fourier_coefs_visual_check()
     test_trial_theta_geom_func_visual_check()
     test_trial_theta_geom_func_different_angle_per_surface_visual_check()
-    test_get_fourier_coefs_visual_check()

--- a/test/python/test_vmec_coords.py
+++ b/test/python/test_vmec_coords.py
@@ -86,11 +86,8 @@ def test_vmec_plot_surfaces_visual_check(tmp_path):
         # Save to build directory for artifact collection
         build_artifact = Path("build/test/python/vmec_surfaces.png")
         build_artifact.parent.mkdir(parents=True, exist_ok=True)
-
-        fig.savefig(build_artifact)
         outfile = build_artifact
-        # Show interactively; in headless backends this is a no-op
-        plt.show()
+        fig.savefig(build_artifact)
         plt.close(fig)
         assert outfile.exists()
         assert outfile.stat().st_size > 0


### PR DESCRIPTION
### **User description**
## Summary
- add a reusable reset_field_eq_state() that releases cached equilibrium arrays before re-init
- call the reset from the Boozer f2py deinit path and geoflux initialiser to avoid double allocation errors
- re-enable Boozer pytest module, modernise its expectations, and send generated PNG artifacts to build/test

## Testing
- pytest -q -k boozer -s

Fixes #126


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix field_eq memory allocation bug with reset function

- Restore and modernize Boozer test module

- Add proper test artifact handling to build directory

- Clean up Fortran code formatting and imports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["field_eq_mod.f90"] -- "add reset function" --> B["reset_field_eq_state()"]
  B -- "called by" --> C["f2py deinit"]
  B -- "called by" --> D["geoflux initializer"]
  E["test_boozer.py"] -- "modernized" --> F["working tests"]
  F -- "artifacts to" --> G["build/test/"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>f2py_efit_to_boozer.f90</strong><dd><code>Add field_eq reset call to f2py deinit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/efit_to_boozer/f2py_interfaces/f2py_efit_to_boozer.f90

<ul><li>Import <code>reset_field_eq_state</code> from field_eq_mod<br> <li> Call reset function in deinit subroutine<br> <li> Remove manual icall_eq reset<br> <li> Clean up code formatting and spacing</ul>


</details>


  </td>
<td><a
href="https://github.com/itpplasma/libneo/pull/143/files#diff-b0dbac3e8087abcc4f14acb63635fad093406263173ab14a160539eb00784633">+113/-116</a></td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>field_eq_mod.f90</strong><dd><code>Add reusable field_eq state reset function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/magfie/field_eq_mod.f90

<ul><li>Add new <code>reset_field_eq_state()</code> subroutine<br> <li> Deallocate all module arrays safely<br> <li> Reset state variables to initial values<br> <li> Clean up code formatting</ul>


</details>


  </td>
<td><a
href="https://github.com/itpplasma/libneo/pull/143/files#diff-1c045d3d99511438356cf6e357dcc01e6b3c3a2aca4969506d3f3f9851c424a2">+48/-25</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>geoflux_field.f90</strong><dd><code>Use field_eq reset in geoflux initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

src/magfie/geoflux_field.f90

<ul><li>Call <code>reset_field_eq_state()</code> in spline_geoflux_data<br> <li> Remove manual skip_read and icall_eq resets<br> <li> Clean up code formatting and imports</ul>


</details>


  </td>
<td><a
href="https://github.com/itpplasma/libneo/pull/143/files#diff-2b8f9ebf93559f814417276f01aabd421e36e70cb14c9f0eaee672f2627c62b0">+82/-83</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table> <tr>
  <td>
    <details>
<summary><strong>test_boozer.py</strong><dd><code>Restore and modernize Boozer test module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/tests/test_boozer.py

<ul><li>Remove xfail markers and restore working tests<br> <li> Add proper test directory setup with monkeypatch<br> <li> Redirect PNG artifacts to build/test directory<br> <li> Fix test assertions and modernize expectations</ul>


</details>


  </td>
<td><a
href="https://github.com/itpplasma/libneo/pull/143/files#diff-035637ddd5ac3c8d8675a407de8df3df7beb6138db754dc08bfadebb22067c1e">+39/-33</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___