### PR TITLE
feat: add write_chartmap_from_stl for STL-based chartmap generation

### DIFF
--- a/python/libneo/stl_boundary.py
+++ b/python/libneo/stl_boundary.py
@@ -368,6 +368,87 @@ def extract_boundary_slices(
     return slices
 
 
+def write_chartmap_from_stl(
+    slices: list[BoundarySlice],
+    out_path: Path,
+    *,
+    nrho: int = 33,
+    ntheta: int = 65,
+    num_field_periods: int = 1,
+    M: int = 16,
+) -> None:
+    """Write a chartmap NetCDF file from STL boundary slices.
+
+    Uses map2disc conformal mapping at each toroidal slice.
+    Metadata conventions:
+      - zeta_convention: cyl (cylindrical toroidal angle)
+      - rho_convention: unknown (geometric radial, not flux-based)
+    """
+    from map2disc import map as m2d
+    from netCDF4 import Dataset
+
+    n_zeta = len(slices)
+    if n_zeta == 0:
+        raise ValueError("no slices to write")
+
+    rho = np.linspace(0.0, 1.0, nrho)
+    theta = np.linspace(0.0, 2.0 * np.pi, ntheta, endpoint=False)
+    zeta = np.array([s.phi for s in slices])
+
+    x = np.zeros((nrho, ntheta, n_zeta), dtype=np.float64)
+    y = np.zeros((nrho, ntheta, n_zeta), dtype=np.float64)
+    z = np.zeros((nrho, ntheta, n_zeta), dtype=np.float64)
+
+    for iz, s in enumerate(slices):
+        curve = _curve_from_contour(s.outer_filled)
+        bcm = m2d.BoundaryConformingMapping(curve=curve, M=M, Nt=256, Ng=(256, 256))
+        bcm.solve_domain2disk()
+        bcm.solve_disk2domain()
+
+        xy = bcm.eval_rt_1d(rho, theta)
+        R_grid = xy[0]
+        Z_grid = xy[1]
+
+        phi = s.phi
+        ax_x, ax_y = s.axis_xy
+        for ir in range(nrho):
+            for it in range(ntheta):
+                R_val = R_grid[ir, it]
+                Z_val = Z_grid[ir, it]
+                x[ir, it, iz] = (ax_x + R_val * np.cos(phi)) * 100.0
+                y[ir, it, iz] = (ax_y + R_val * np.sin(phi)) * 100.0
+                z[ir, it, iz] = Z_val * 100.0
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with Dataset(out_path, "w", format="NETCDF4") as ds:
+        ds.setncattr("zeta_convention", "cyl")
+        ds.setncattr("rho_convention", "unknown")
+
+        ds.createDimension("rho", nrho)
+        ds.createDimension("theta", ntheta)
+        ds.createDimension("zeta", n_zeta)
+
+        v_rho = ds.createVariable("rho", "f8", ("rho",))
+        v_theta = ds.createVariable("theta", "f8", ("theta",))
+        v_zeta = ds.createVariable("zeta", "f8", ("zeta",))
+        v_x = ds.createVariable("x", "f8", ("rho", "theta", "zeta"))
+        v_y = ds.createVariable("y", "f8", ("rho", "theta", "zeta"))
+        v_z = ds.createVariable("z", "f8", ("rho", "theta", "zeta"))
+        v_nfp = ds.createVariable("num_field_periods", "i4")
+
+        v_x.units = "cm"
+        v_y.units = "cm"
+        v_z.units = "cm"
+
+        v_rho[:] = rho
+        v_theta[:] = theta
+        v_zeta[:] = zeta
+        v_x[:, :, :] = x
+        v_y[:, :, :] = y
+        v_z[:, :, :] = z
+        v_nfp.assignValue(num_field_periods)
+
+
 def write_boundaries_netcdf(slices: list[BoundarySlice], out_path: Path) -> None:
     from netCDF4 import Dataset
 


### PR DESCRIPTION
### **User description**
## Summary

Add function to generate chartmap NetCDF files from STL wall meshes with holes (e.g., from `vmec_wall` + port cutting).

### Key features
- Uses map2disc conformal mapping at each toroidal slice
- Sets correct metadata conventions:
  - `zeta_convention: cyl` (cylindrical toroidal angle)
  - `rho_convention: unknown` (geometric radial, not flux-based)
- Outputs standard chartmap format with x,y,z grids in cm

### Use case
This enables chartmap coordinate generation from arbitrary wall geometry with holes, independent of VMEC equilibrium data. The workflow:

1. `vmec_wall.py`: VMEC wout -> wall mesh
2. `cut_cylindrical_ports()`: cut holes for ports
3. `extract_boundary_slices()`: extract R-Z boundaries at each phi, fill holes
4. `write_chartmap_from_stl()`: generate chartmap NetCDF with proper metadata

## Test plan
- [x] Added `test_write_chartmap_from_stl_torus` test
- [x] All existing tests pass (51/51)
- [x] Verified correct metadata conventions in output file


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `write_chartmap_from_stl()` function for chartmap NetCDF generation from STL meshes

- Uses map2disc conformal mapping at each toroidal slice for coordinate transformation

- Sets proper metadata conventions: `zeta_convention: cyl` and `rho_convention: unknown`

- Outputs standard chartmap format with x,y,z grids in cm

- Add comprehensive test validating chartmap generation from torus mesh


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["STL Boundary Slices"] -->|map2disc conformal mapping| B["R-Z Grid Coordinates"]
  B -->|cylindrical transformation| C["X-Y-Z Cartesian Grid"]
  C -->|NetCDF output| D["Chartmap File"]
  D -->|metadata| E["zeta_convention: cyl<br/>rho_convention: unknown"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stl_boundary.py</strong><dd><code>Add chartmap generation from STL boundary slices</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/libneo/stl_boundary.py

<ul><li>Add <code>write_chartmap_from_stl()</code> function that generates chartmap NetCDF <br>files from boundary slices<br> <li> Implements conformal mapping using map2disc at each toroidal slice<br> <li> Transforms R-Z coordinates to X-Y-Z Cartesian coordinates in cm<br> <li> Sets required metadata attributes for zeta and rho conventions<br> <li> Creates NetCDF file with proper dimensions (rho, theta, zeta) and <br>variables</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/181/files#diff-56156ce2a1a0b0249656f6757892a00025e8f07eb5dd18c2294ab2e5a71fc9d2">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_stl_boundary.py</strong><dd><code>Add test for chartmap generation from torus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/tests/test_stl_boundary.py

<ul><li>Add <code>test_write_chartmap_from_stl_torus()</code> test function validating <br>chartmap generation<br> <li> Creates synthetic torus mesh and extracts boundary slices<br> <li> Verifies correct metadata conventions in output NetCDF file<br> <li> Validates dimensions, variables, and units in generated chartmap<br> <li> Checks coordinate ranges for physical validity</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/181/files#diff-c807fb052b8116de01bde644a3ccf96282ec7a48f36caa3bf94d8311ee2e9c89">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

