### PR TITLE
Test: validate map2disc chartmap boundary vs VMEC

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -266,6 +266,28 @@ set_tests_properties(setup_vmec_chartmap_python PROPERTIES
   DEPENDS setup_vmec_wout
 )
 
+add_test(
+  NAME validate_vmec_map2disc_chartmap_boundary_python
+  COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/test/scripts/validate_vmec_map2disc_chartmap_boundary.py
+          --wout ${CMAKE_CURRENT_BINARY_DIR}/wout.nc
+          --chartmap ${CMAKE_CURRENT_BINARY_DIR}/wout_vmec_python.chartmap.nc
+)
+set_tests_properties(validate_vmec_map2disc_chartmap_boundary_python PROPERTIES
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS setup_vmec_chartmap_python
+)
+
+add_test(
+  NAME validate_vmec_map2disc_chartmap_boundary_cli
+  COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/test/scripts/validate_vmec_map2disc_chartmap_boundary.py
+          --wout ${CMAKE_CURRENT_BINARY_DIR}/wout.nc
+          --chartmap ${CMAKE_CURRENT_BINARY_DIR}/wout_vmec_cli.chartmap.nc
+)
+set_tests_properties(validate_vmec_map2disc_chartmap_boundary_cli PROPERTIES
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS setup_vmec_chartmap_python
+)
+
 add_test(NAME test_chartmap_coordinates
   COMMAND test_chartmap_coordinates.x)
 set_tests_properties(test_chartmap_coordinates PROPERTIES

--- a/test/scripts/validate_vmec_map2disc_chartmap_boundary.py
+++ b/test/scripts/validate_vmec_map2disc_chartmap_boundary.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Validate that a map2disc-generated VMEC-boundary chartmap reproduces the VMEC boundary.
+
+For selected zeta slices and all theta grid points at rho=1:
+  - Compute R_chart = sqrt(x^2 + y^2)/100, Z_chart = z/100 (convert cm->m)
+  - Compare against VMEC boundary evaluation at s=1 (last surface index)
+
+Fails if max abs error in R or Z exceeds tolerances.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+import numpy as np
+from netCDF4 import Dataset
+
+
+def _import_libneo_from_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(repo_root / "python"))
+
+
+def _load_chartmap_boundary(chartmap_path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    with Dataset(chartmap_path, "r") as ds:
+        rho = np.array(ds.variables["rho"][:], dtype=float)
+        theta = np.array(ds.variables["theta"][:], dtype=float)
+        zeta = np.array(ds.variables["zeta"][:], dtype=float)
+        x = np.array(ds.variables["x"][:], dtype=float)
+        y = np.array(ds.variables["y"][:], dtype=float)
+        z = np.array(ds.variables["z"][:], dtype=float)
+
+        if ds.getncattr("zeta_convention") != "cyl":
+            raise RuntimeError("expected zeta_convention=cyl")
+        if ds.getncattr("rho_convention") != "unknown":
+            raise RuntimeError("expected rho_convention=unknown")
+
+    if rho.ndim != 1 or theta.ndim != 1 or zeta.ndim != 1:
+        raise RuntimeError("expected rho/theta/zeta to be 1D")
+    if rho.size < 2 or theta.size < 2 or zeta.size < 2:
+        raise RuntimeError("expected rho/theta/zeta lengths >= 2")
+
+    # File order is (zeta, theta, rho)
+    if x.shape != (zeta.size, theta.size, rho.size):
+        raise RuntimeError(f"unexpected x shape {x.shape}")
+
+    ir = int(rho.size - 1)
+    R_chart = np.sqrt(x[:, :, ir] ** 2 + y[:, :, ir] ** 2) / 100.0
+    Z_chart = z[:, :, ir] / 100.0
+    return theta, zeta, np.stack([R_chart, Z_chart], axis=-1)
+
+
+def _select_zeta_indices(nzeta: int) -> list[int]:
+    if nzeta < 2:
+        return [0]
+    candidates = [0, 1, nzeta // 2, nzeta - 2, nzeta - 1]
+    out: list[int] = []
+    for i in candidates:
+        ii = int(max(0, min(nzeta - 1, i)))
+        if ii not in out:
+            out.append(ii)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="validate_vmec_map2disc_chartmap_boundary")
+    p.add_argument("--wout", type=Path, required=True)
+    p.add_argument("--chartmap", type=Path, required=True)
+    p.add_argument("--tol-R", type=float, default=1.0e-10)
+    p.add_argument("--tol-Z", type=float, default=1.0e-10)
+    args = p.parse_args(argv)
+
+    _import_libneo_from_repo()
+    from libneo.vmec import VMECGeometry
+
+    wout = args.wout.resolve()
+    chartmap = args.chartmap.resolve()
+    if not wout.exists() or wout.stat().st_size == 0:
+        raise RuntimeError(f"missing wout file: {wout}")
+    if not chartmap.exists() or chartmap.stat().st_size == 0:
+        raise RuntimeError(f"missing chartmap file: {chartmap}")
+
+    theta, zeta, rz_chart = _load_chartmap_boundary(chartmap)
+
+    geom = VMECGeometry.from_file(str(wout))
+    s_index = int(geom.rmnc.shape[1] - 1)
+
+    iz_list = _select_zeta_indices(int(zeta.size))
+    max_dR = 0.0
+    max_dZ = 0.0
+    for iz in iz_list:
+        R_vmec, Z_vmec, _ = geom.coords(s_index, theta, float(zeta[iz]), use_asym=True)
+        R_chart = rz_chart[iz, :, 0]
+        Z_chart = rz_chart[iz, :, 1]
+
+        dR = np.max(np.abs(R_chart - R_vmec))
+        dZ = np.max(np.abs(Z_chart - Z_vmec))
+        max_dR = max(max_dR, float(dR))
+        max_dZ = max(max_dZ, float(dZ))
+
+    print(f"PASS: {chartmap.name} rho=1 vs VMEC s=1 max|dR|={max_dR:.3e} m max|dZ|={max_dZ:.3e} m")
+
+    if max_dR > float(args.tol_R) or max_dZ > float(args.tol_Z):
+        raise SystemExit(
+            f"FAIL: boundary mismatch exceeds tolerance: max|dR|={max_dR:.3e} "
+            f"(tol {args.tol_R:.3e}), max|dZ|={max_dZ:.3e} (tol {args.tol_Z:.3e})"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### **User description**
Fixes #187.

## What changed
- Add a Python validator (`test/scripts/validate_vmec_map2disc_chartmap_boundary.py`) that checks the map2disc VMEC-boundary chartmap reproduces the VMEC last closed surface on `rho=1`.
- Run it in CTest for both Python-API and CLI generated chartmaps:
  - `validate_vmec_map2disc_chartmap_boundary_python`
  - `validate_vmec_map2disc_chartmap_boundary_cli`

## Validation
Local `make test`: 56/56 passed (log: `/tmp/libneo-issue187-make-test.log`).


___

### **PR Type**
Tests


___

### **Description**
- Add Python validator script to verify map2disc VMEC-boundary chartmap accuracy

- Compare chartmap boundary at rho=1 against VMEC surface at s=1

- Validate R and Z coordinates across selected zeta slices

- Integrate two CTest cases for Python-API and CLI chartmap generation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VMEC wout file"] --> B["VMECGeometry"]
  C["map2disc chartmap"] --> D["Load boundary data"]
  B --> E["Evaluate at s=1"]
  D --> F["Extract rho=1 surface"]
  E --> G["Compare R,Z coordinates"]
  F --> G
  G --> H["Validate against tolerances"]
  H --> I["Pass/Fail result"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate_vmec_map2disc_chartmap_boundary.py</strong><dd><code>VMEC boundary chartmap validation script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/scripts/validate_vmec_map2disc_chartmap_boundary.py

<ul><li>New Python validator script that loads map2disc chartmap and VMEC <br>geometry<br> <li> Extracts boundary coordinates at rho=1 from chartmap and s=1 from VMEC<br> <li> Compares R and Z coordinates across selected zeta slices and all theta <br>points<br> <li> Validates maximum absolute errors against configurable tolerances <br>(default 1e-10 m)</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/188/files#diff-c6c81391b5937ecdeeedf7c9688bb8962ef16d955924ff089d5cdb539dcb8e13">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Register CTest cases for chartmap boundary validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/CMakeLists.txt

<ul><li>Add two new CTest cases for boundary validation<br> <li> <code>validate_vmec_map2disc_chartmap_boundary_python</code> tests Python-API <br>generated chartmap<br> <li> <code>validate_vmec_map2disc_chartmap_boundary_cli</code> tests CLI generated <br>chartmap<br> <li> Both tests depend on <code>setup_vmec_chartmap_python</code> and use wout.nc and <br>respective chartmap files</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/188/files#diff-33394812ba204689144fd2f80832db83853ba1cb32403edb4e15fe4893e675fd">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

