### PR TITLE
Chartmap: enforce map2disc conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Python interface package and scripts/functions.
 ### Chartmap generators
 Generate `*.chartmap.nc` volumes compatible with `libneo_coordinates`.
 
+For map2disc-generated chartmaps, `zeta` is the cylindrical toroidal angle
+(`zeta_convention=cyl`) and `rho` is a geometric disk radius (`rho_convention=unknown`).
+
 Install dependencies:
 
     pip install -e ".[chartmap]"

--- a/python/libneo/chartmap.py
+++ b/python/libneo/chartmap.py
@@ -61,6 +61,7 @@ def write_chartmap_from_vmec_boundary(
     - Variables: rho, theta, zeta, x, y, z, num_field_periods
     - x/y/z stored with file dims (zeta, theta, rho)
     - Units: cm
+    - Conventions: zeta_convention=cyl, rho_convention=unknown (geometric disk radius)
     """
     from map2disc import map as m2d
     from netCDF4 import Dataset

--- a/test/scripts/setup_vmec_chartmap_python.py
+++ b/test/scripts/setup_vmec_chartmap_python.py
@@ -28,17 +28,20 @@ def main(argv: list[str] | None = None) -> int:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     wout = out_dir / "wout.nc"
-    outfile = out_dir / "wout_vmec_python.chartmap.nc"
+    outfile_api = out_dir / "wout_vmec_python.chartmap.nc"
+    outfile_cli = out_dir / "wout_vmec_cli.chartmap.nc"
 
     if not wout.exists() or wout.stat().st_size == 0:
         raise RuntimeError(f"missing wout fixture: {wout}")
 
     _import_libneo_from_repo()
     from libneo.chartmap import write_chartmap_from_vmec_boundary
+    from libneo.chartmap_cli import main as chartmap_cli_main
+    from netCDF4 import Dataset
 
     write_chartmap_from_vmec_boundary(
         wout,
-        outfile,
+        outfile_api,
         nrho=17,
         ntheta=33,
         nzeta=17,
@@ -47,11 +50,37 @@ def main(argv: list[str] | None = None) -> int:
         Ng=(128, 128),
     )
 
-    if not outfile.exists() or outfile.stat().st_size == 0:
-        raise RuntimeError(f"failed to create {outfile}")
+    chartmap_cli_main(
+        [
+            "from-vmec",
+            str(wout),
+            str(outfile_cli),
+            "--nrho",
+            "17",
+            "--ntheta",
+            "33",
+            "--nzeta",
+            "17",
+            "--M",
+            "12",
+            "--Nt",
+            "128",
+            "--Ng",
+            "128",
+            "128",
+        ]
+    )
+
+    for path in (outfile_api, outfile_cli):
+        if not path.exists() or path.stat().st_size == 0:
+            raise RuntimeError(f"failed to create {path}")
+        with Dataset(path, "r") as ds:
+            if ds.getncattr("zeta_convention") != "cyl":
+                raise RuntimeError("expected zeta_convention=cyl")
+            if ds.getncattr("rho_convention") != "unknown":
+                raise RuntimeError("expected rho_convention=unknown")
     return 0
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
-


### PR DESCRIPTION
### **User description**
Fixes #185.

## What changed
- Documentation: clarify that map2disc chartmaps use `zeta_convention=cyl` and `rho_convention=unknown` (rho is a geometric disk radius).
- Tests: `setup_vmec_chartmap_python` now generates chartmaps via both the Python API and the CLI codepath and asserts both global attributes.

## Tests
Local `make test`: 54/54 passed (log: `/tmp/libneo-issue185-make-test.log`).


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Document map2disc chartmap conventions in code and README

- Extend test to validate both Python API and CLI code paths

- Assert zeta_convention=cyl and rho_convention=unknown attributes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["map2disc chartmap generation"] --> B["Python API path"]
  A --> C["CLI path"]
  B --> D["Validate conventions"]
  C --> D
  D --> E["zeta_convention=cyl<br/>rho_convention=unknown"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chartmap.py</strong><dd><code>Document map2disc chartmap conventions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/libneo/chartmap.py

<ul><li>Added documentation clarifying map2disc chartmap conventions<br> <li> Specified zeta_convention=cyl and rho_convention=unknown in docstring</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/186/files#diff-c3d4918ce80f043ea1bbbc8328d3775412e5b287cbed6d765f46f0a36211049d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document map2disc chartmap coordinate conventions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added section documenting map2disc chartmap coordinate conventions<br> <li> Clarified that zeta is cylindrical toroidal angle and rho is geometric <br>disk radius</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/186/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup_vmec_chartmap_python.py</strong><dd><code>Validate chartmap conventions for both code paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/scripts/setup_vmec_chartmap_python.py

<ul><li>Extended test to generate chartmaps via both Python API and CLI<br> <li> Added validation of zeta_convention and rho_convention attributes<br> <li> Renamed output files to distinguish API vs CLI generated chartmaps<br> <li> Imported Dataset and chartmap_cli_main for comprehensive testing</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/186/files#diff-f408c12de9575716c0c065cfe19b9a4b9319215c24f38be97243ae3dbbb7078a">+34/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

