### PR TITLE
Chartmap: define NetCDF conventions and add validator

### DIFF
--- a/CMakeSources.in
+++ b/CMakeSources.in
@@ -26,6 +26,7 @@ add_library(neo STATIC
     src/coordinates/libneo_coordinates_vmec.f90
     src/coordinates/libneo_coordinates_geoflux.f90
     src/coordinates/libneo_coordinates_chartmap.f90
+    src/coordinates/libneo_coordinates_chartmap_validator.f90
     src/spline_vmec_data.f90
     src/vmecinm_m.f90
     src/vmec/vmec_field_tools.f90

--- a/src/coordinates/libneo_coordinates.f90
+++ b/src/coordinates/libneo_coordinates.f90
@@ -3,6 +3,26 @@ module libneo_coordinates
     use interpolate, only: BatchSplineData3D
     implicit none
 
+    character(len=*), parameter :: chartmap_netcdf_spec = &
+                                   "Chartmap NetCDF conventions:"//new_line('a')// &
+                                   "- Dimensions: rho, theta, zeta"//new_line('a')// &
+                                   "- Variables (required):"//new_line('a')// &
+                                   "  rho(rho), theta(theta)"//new_line('a')// &
+                                   "  zeta(zeta)"//new_line('a')// &
+                                   "  x(zeta,theta,rho)"//new_line('a')// &
+                                   "  y(zeta,theta,rho)"//new_line('a')// &
+                                   "  z(zeta,theta,rho)"//new_line('a')// &
+                                   "- Optional: nfp (integer >= 1)"//new_line('a')// &
+                                   "- Ranges:"//new_line('a')// &
+                                   "  rho in [0,1]"//new_line('a')// &
+                                   "  theta in [0,2pi)"//new_line('a')// &
+                                   "  zeta in [0,2pi/nfp)"//new_line('a')// &
+                                   "periodic dims exclude endpoint"//new_line('a')// &
+                                   "- Storage order:"//new_line('a')// &
+                                   "  file dims (zeta,theta,rho)"//new_line('a')// &
+                                   "Fortran reads x(rho,theta,zeta)"//new_line('a')// &
+                                   "- Units: x,y,z in cm"
+
     type, abstract :: coordinate_system_t
     contains
         procedure(evaluate_point_if), deferred :: evaluate_point
@@ -23,14 +43,14 @@ module libneo_coordinates
             import :: coordinate_system_t, dp
             class(coordinate_system_t), intent(in) :: self
             real(dp), intent(in) :: u(3)
-            real(dp), intent(out) :: e_cov(3,3)
+            real(dp), intent(out) :: e_cov(3, 3)
         end subroutine
 
         subroutine metric_tensor_if(self, u, g, ginv, sqrtg)
             import :: coordinate_system_t, dp
             class(coordinate_system_t), intent(in) :: self
             real(dp), intent(in) :: u(3)
-            real(dp), intent(out) :: g(3,3), ginv(3,3), sqrtg
+            real(dp), intent(out) :: g(3, 3), ginv(3, 3), sqrtg
         end subroutine
 
         subroutine from_cyl_if(self, xcyl, u, ierr)
@@ -55,6 +75,12 @@ module libneo_coordinates
             class(coordinate_system_t), allocatable, intent(out) :: cs
             character(len=*), intent(in) :: filename
         end subroutine
+
+        module subroutine validate_chartmap_file(filename, ierr, message)
+            character(len=*), intent(in) :: filename
+            integer, intent(out) :: ierr
+            character(len=*), intent(out) :: message
+        end subroutine validate_chartmap_file
     end interface
 
     type, extends(coordinate_system_t) :: vmec_coordinate_system_t
@@ -88,13 +114,13 @@ module libneo_coordinates
         module subroutine vmec_covariant_basis(self, u, e_cov)
             class(vmec_coordinate_system_t), intent(in) :: self
             real(dp), intent(in) :: u(3)
-            real(dp), intent(out) :: e_cov(3,3)
+            real(dp), intent(out) :: e_cov(3, 3)
         end subroutine vmec_covariant_basis
 
         module subroutine vmec_metric_tensor(self, u, g, ginv, sqrtg)
             class(vmec_coordinate_system_t), intent(in) :: self
             real(dp), intent(in) :: u(3)
-            real(dp), intent(out) :: g(3,3), ginv(3,3), sqrtg
+            real(dp), intent(out) :: g(3, 3), ginv(3, 3), sqrtg
         end subroutine vmec_metric_tensor
 
         module subroutine vmec_from_cyl(self, xcyl, u, ierr)
@@ -113,13 +139,13 @@ module libneo_coordinates
         module subroutine chartmap_covariant_basis(self, u, e_cov)
             class(chartmap_coordinate_system_t), intent(in) :: self
             real(dp), intent(in) :: u(3)
-            real(dp), intent(out) :: e_cov(3,3)
+            real(dp), intent(out) :: e_cov(3, 3)
         end subroutine chartmap_covariant_basis
 
         module subroutine chartmap_metric_tensor(self, u, g, ginv, sqrtg)
             class(chartmap_coordinate_system_t), intent(in) :: self
             real(dp), intent(in) :: u(3)
-            real(dp), intent(out) :: g(3,3), ginv(3,3), sqrtg
+            real(dp), intent(out) :: g(3, 3), ginv(3, 3), sqrtg
         end subroutine chartmap_metric_tensor
 
         module subroutine chartmap_from_cyl(self, xcyl, u, ierr)

--- a/src/coordinates/libneo_coordinates_chartmap_validator.f90
+++ b/src/coordinates/libneo_coordinates_chartmap_validator.f90
@@ -1,0 +1,431 @@
+submodule(libneo_coordinates) libneo_coordinates_chartmap_validator
+    use math_constants, only: TWOPI
+    use netcdf, only: NF90_BYTE, NF90_CHAR, NF90_DOUBLE, NF90_INT, NF90_INT64, &
+                      NF90_MAX_VAR_DIMS, NF90_NOERR, NF90_NOWRITE, NF90_SHORT, &
+                          nf90_close, &
+                      nf90_get_att, nf90_get_var, nf90_inq_dimid, nf90_inq_varid, &
+                      nf90_inquire_attribute, nf90_inquire_dimension, &
+                          nf90_inquire_variable, &
+                      nf90_open, nf90_strerror
+    implicit none
+
+contains
+
+    module subroutine validate_chartmap_file(filename, ierr, message)
+        character(len=*), intent(in) :: filename
+        integer, intent(out) :: ierr
+        character(len=*), intent(out) :: message
+
+        integer, parameter :: ok = 0
+        integer, parameter :: err_open = 1
+        integer, parameter :: err_missing_dim = 2
+        integer, parameter :: err_invalid_dim = 3
+        integer, parameter :: err_missing_var = 4
+        integer, parameter :: err_bad_var = 5
+        integer, parameter :: err_missing_units = 6
+        integer, parameter :: err_bad_units = 7
+        integer, parameter :: err_bad_grid = 8
+
+        integer :: status
+        integer :: ncid
+        integer :: dim_rho, dim_theta, dim_zeta
+        integer :: len_rho, len_theta, len_zeta
+        integer :: var_rho, var_theta, var_zeta, var_x, var_y, var_z
+        integer :: nfp
+        real(dp), allocatable :: rho(:), theta(:), zeta(:)
+        real(dp) :: period
+
+        ierr = ok
+        message = ""
+
+        status = nf90_open(trim(filename), NF90_NOWRITE, ncid)
+        if (status /= NF90_NOERR) then
+            ierr = err_open
+            message = "open failed: "//trim(nf90_strerror(status))
+            return
+        end if
+
+        do
+            call require_dim(ncid, "rho", dim_rho, len_rho, ierr, message)
+            if (ierr /= ok) exit
+            call require_dim(ncid, "theta", dim_theta, len_theta, ierr, message)
+            if (ierr /= ok) exit
+            call require_dim(ncid, "zeta", dim_zeta, len_zeta, ierr, message)
+            if (ierr /= ok) exit
+
+            if (len_rho < 2 .or. len_theta < 2 .or. len_zeta < 1) then
+                ierr = err_invalid_dim
+                message = "invalid dimension length(s)"
+                exit
+            end if
+
+            call require_1d_real64(ncid, "rho", dim_rho, var_rho, ierr, message)
+            if (ierr /= ok) exit
+            call require_1d_real64(ncid, "theta", dim_theta, var_theta, ierr, message)
+            if (ierr /= ok) exit
+            call require_1d_real64(ncid, "zeta", dim_zeta, var_zeta, ierr, message)
+            if (ierr /= ok) exit
+
+            call require_3d_real64(ncid, "x", dim_rho, dim_theta, dim_zeta, var_x, &
+                                   ierr, message)
+            if (ierr /= ok) exit
+            call require_3d_real64(ncid, "y", dim_rho, dim_theta, dim_zeta, var_y, &
+                                   ierr, message)
+            if (ierr /= ok) exit
+            call require_3d_real64(ncid, "z", dim_rho, dim_theta, dim_zeta, var_z, &
+                                   ierr, message)
+            if (ierr /= ok) exit
+
+            call require_units_cm(ncid, "x", var_x, ierr, message)
+            if (ierr /= ok) exit
+            call require_units_cm(ncid, "y", var_y, ierr, message)
+            if (ierr /= ok) exit
+            call require_units_cm(ncid, "z", var_z, ierr, message)
+            if (ierr /= ok) exit
+
+            call read_optional_nfp(ncid, nfp, ierr, message)
+            if (ierr /= ok) exit
+
+            allocate (rho(len_rho), theta(len_theta), zeta(len_zeta))
+            call read_grid(ncid, var_rho, "rho", rho, ierr, message)
+            if (ierr /= ok) exit
+            call read_grid(ncid, var_theta, "theta", theta, ierr, message)
+            if (ierr /= ok) exit
+            call read_grid(ncid, var_zeta, "zeta", zeta, ierr, message)
+            if (ierr /= ok) exit
+
+            call check_rho_grid(rho, ierr, message)
+            if (ierr /= ok) exit
+
+            call check_periodic_grid("theta", theta, TWOPI, ierr, message)
+            if (ierr /= ok) exit
+
+            period = TWOPI/real(nfp, dp)
+            call check_periodic_grid("zeta", zeta, period, ierr, message)
+            if (ierr /= ok) exit
+
+            exit
+        end do
+
+        status = nf90_close(ncid)
+    end subroutine validate_chartmap_file
+
+    subroutine require_dim(ncid, name, dimid, dimlen, ierr, message)
+        integer, intent(in) :: ncid
+        character(len=*), intent(in) :: name
+        integer, intent(out) :: dimid
+        integer, intent(out) :: dimlen
+        integer, intent(out) :: ierr
+        character(len=*), intent(out) :: message
+
+        integer :: status
+
+        ierr = 0
+        message = ""
+
+        status = nf90_inq_dimid(ncid, trim(name), dimid)
+        if (status /= NF90_NOERR) then
+            ierr = 2
+            message = "missing dimension "//trim(name)
+            return
+        end if
+
+        status = nf90_inquire_dimension(ncid, dimid, len=dimlen)
+        if (status /= NF90_NOERR) then
+            ierr = 3
+            message = "invalid dimension "//trim(name)
+            return
+        end if
+    end subroutine require_dim
+
+    subroutine require_1d_real64(ncid, name, dimid, varid, ierr, message)
+        integer, intent(in) :: ncid
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: dimid
+        integer, intent(out) :: varid
+        integer, intent(out) :: ierr
+        character(len=*), intent(out) :: message
+
+        integer :: status, xtype, ndims
+        integer :: dimids(NF90_MAX_VAR_DIMS)
+
+        ierr = 0
+        message = ""
+
+        status = nf90_inq_varid(ncid, trim(name), varid)
+        if (status /= NF90_NOERR) then
+            ierr = 4
+            message = "missing variable "//trim(name)
+            return
+        end if
+
+        status = nf90_inquire_variable(ncid, varid, xtype=xtype, ndims=ndims, &
+                                       dimids=dimids)
+        if (status /= NF90_NOERR) then
+            ierr = 5
+            message = "could not inquire variable "//trim(name)
+            return
+        end if
+
+        if (xtype /= NF90_DOUBLE .or. ndims /= 1 .or. dimids(1) /= dimid) then
+            ierr = 5
+            message = "variable "//trim(name)//" must be float64 with correct dimension"
+            return
+        end if
+    end subroutine require_1d_real64
+
+    subroutine require_3d_real64(ncid, name, dim_rho, dim_theta, dim_zeta, varid, &
+                                 ierr, message)
+        integer, intent(in) :: ncid
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: dim_rho, dim_theta, dim_zeta
+        integer, intent(out) :: varid
+        integer, intent(out) :: ierr
+        character(len=*), intent(out) :: message
+
+        integer :: status, xtype, ndims
+        integer :: dimids(NF90_MAX_VAR_DIMS)
+
+        ierr = 0
+        message = ""
+
+        status = nf90_inq_varid(ncid, trim(name), varid)
+        if (status /= NF90_NOERR) then
+            ierr = 4
+            message = "missing variable "//trim(name)
+            return
+        end if
+
+        status = nf90_inquire_variable(ncid, varid, xtype=xtype, ndims=ndims, &
+                                       dimids=dimids)
+        if (status /= NF90_NOERR) then
+            ierr = 5
+            message = "could not inquire variable "//trim(name)
+            return
+        end if
+
+        if (xtype /= NF90_DOUBLE .or. ndims /= 3) then
+            ierr = 5
+            message = "variable "//trim(name)//" must be float64 with 3 dimensions"
+            return
+        end if
+
+        if (dimids(1) /= dim_rho .or. dimids(2) /= dim_theta .or. dimids(3) /= &
+            dim_zeta) then
+            ierr = 5
+            message = "variable "//trim(name)// &
+                      " has wrong dimension order; expected (rho,theta,zeta)"
+            return
+        end if
+    end subroutine require_3d_real64
+
+    subroutine require_units_cm(ncid, name, varid, ierr, message)
+        integer, intent(in) :: ncid
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: varid
+        integer, intent(out) :: ierr
+        character(len=*), intent(out) :: message
+
+        integer :: status, att_len, att_type
+        character(len=:), allocatable :: units
+
+        ierr = 0
+        message = ""
+
+        status = nf90_inquire_attribute(ncid, varid, "units", xtype=att_type, &
+                                        len=att_len)
+        if (status /= NF90_NOERR) then
+            ierr = 6
+            message = "missing units attribute for "//trim(name)
+            return
+        end if
+
+        if (att_type /= NF90_CHAR .or. att_len < 1) then
+            ierr = 7
+            message = "invalid units attribute for "//trim(name)
+            return
+        end if
+
+        allocate (character(len=att_len) :: units)
+        status = nf90_get_att(ncid, varid, "units", units)
+        if (status /= NF90_NOERR) then
+            ierr = 7
+            message = "could not read units attribute for "//trim(name)
+            return
+        end if
+
+        if (trim(units) /= "cm") then
+            ierr = 7
+            message = "units for "//trim(name)//" must be cm"
+            return
+        end if
+    end subroutine require_units_cm
+
+    subroutine read_optional_nfp(ncid, nfp, ierr, message)
+        integer, intent(in) :: ncid
+        integer, intent(out) :: nfp
+        integer, intent(out) :: ierr
+        character(len=*), intent(out) :: message
+
+        integer :: status, varid, xtype, ndims
+
+        ierr = 0
+        message = ""
+        nfp = 1
+
+        status = nf90_inq_varid(ncid, "nfp", varid)
+        if (status /= NF90_NOERR) return
+
+        status = nf90_inquire_variable(ncid, varid, xtype=xtype, ndims=ndims)
+        if (status /= NF90_NOERR) then
+            ierr = 5
+            message = "could not inquire variable nfp"
+            return
+        end if
+
+        if (ndims /= 0 .or. .not. is_integer_xtype(xtype)) then
+            ierr = 5
+            message = "nfp must be a scalar integer variable"
+            return
+        end if
+
+        status = nf90_get_var(ncid, varid, nfp)
+        if (status /= NF90_NOERR) then
+            ierr = 5
+            message = "could not read nfp"
+            return
+        end if
+
+        if (nfp < 1) then
+            ierr = 5
+            message = "nfp must be >= 1"
+            return
+        end if
+    end subroutine read_optional_nfp
+
+    subroutine read_grid(ncid, varid, name, x, ierr, message)
+        integer, intent(in) :: ncid
+        integer, intent(in) :: varid
+        character(len=*), intent(in) :: name
+        real(dp), intent(out) :: x(:)
+        integer, intent(out) :: ierr
+        character(len=*), intent(out) :: message
+
+        integer :: status
+
+        ierr = 0
+        message = ""
+
+        status = nf90_get_var(ncid, varid, x)
+        if (status /= NF90_NOERR) then
+            ierr = 5
+            message = "could not read "//trim(name)
+        end if
+    end subroutine read_grid
+
+    subroutine check_rho_grid(rho, ierr, message)
+        real(dp), intent(in) :: rho(:)
+        integer, intent(out) :: ierr
+        character(len=*), intent(out) :: message
+
+        real(dp), parameter :: tol = 1.0e-12_dp
+
+        ierr = 0
+        message = ""
+
+        if (.not. is_strictly_increasing(rho)) then
+            ierr = 8
+            message = "rho grid must be strictly increasing"
+            return
+        end if
+
+        if (abs(rho(1) - 0.0_dp) > tol .or. abs(rho(size(rho)) - 1.0_dp) > tol) then
+            ierr = 8
+            message = "rho must span [0,1] including endpoints"
+            return
+        end if
+    end subroutine check_rho_grid
+
+    subroutine check_periodic_grid(name, x, period, ierr, message)
+        character(len=*), intent(in) :: name
+        real(dp), intent(in) :: x(:)
+        real(dp), intent(in) :: period
+        integer, intent(out) :: ierr
+        character(len=*), intent(out) :: message
+
+        real(dp), parameter :: tol = 1.0e-12_dp
+        real(dp) :: step_expected
+
+        ierr = 0
+        message = ""
+
+        if (size(x) == 1) then
+            if (abs(x(1) - 0.0_dp) > tol) then
+                ierr = 8
+                message = trim(name)//" must start at 0"
+            end if
+            return
+        end if
+
+        if (.not. is_strictly_increasing(x)) then
+            ierr = 8
+            message = trim(name)//" grid must be strictly increasing"
+            return
+        end if
+
+        step_expected = period/real(size(x), dp)
+        if (abs(x(1) - 0.0_dp) > tol) then
+            ierr = 8
+            message = trim(name)//" must start at 0"
+            return
+        end if
+
+        if (.not. is_uniform_step(x, step_expected, tol)) then
+            ierr = 8
+            message = trim(name)//" must be uniform with endpoint excluded"
+            return
+        end if
+
+        if (x(size(x)) > (period - step_expected + tol)) then
+            ierr = 8
+            message = trim(name)//" must exclude the period endpoint"
+            return
+        end if
+    end subroutine check_periodic_grid
+
+    logical function is_integer_xtype(xtype)
+        integer, intent(in) :: xtype
+        is_integer_xtype = (xtype == NF90_BYTE) .or. (xtype == NF90_SHORT) .or. &
+                           (xtype == NF90_INT) .or. (xtype == NF90_INT64)
+    end function is_integer_xtype
+
+    logical function is_strictly_increasing(x)
+        real(dp), intent(in) :: x(:)
+        integer :: i
+
+        is_strictly_increasing = .true.
+        do i = 2, size(x)
+            if (x(i) <= x(i - 1)) then
+                is_strictly_increasing = .false.
+                return
+            end if
+        end do
+    end function is_strictly_increasing
+
+    logical function is_uniform_step(x, step, tol)
+        real(dp), intent(in) :: x(:)
+        real(dp), intent(in) :: step
+        real(dp), intent(in) :: tol
+
+        real(dp) :: dx_max
+
+        if (size(x) < 2) then
+            is_uniform_step = .true.
+            return
+        end if
+
+        dx_max = maxval(abs((x(2:) - x(:size(x) - 1)) - step))
+        is_uniform_step = (dx_max <= 10.0_dp*tol)
+    end function is_uniform_step
+
+end submodule libneo_coordinates_chartmap_validator

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -147,6 +147,9 @@ target_link_libraries(test_coordinate_systems.x neo ${MAGFIE_LIB})
 add_executable(test_chartmap_coordinates.x source/test_chartmap_coordinates.f90)
 target_link_libraries(test_chartmap_coordinates.x neo ${MAGFIE_LIB})
 
+add_executable(test_chartmap_validator.x source/test_chartmap_validator.f90)
+target_link_libraries(test_chartmap_validator.x neo)
+
 # TODO: Update test for new psi_1..psi_7 interface
 # add_executable(test_analytical_gs_circular.x source/test_analytical_gs_circular.f90)
 # target_link_libraries(test_analytical_gs_circular.x ${MAGFIE_LIB} ${COMMON_LIBS})
@@ -252,6 +255,12 @@ add_test(NAME test_chartmap_coordinates
 set_tests_properties(test_chartmap_coordinates PROPERTIES
   FAIL_REGULAR_EXPRESSION "STOP"
   DEPENDS setup_chartmap_volume)
+
+add_test(NAME test_chartmap_validator
+  COMMAND test_chartmap_validator.x)
+set_tests_properties(test_chartmap_validator PROPERTIES
+  FAIL_REGULAR_EXPRESSION "STOP"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_subdirectory(util_for_test)
 add_subdirectory(util_for_test_field)

--- a/test/scripts/setup_chartmap_volume.py
+++ b/test/scripts/setup_chartmap_volume.py
@@ -78,6 +78,10 @@ def generate_chartmap_circular(outfile: Path) -> None:
         v_z = ds.createVariable("z", "f8", ("zeta", "theta", "rho"))
         v_nfp = ds.createVariable("nfp", "i4")
 
+        v_x.units = "cm"
+        v_y.units = "cm"
+        v_z.units = "cm"
+
         v_rho[:] = rho
         v_theta[:] = theta
         v_zeta[:] = zeta

--- a/test/source/test_chartmap_validator.f90
+++ b/test/source/test_chartmap_validator.f90
@@ -1,0 +1,303 @@
+program test_chartmap_validator
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use libneo_coordinates, only: validate_chartmap_file
+    use math_constants, only: TWOPI
+    use netcdf
+    implicit none
+
+    integer :: ierr
+    integer :: nerrors
+    character(len=2048) :: message
+
+    nerrors = 0
+
+    call write_good_file("chartmap_good.nc")
+    call validate_chartmap_file("chartmap_good.nc", ierr, message)
+    if (ierr /= 0) then
+        print *, "  FAIL: validator rejected a known-good chartmap file"
+        print *, trim(message)
+        nerrors = nerrors + 1
+    else
+        print *, "  PASS: validator accepted a known-good chartmap file"
+    end if
+
+    call write_missing_x_file("chartmap_missing_x.nc")
+    call validate_chartmap_file("chartmap_missing_x.nc", ierr, message)
+    if (ierr == 0 .or. index(message, "missing variable x") == 0) then
+        print *, "  FAIL: expected missing-x error, got code ", ierr
+        print *, trim(message)
+        nerrors = nerrors + 1
+    else
+        print *, "  PASS: missing-x file rejected with expected message"
+    end if
+
+    call write_missing_units_file("chartmap_missing_units.nc")
+    call validate_chartmap_file("chartmap_missing_units.nc", ierr, message)
+    if (ierr == 0 .or. index(message, "units") == 0) then
+        print *, "  FAIL: expected missing-units error, got code ", ierr
+        print *, trim(message)
+        nerrors = nerrors + 1
+    else
+        print *, "  PASS: missing-units file rejected with expected message"
+    end if
+
+    call write_wrong_dims_file("chartmap_wrong_dims.nc")
+    call validate_chartmap_file("chartmap_wrong_dims.nc", ierr, message)
+    if (ierr == 0 .or. index(message, "dimension order") == 0) then
+        print *, "  FAIL: expected wrong-dims error, got code ", ierr
+        print *, trim(message)
+        nerrors = nerrors + 1
+    else
+        print *, "  PASS: wrong-dims file rejected with expected message"
+    end if
+
+    call write_zeta_endpoint_file("chartmap_zeta_endpoint.nc")
+    call validate_chartmap_file("chartmap_zeta_endpoint.nc", ierr, message)
+    if (ierr == 0 .or. index(message, "zeta") == 0) then
+        print *, "  FAIL: expected zeta-endpoint error, got code ", ierr
+        print *, trim(message)
+        nerrors = nerrors + 1
+    else
+        print *, "  PASS: zeta-endpoint file rejected with expected message"
+    end if
+
+    if (nerrors > 0) then
+        print *, "FAILED: ", nerrors, " error(s) detected in chartmap validator tests"
+        error stop 1
+    end if
+
+contains
+
+    subroutine nc_check(status)
+        integer, intent(in) :: status
+        if (status /= NF90_NOERR) then
+            print *, trim(nf90_strerror(status))
+            error stop 2
+        end if
+    end subroutine nc_check
+
+    subroutine define_grids(nrho, ntheta, nzeta, rho, theta, zeta)
+        integer, intent(in) :: nrho, ntheta, nzeta
+        real(dp), intent(out) :: rho(nrho), theta(ntheta), zeta(nzeta)
+        integer :: i
+
+        do i = 1, nrho
+            rho(i) = real(i - 1, dp)/real(nrho - 1, dp)
+        end do
+        do i = 1, ntheta
+            theta(i) = TWOPI*real(i - 1, dp)/real(ntheta, dp)
+        end do
+        do i = 1, nzeta
+            zeta(i) = TWOPI*real(i - 1, dp)/real(nzeta, dp)
+        end do
+    end subroutine define_grids
+
+    subroutine write_missing_x_file(filename)
+        character(len=*), intent(in) :: filename
+        integer :: ncid
+        integer :: dim_rho, dim_theta, dim_zeta
+        integer :: var_rho, var_theta, var_zeta, var_y, var_z, var_nfp
+        integer, parameter :: nrho = 3, ntheta = 4, nzeta = 5
+        real(dp) :: rho(nrho), theta(ntheta), zeta(nzeta)
+        real(dp) :: y(nrho, ntheta, nzeta), z(nrho, ntheta, nzeta)
+
+        call define_grids(nrho, ntheta, nzeta, rho, theta, zeta)
+        y = 0.0_dp
+        z = 0.0_dp
+
+        call nc_check(nf90_create(trim(filename), NF90_NETCDF4, ncid))
+        call nc_check(nf90_def_dim(ncid, "rho", nrho, dim_rho))
+        call nc_check(nf90_def_dim(ncid, "theta", ntheta, dim_theta))
+        call nc_check(nf90_def_dim(ncid, "zeta", nzeta, dim_zeta))
+        call nc_check(nf90_def_var(ncid, "rho", NF90_DOUBLE, [dim_rho], var_rho))
+        call nc_check(nf90_def_var(ncid, "theta", NF90_DOUBLE, [dim_theta], var_theta))
+        call nc_check(nf90_def_var(ncid, "zeta", NF90_DOUBLE, [dim_zeta], var_zeta))
+        call nc_check(nf90_def_var(ncid, "y", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_y))
+        call nc_check(nf90_def_var(ncid, "z", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_z))
+        call nc_check(nf90_def_var(ncid, "nfp", NF90_INT, var_nfp))
+        call nc_check(nf90_put_att(ncid, var_y, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_z, "units", "cm"))
+        call nc_check(nf90_enddef(ncid))
+
+        call nc_check(nf90_put_var(ncid, var_rho, rho))
+        call nc_check(nf90_put_var(ncid, var_theta, theta))
+        call nc_check(nf90_put_var(ncid, var_zeta, zeta))
+        call nc_check(nf90_put_var(ncid, var_y, y))
+        call nc_check(nf90_put_var(ncid, var_z, z))
+        call nc_check(nf90_put_var(ncid, var_nfp, 1))
+        call nc_check(nf90_close(ncid))
+    end subroutine write_missing_x_file
+
+    subroutine write_good_file(filename)
+        character(len=*), intent(in) :: filename
+        integer :: ncid
+        integer :: dim_rho, dim_theta, dim_zeta
+        integer :: var_rho, var_theta, var_zeta, var_x, var_y, var_z, var_nfp
+        integer, parameter :: nrho = 3, ntheta = 4, nzeta = 5
+        real(dp) :: rho(nrho), theta(ntheta), zeta(nzeta)
+        real(dp) :: x(nrho, ntheta, nzeta), y(nrho, ntheta, nzeta), z(nrho, &
+                                                                      ntheta, nzeta)
+
+        call define_grids(nrho, ntheta, nzeta, rho, theta, zeta)
+        x = 0.0_dp
+        y = 0.0_dp
+        z = 0.0_dp
+
+        call nc_check(nf90_create(trim(filename), NF90_NETCDF4, ncid))
+        call nc_check(nf90_def_dim(ncid, "rho", nrho, dim_rho))
+        call nc_check(nf90_def_dim(ncid, "theta", ntheta, dim_theta))
+        call nc_check(nf90_def_dim(ncid, "zeta", nzeta, dim_zeta))
+        call nc_check(nf90_def_var(ncid, "rho", NF90_DOUBLE, [dim_rho], var_rho))
+        call nc_check(nf90_def_var(ncid, "theta", NF90_DOUBLE, [dim_theta], var_theta))
+        call nc_check(nf90_def_var(ncid, "zeta", NF90_DOUBLE, [dim_zeta], var_zeta))
+        call nc_check(nf90_def_var(ncid, "x", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_x))
+        call nc_check(nf90_def_var(ncid, "y", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_y))
+        call nc_check(nf90_def_var(ncid, "z", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_z))
+        call nc_check(nf90_def_var(ncid, "nfp", NF90_INT, var_nfp))
+        call nc_check(nf90_put_att(ncid, var_x, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_y, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_z, "units", "cm"))
+        call nc_check(nf90_enddef(ncid))
+
+        call nc_check(nf90_put_var(ncid, var_rho, rho))
+        call nc_check(nf90_put_var(ncid, var_theta, theta))
+        call nc_check(nf90_put_var(ncid, var_zeta, zeta))
+        call nc_check(nf90_put_var(ncid, var_x, x))
+        call nc_check(nf90_put_var(ncid, var_y, y))
+        call nc_check(nf90_put_var(ncid, var_z, z))
+        call nc_check(nf90_put_var(ncid, var_nfp, 1))
+        call nc_check(nf90_close(ncid))
+    end subroutine write_good_file
+
+    subroutine write_missing_units_file(filename)
+        character(len=*), intent(in) :: filename
+        integer :: ncid
+        integer :: dim_rho, dim_theta, dim_zeta
+        integer :: var_rho, var_theta, var_zeta, var_x, var_y, var_z
+        integer, parameter :: nrho = 3, ntheta = 4, nzeta = 5
+        real(dp) :: rho(nrho), theta(ntheta), zeta(nzeta)
+        real(dp) :: x(nrho, ntheta, nzeta), y(nrho, ntheta, nzeta), z(nrho, &
+                                                                      ntheta, nzeta)
+
+        call define_grids(nrho, ntheta, nzeta, rho, theta, zeta)
+        x = 0.0_dp
+        y = 0.0_dp
+        z = 0.0_dp
+
+        call nc_check(nf90_create(trim(filename), NF90_NETCDF4, ncid))
+        call nc_check(nf90_def_dim(ncid, "rho", nrho, dim_rho))
+        call nc_check(nf90_def_dim(ncid, "theta", ntheta, dim_theta))
+        call nc_check(nf90_def_dim(ncid, "zeta", nzeta, dim_zeta))
+        call nc_check(nf90_def_var(ncid, "rho", NF90_DOUBLE, [dim_rho], var_rho))
+        call nc_check(nf90_def_var(ncid, "theta", NF90_DOUBLE, [dim_theta], var_theta))
+        call nc_check(nf90_def_var(ncid, "zeta", NF90_DOUBLE, [dim_zeta], var_zeta))
+        call nc_check(nf90_def_var(ncid, "x", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_x))
+        call nc_check(nf90_def_var(ncid, "y", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_y))
+        call nc_check(nf90_def_var(ncid, "z", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_z))
+        call nc_check(nf90_enddef(ncid))
+
+        call nc_check(nf90_put_var(ncid, var_rho, rho))
+        call nc_check(nf90_put_var(ncid, var_theta, theta))
+        call nc_check(nf90_put_var(ncid, var_zeta, zeta))
+        call nc_check(nf90_put_var(ncid, var_x, x))
+        call nc_check(nf90_put_var(ncid, var_y, y))
+        call nc_check(nf90_put_var(ncid, var_z, z))
+        call nc_check(nf90_close(ncid))
+    end subroutine write_missing_units_file
+
+    subroutine write_wrong_dims_file(filename)
+        character(len=*), intent(in) :: filename
+        integer :: ncid
+        integer :: dim_rho, dim_theta, dim_zeta
+        integer :: var_rho, var_theta, var_zeta, var_x, var_y, var_z
+        integer, parameter :: nrho = 3, ntheta = 4, nzeta = 5
+        real(dp) :: rho(nrho), theta(ntheta), zeta(nzeta)
+        real(dp) :: x(nzeta, ntheta, nrho), y(nzeta, ntheta, nrho), z(nzeta, &
+                                                                      ntheta, nrho)
+
+        call define_grids(nrho, ntheta, nzeta, rho, theta, zeta)
+        x = 0.0_dp
+        y = 0.0_dp
+        z = 0.0_dp
+
+        call nc_check(nf90_create(trim(filename), NF90_NETCDF4, ncid))
+        call nc_check(nf90_def_dim(ncid, "rho", nrho, dim_rho))
+        call nc_check(nf90_def_dim(ncid, "theta", ntheta, dim_theta))
+        call nc_check(nf90_def_dim(ncid, "zeta", nzeta, dim_zeta))
+        call nc_check(nf90_def_var(ncid, "rho", NF90_DOUBLE, [dim_rho], var_rho))
+        call nc_check(nf90_def_var(ncid, "theta", NF90_DOUBLE, [dim_theta], var_theta))
+        call nc_check(nf90_def_var(ncid, "zeta", NF90_DOUBLE, [dim_zeta], var_zeta))
+        call nc_check(nf90_def_var(ncid, "x", NF90_DOUBLE, &
+                                   [dim_zeta, dim_theta, dim_rho], var_x))
+        call nc_check(nf90_def_var(ncid, "y", NF90_DOUBLE, &
+                                   [dim_zeta, dim_theta, dim_rho], var_y))
+        call nc_check(nf90_def_var(ncid, "z", NF90_DOUBLE, &
+                                   [dim_zeta, dim_theta, dim_rho], var_z))
+        call nc_check(nf90_put_att(ncid, var_x, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_y, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_z, "units", "cm"))
+        call nc_check(nf90_enddef(ncid))
+
+        call nc_check(nf90_put_var(ncid, var_rho, rho))
+        call nc_check(nf90_put_var(ncid, var_theta, theta))
+        call nc_check(nf90_put_var(ncid, var_zeta, zeta))
+        call nc_check(nf90_put_var(ncid, var_x, x))
+        call nc_check(nf90_put_var(ncid, var_y, y))
+        call nc_check(nf90_put_var(ncid, var_z, z))
+        call nc_check(nf90_close(ncid))
+    end subroutine write_wrong_dims_file
+
+    subroutine write_zeta_endpoint_file(filename)
+        character(len=*), intent(in) :: filename
+        integer :: ncid
+        integer :: dim_rho, dim_theta, dim_zeta
+        integer :: var_rho, var_theta, var_zeta, var_x, var_y, var_z, var_nfp
+        integer, parameter :: nrho = 3, ntheta = 4, nzeta = 3
+        real(dp) :: rho(nrho), theta(ntheta), zeta(nzeta)
+        real(dp) :: x(nrho, ntheta, nzeta), y(nrho, ntheta, nzeta), z(nrho, &
+                                                                      ntheta, nzeta)
+
+        call define_grids(nrho, ntheta, nzeta, rho, theta, zeta)
+        zeta(nzeta) = TWOPI
+        x = 0.0_dp
+        y = 0.0_dp
+        z = 0.0_dp
+
+        call nc_check(nf90_create(trim(filename), NF90_NETCDF4, ncid))
+        call nc_check(nf90_def_dim(ncid, "rho", nrho, dim_rho))
+        call nc_check(nf90_def_dim(ncid, "theta", ntheta, dim_theta))
+        call nc_check(nf90_def_dim(ncid, "zeta", nzeta, dim_zeta))
+        call nc_check(nf90_def_var(ncid, "rho", NF90_DOUBLE, [dim_rho], var_rho))
+        call nc_check(nf90_def_var(ncid, "theta", NF90_DOUBLE, [dim_theta], var_theta))
+        call nc_check(nf90_def_var(ncid, "zeta", NF90_DOUBLE, [dim_zeta], var_zeta))
+        call nc_check(nf90_def_var(ncid, "x", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_x))
+        call nc_check(nf90_def_var(ncid, "y", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_y))
+        call nc_check(nf90_def_var(ncid, "z", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_z))
+        call nc_check(nf90_def_var(ncid, "nfp", NF90_INT, var_nfp))
+        call nc_check(nf90_put_att(ncid, var_x, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_y, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_z, "units", "cm"))
+        call nc_check(nf90_enddef(ncid))
+
+        call nc_check(nf90_put_var(ncid, var_rho, rho))
+        call nc_check(nf90_put_var(ncid, var_theta, theta))
+        call nc_check(nf90_put_var(ncid, var_zeta, zeta))
+        call nc_check(nf90_put_var(ncid, var_x, x))
+        call nc_check(nf90_put_var(ncid, var_y, y))
+        call nc_check(nf90_put_var(ncid, var_z, z))
+        call nc_check(nf90_put_var(ncid, var_nfp, 1))
+        call nc_check(nf90_close(ncid))
+    end subroutine write_zeta_endpoint_file
+
+end program test_chartmap_validator


### PR DESCRIPTION
### **User description**
Implements the chartmap NetCDF conventions + machine-validated checks.

Changes
- Define the chartmap NetCDF conventions in `libneo_coordinates::chartmap_netcdf_spec`.
- Add `validate_chartmap_file(filename, ierr, message)` and validate chartmap files before reading them.
- Add a new Fortran test `test_chartmap_validator` that validates a known-good file and several malformed cases.
- Add units (cm) to the chartmap test volume generator.

Tests
- `make test` (ctest: 45/45 passed). See `/tmp/libneo_issue161_make_test_final.log`.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Define chartmap NetCDF conventions specification with required dimensions, variables, and ranges

- Implement `validate_chartmap_file()` subroutine with comprehensive validation checks
  - Validates required dimensions (rho, theta, zeta) and their sizes
  - Validates required 3D variables (x, y, z) with correct dimensions and float64 type
  - Validates units attribute (cm) on coordinate variables
  - Validates grid properties (rho in [0,1], theta and zeta periodic, uniform spacing)
  - Validates optional nfp scalar integer variable

- Add comprehensive Fortran test suite with 5 test cases covering good and malformed files

- Integrate validator into chartmap initialization with error reporting

- Code formatting improvements (spacing consistency in array declarations)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["chartmap_netcdf_spec<br/>constant"] --> B["validate_chartmap_file<br/>subroutine"]
  B --> C["Dimension checks<br/>rho, theta, zeta"]
  B --> D["Variable checks<br/>x, y, z types & dims"]
  B --> E["Units validation<br/>cm required"]
  B --> F["Grid validation<br/>ranges & spacing"]
  B --> G["Optional nfp<br/>scalar integer"]
  B --> H["initialize_chartmap<br/>calls validator"]
  I["test_chartmap_validator<br/>program"] --> J["5 test cases<br/>good + malformed"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>libneo_coordinates.f90</strong><dd><code>Define chartmap conventions and validator interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coordinates/libneo_coordinates.f90

<ul><li>Added <code>chartmap_netcdf_spec</code> parameter defining conventions (dimensions, <br>variables, ranges, storage order, units)<br> <li> Added interface declaration for <code>validate_chartmap_file()</code> subroutine<br> <li> Fixed spacing in array declarations (e.g., <code>e_cov(3, 3)</code> instead of <br><code>e_cov(3,3)</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/165/files#diff-2b5f4e6d920583dfe266a0ca85ee102731873827ec62bc73d6d7c60809334809">+32/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>libneo_coordinates_chartmap.f90</strong><dd><code>Integrate validator and improve code formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coordinates/libneo_coordinates_chartmap.f90

<ul><li>Integrated <code>validate_chartmap_file()</code> call in <code>initialize_chartmap()</code> with <br>error handling<br> <li> Fixed code formatting (spacing in allocate statements, line <br>continuations, operator spacing)<br> <li> Improved readability of matrix calculations in <br><code>chartmap_metric_tensor()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/165/files#diff-ee712e2206187619d99f188701cbe455ad4a9f4da743260ffc73f1c8efa4aed1">+37/-27</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>libneo_coordinates_chartmap_validator.f90</strong><dd><code>Implement comprehensive chartmap NetCDF validator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coordinates/libneo_coordinates_chartmap_validator.f90

<ul><li>Implemented <code>validate_chartmap_file()</code> with comprehensive NetCDF <br>validation logic<br> <li> Added helper subroutines: <code>require_dim()</code>, <code>require_1d_real64()</code>, <br><code>require_3d_real64()</code>, <code>require_units_cm()</code>, <code>read_optional_nfp()</code>, <br><code>read_grid()</code>, <code>check_rho_grid()</code>, <code>check_periodic_grid()</code><br> <li> Added utility functions: <code>is_integer_xtype()</code>, <code>is_strictly_increasing()</code>, <br><code>is_uniform_step()</code><br> <li> Validates dimensions, variable types/shapes, units attributes, and <br>grid properties with detailed error messages</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/165/files#diff-565bba29a370078e0ec25b91457b630bcc6342dd4195955485b62758dd2f37b0">+431/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>setup_chartmap_volume.py</strong><dd><code>Add units attribute to coordinate variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/scripts/setup_chartmap_volume.py

<ul><li>Added units attribute ("cm") to x, y, z variables in generated NetCDF <br>files</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/165/files#diff-f4555f851c80a287e81571cbb18d13c79282c4f315127ce2caeb7c01a32437ca">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_chartmap_validator.f90</strong><dd><code>Add comprehensive chartmap validator test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/source/test_chartmap_validator.f90

<ul><li>Created test program with 5 test cases: good file, missing variable, <br>missing units, wrong dimension order, zeta endpoint violation<br> <li> Implemented helper subroutines to generate test NetCDF files with <br>various configurations<br> <li> Tests validate both acceptance of valid files and rejection of <br>malformed files with correct error messages</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/165/files#diff-361cd2d476ff83b3f005b8357ab55203a8b1d2e538440035c3a6ff69d034b483">+303/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeSources.in</strong><dd><code>Add validator source to build configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakeSources.in

- Added `libneo_coordinates_chartmap_validator.f90` to build sources


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/165/files#diff-57f249c75b1b84ad15fd6cf875a7960543824832ae3e9ac70336eb7038f6ff1a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Add validator test to CMake configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/CMakeLists.txt

<ul><li>Added <code>test_chartmap_validator.x</code> executable target<br> <li> Registered test with CMake/CTest with appropriate failure detection</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/165/files#diff-33394812ba204689144fd2f80832db83853ba1cb32403edb4e15fe4893e675fd">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

