### PR TITLE
Change netcdffile default to empty string for sentinel detection

### DIFF
--- a/src/canonical_coordinates_mod.f90
+++ b/src/canonical_coordinates_mod.f90
@@ -9,7 +9,7 @@
   end module parmot_mod
 !
   module new_vmec_stuff_mod
-    character*1000   :: netcdffile = 'wout.nc'
+    character*1000   :: netcdffile = ''  ! Empty = unset, apply 'wout.nc' default at usage
     integer          :: nsurfm,nstrm,nper=1,kpar
     integer          :: multharm=5,n_theta,n_phi
     integer          :: ns_A=5  !<- spline order for vector potential

--- a/src/new_vmec_allocation_stuff.f90
+++ b/src/new_vmec_allocation_stuff.f90
@@ -9,12 +9,15 @@ contains
 !
   integer :: ncid, status
   integer, dimension(2) :: lens
+  character(len=1000) :: filename
 !
-  status = nf90_open(netcdffile, NF90_NOWRITE, ncid)
+  filename = netcdffile
+  if (len_trim(filename) == 0) filename = 'wout.nc'
+  status = nf90_open(trim(filename), NF90_NOWRITE, ncid)
   if(status /= nf90_noerr) then
     print *, "new_allocate_vmec_stuff: could not find VMEC NetCDF file"
     print *, trim(nf90_strerror(status))
-    print *, trim(netcdffile)
+    print *, trim(filename)
     error stop
   end if
 !

--- a/src/vmecinm_m.f90
+++ b/src/vmecinm_m.f90
@@ -53,6 +53,7 @@ contains
         real(dp), dimension(nstrb, 0:kparb) :: rmns, zmns, almns, lmns
         integer :: lasym_int
         logical :: lasym
+        character(len=1000) :: filename
 
         associate (dummy => nsurfb)
         end associate
@@ -64,7 +65,9 @@ contains
             sps(i) = dble(i)
         end do
 
-        call nc_open(netcdffile, ncid)
+        filename = netcdffile
+        if (len_trim(filename) == 0) filename = 'wout.nc'
+        call nc_open(trim(filename), ncid)
 
         call nc_get(ncid, 'lasym__logical__', lasym_int)
         lasym = (lasym_int == 1)


### PR DESCRIPTION
### **User description**
## Summary
- Change `netcdffile` default from `'wout.nc'` to empty string `''`
- Apply `'wout.nc'` default at usage sites when `netcdffile` is empty
- Enables proper detection of whether parameter was explicitly set

## Test plan
- [x] All 41 libneo tests pass locally
- [x] SIMPLE tests pass with updated aliasing logic


___

### **PR Type**
Enhancement


___

### **Description**
- Change `netcdffile` default from `'wout.nc'` to empty string

- Apply `'wout.nc'` default at usage sites when empty

- Enables detection of explicit parameter assignment

- Allows downstream code to distinguish user-set vs default values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["netcdffile parameter"] -->|"empty string"| B["Apply 'wout.nc' default at usage"]
  A -->|"user-set value"| C["Use user-provided value"]
  B --> D["Downstream code can detect intent"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>canonical_coordinates_mod.f90</strong><dd><code>Change netcdffile default to empty string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/canonical_coordinates_mod.f90

<ul><li>Changed <code>netcdffile</code> module variable default from <code>'wout.nc'</code> to empty <br>string <code>''</code><br> <li> Added clarifying comment explaining empty string means unset</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/155/files#diff-88075aaefe1559418c2d27c3b03f2508f63ee8a06746564e059359739eb12b90">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>new_vmec_allocation_stuff.f90</strong><dd><code>Apply netcdffile default at allocation site</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/new_vmec_allocation_stuff.f90

<ul><li>Added local <code>filename</code> variable to handle default application<br> <li> Apply <code>'wout.nc'</code> default when <code>netcdffile</code> is empty<br> <li> Updated <code>nf90_open</code> call to use local <code>filename</code> variable<br> <li> Updated error message to reference local <code>filename</code></ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/155/files#diff-5194824bccc4616b80fa97589af08fad69813ce65504859b6956fa644ca553ec">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vmecinm_m.f90</strong><dd><code>Apply netcdffile default in vmecin subroutine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/vmecinm_m.f90

<ul><li>Added local <code>filename</code> variable in <code>vmecin</code> subroutine<br> <li> Apply <code>'wout.nc'</code> default when <code>netcdffile</code> is empty<br> <li> Updated <code>nc_open</code> call to use local <code>filename</code> variable</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/155/files#diff-8a547c66f446eb4a986391409ebdda7d8256b373e5439cbe02bb94499907534b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

