### PR TITLE
Expose vmec_coordinate_system_t type for external use

### DIFF
--- a/src/coordinates/libneo_coordinates.f90
+++ b/src/coordinates/libneo_coordinates.f90
@@ -57,6 +57,14 @@ module libneo_coordinates
         end subroutine
     end interface
 
+    type, extends(coordinate_system_t) :: vmec_coordinate_system_t
+    contains
+        procedure :: evaluate_point => vmec_evaluate_point
+        procedure :: covariant_basis => vmec_covariant_basis
+        procedure :: metric_tensor => vmec_metric_tensor
+        procedure :: from_cyl => vmec_from_cyl
+    end type vmec_coordinate_system_t
+
     type, extends(coordinate_system_t) :: chartmap_coordinate_system_t
         type(BatchSplineData3D) :: spl_xyz
         integer :: nrho = 0
@@ -71,6 +79,31 @@ module libneo_coordinates
     end type chartmap_coordinate_system_t
 
     interface
+        module subroutine vmec_evaluate_point(self, u, x)
+            class(vmec_coordinate_system_t), intent(in) :: self
+            real(dp), intent(in) :: u(3)
+            real(dp), intent(out) :: x(3)
+        end subroutine vmec_evaluate_point
+
+        module subroutine vmec_covariant_basis(self, u, e_cov)
+            class(vmec_coordinate_system_t), intent(in) :: self
+            real(dp), intent(in) :: u(3)
+            real(dp), intent(out) :: e_cov(3,3)
+        end subroutine vmec_covariant_basis
+
+        module subroutine vmec_metric_tensor(self, u, g, ginv, sqrtg)
+            class(vmec_coordinate_system_t), intent(in) :: self
+            real(dp), intent(in) :: u(3)
+            real(dp), intent(out) :: g(3,3), ginv(3,3), sqrtg
+        end subroutine vmec_metric_tensor
+
+        module subroutine vmec_from_cyl(self, xcyl, u, ierr)
+            class(vmec_coordinate_system_t), intent(in) :: self
+            real(dp), intent(in) :: xcyl(3)
+            real(dp), intent(out) :: u(3)
+            integer, intent(out) :: ierr
+        end subroutine vmec_from_cyl
+
         module subroutine chartmap_evaluate_point(self, u, x)
             class(chartmap_coordinate_system_t), intent(in) :: self
             real(dp), intent(in) :: u(3)

--- a/src/coordinates/libneo_coordinates_vmec.f90
+++ b/src/coordinates/libneo_coordinates_vmec.f90
@@ -2,14 +2,6 @@ submodule (libneo_coordinates) libneo_coordinates_vmec
     use spline_vmec_sub, only: splint_vmec_data
     implicit none
 
-    type, extends(coordinate_system_t) :: vmec_coordinate_system_t
-    contains
-        procedure :: evaluate_point => vmec_evaluate_point
-        procedure :: covariant_basis => vmec_covariant_basis
-        procedure :: metric_tensor => vmec_metric_tensor
-        procedure :: from_cyl => vmec_from_cyl
-    end type vmec_coordinate_system_t
-
 contains
 
     module subroutine make_vmec_coordinate_system(cs)


### PR DESCRIPTION
### **User description**
## Summary

Exposes `vmec_coordinate_system_t` type by moving it from the submodule to the parent module, following the same pattern as `chartmap_coordinate_system_t`.

## Motivation

This is needed for SIMPLE's chartmap reference coordinates feature. When building splined fields, we need to distinguish between VMEC coordinates (which return cylindrical R,φ,Z) and chartmap coordinates (which return Cartesian X,Y,Z) to properly convert to the Cartesian coordinates expected by coils fields.

## Changes

- Move `vmec_coordinate_system_t` type definition from `libneo_coordinates_vmec.f90` (submodule) to `libneo_coordinates.f90` (parent module)
- Add interface declarations for `vmec_*` methods in parent module  
- Remove duplicate type definition from submodule (keep implementations)

## Testing

- Built libneo successfully with changes
- Follows existing pattern used for `chartmap_coordinate_system_t`

## Related

- Required for SIMPLE PR implementing chartmap reference coordinates


___

### **PR Type**
Enhancement


___

### **Description**
- Expose `vmec_coordinate_system_t` type from parent module for external use

- Move type definition from submodule to parent module for public accessibility

- Add interface declarations for four VMEC coordinate system methods

- Follow existing pattern used by `chartmap_coordinate_system_t`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["libneo_coordinates.f90<br/>Parent Module"] -->|"Add type definition<br/>and interfaces"| B["vmec_coordinate_system_t<br/>Now Public"]
  C["libneo_coordinates_vmec.f90<br/>Submodule"] -->|"Remove duplicate<br/>type definition"| D["Keep implementations<br/>only"]
  B -->|"Enables downstream<br/>code access"| E["SIMPLE chartmap<br/>reference coordinates"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>libneo_coordinates.f90</strong><dd><code>Add vmec_coordinate_system_t type and interfaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coordinates/libneo_coordinates.f90

<ul><li>Add <code>vmec_coordinate_system_t</code> type definition extending <br><code>coordinate_system_t</code><br> <li> Define four type-bound procedures: <code>evaluate_point</code>, <code>covariant_basis</code>, <br><code>metric_tensor</code>, <code>from_cyl</code><br> <li> Add module subroutine interface declarations for all four VMEC methods<br> <li> Position type definition before <code>chartmap_coordinate_system_t</code> for <br>consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/159/files#diff-2b5f4e6d920583dfe266a0ca85ee102731873827ec62bc73d6d7c60809334809">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>libneo_coordinates_vmec.f90</strong><dd><code>Remove duplicate type definition from submodule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coordinates/libneo_coordinates_vmec.f90

<ul><li>Remove duplicate <code>vmec_coordinate_system_t</code> type definition from <br>submodule<br> <li> Keep all method implementations intact in submodule<br> <li> Reduce code duplication by centralizing type definition in parent <br>module</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/159/files#diff-01b9a82034036b8146c8354ae9d13c5a6c187d09a89d759e63fb428ee944b54a">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

