### PR TITLE
VMEC: align python Fourier phase with Fortran; implement from_cyl

### DIFF
--- a/python/libneo/vmec.py
+++ b/python/libneo/vmec.py
@@ -34,17 +34,17 @@ def _to_mode_ns_from_var(var) -> np.ndarray:
 
 
 def _cfunct(theta: np.ndarray, zeta: float, coeff: np.ndarray, xm: np.ndarray, xn: np.ndarray) -> np.ndarray:
-    """Cosine series evaluation: sum_k coeff_k(s) * cos(xm_k*theta + xn_k*zeta)."""
+    """Cosine series evaluation: sum_k coeff_k(s) * cos(xm_k*theta - xn_k*zeta)."""
     theta = np.asarray(theta, dtype=float)
-    angle = np.outer(xm, theta) + np.outer(xn, np.atleast_1d(float(zeta)))
+    angle = np.outer(xm, theta) - np.outer(xn, np.atleast_1d(float(zeta)))
     cos_terms = np.cos(angle)
     return coeff.T @ cos_terms
 
 
 def _sfunct(theta: np.ndarray, zeta: float, coeff: np.ndarray, xm: np.ndarray, xn: np.ndarray) -> np.ndarray:
-    """Sine series evaluation: sum_k coeff_k(s) * sin(xm_k*theta + xn_k*zeta)."""
+    """Sine series evaluation: sum_k coeff_k(s) * sin(xm_k*theta - xn_k*zeta)."""
     theta = np.asarray(theta, dtype=float)
-    angle = np.outer(xm, theta) + np.outer(xn, np.atleast_1d(float(zeta)))
+    angle = np.outer(xm, theta) - np.outer(xn, np.atleast_1d(float(zeta)))
     sin_terms = np.sin(angle)
     return coeff.T @ sin_terms
 

--- a/python/libneo/vmec_to_efit.py
+++ b/python/libneo/vmec_to_efit.py
@@ -154,13 +154,12 @@ def cfunct(theta, zeta, coeff, xm, xn):
     nmode, ns = coeff.shape
     result = np.zeros((ns, len(theta)))
     for m in range(nmode):
-        result += coeff[m, :].reshape(ns, 1) * np.cos(xm[m] * theta + xn[m] * zeta)
+        result += coeff[m, :].reshape(ns, 1) * np.cos(xm[m] * theta - xn[m] * zeta)
     return result
 
 def sfunct(theta, zeta, coeff, xm, xn):
     nmode, ns = coeff.shape
     result = np.zeros((ns, len(theta)))
     for m in range(nmode):
-        result += coeff[m, :].reshape(ns, 1) * np.sin(xm[m] * theta + xn[m] * zeta)
+        result += coeff[m, :].reshape(ns, 1) * np.sin(xm[m] * theta - xn[m] * zeta)
     return result
-

--- a/python/libneo/vmec_utils.py
+++ b/python/libneo/vmec_utils.py
@@ -433,12 +433,12 @@ def cfunct(theta, zeta, coeff, xm, xn):
     nmode, ns = coeff.shape
     result = np.zeros((ns, len(theta)))
     for m in range(nmode):
-        result += coeff[m, :].reshape(ns, 1) * np.cos(xm[m] * theta + xn[m] * zeta)
+        result += coeff[m, :].reshape(ns, 1) * np.cos(xm[m] * theta - xn[m] * zeta)
     return result
 
 def sfunct(theta, zeta, coeff, xm, xn):
     nmode, ns = coeff.shape
     result = np.zeros((ns, len(theta)))
     for m in range(nmode):
-        result += coeff[m, :].reshape(ns, 1) * np.sin(xm[m] * theta + xn[m] * zeta)
+        result += coeff[m, :].reshape(ns, 1) * np.sin(xm[m] * theta - xn[m] * zeta)
     return result

--- a/src/coordinates/libneo_coordinates_vmec.f90
+++ b/src/coordinates/libneo_coordinates_vmec.f90
@@ -1,6 +1,7 @@
 submodule (libneo_coordinates) libneo_coordinates_vmec
     use spline_vmec_sub, only: splint_vmec_data
     use cylindrical_cartesian, only: cyl_to_cart
+    use math_constants, only: TWOPI
     implicit none
 
 contains
@@ -119,7 +120,105 @@ contains
         real(dp), intent(out) :: u(3)
         integer, intent(out) :: ierr
 
-        error stop "vmec_from_cyl: not implemented"
+        integer, parameter :: max_iter = 50
+        real(dp), parameter :: tol_res = 1.0e-10_dp
+        real(dp), parameter :: tol_step = 1.0e-12_dp
+
+        real(dp) :: s, theta, varphi
+        real(dp) :: A_phi, A_theta, dA_phi_ds, dA_theta_ds, aiota
+        real(dp) :: R, Z, alam
+        real(dp) :: dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp
+        real(dp) :: dl_ds, dl_dt, dl_dp
+        real(dp) :: R_axis, Z_axis, R_bnd, Z_bnd
+        real(dp) :: rs, zs, dist_axis, dist_bnd
+        real(dp) :: f(2), J(2, 2), det, delta(2)
+        real(dp) :: res_norm, res_norm_try, alpha
+        real(dp) :: s_try, theta_try
+        integer :: iter, k
+
+        associate(dummy => self)
+        end associate
+
+        ierr = 0
+        varphi = xcyl(2)
+
+        call splint_vmec_data(0.0_dp, 0.0_dp, varphi, A_phi, A_theta, &
+                              dA_phi_ds, dA_theta_ds, aiota, R_axis, Z_axis, &
+                              alam, dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, &
+                              dl_ds, dl_dt, dl_dp)
+
+        rs = xcyl(1) - R_axis
+        zs = xcyl(3) - Z_axis
+        theta = modulo(atan2(zs, rs), TWOPI)
+
+        call splint_vmec_data(1.0_dp, theta, varphi, A_phi, A_theta, dA_phi_ds, &
+                              dA_theta_ds, aiota, R_bnd, Z_bnd, alam, dR_ds, &
+                              dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, dl_ds, dl_dt, &
+                              dl_dp)
+
+        dist_axis = sqrt(rs**2 + zs**2)
+        dist_bnd = sqrt((R_bnd - R_axis)**2 + (Z_bnd - Z_axis)**2)
+        if (dist_bnd > 1.0e-12_dp) then
+            s = min(1.0_dp, max(0.0_dp, (dist_axis/dist_bnd)**2))
+        else
+            s = 0.0_dp
+        end if
+
+        do iter = 1, max_iter
+            call splint_vmec_data(s, theta, varphi, A_phi, A_theta, dA_phi_ds, &
+                                  dA_theta_ds, aiota, R, Z, alam, dR_ds, &
+                                  dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, dl_ds, &
+                                  dl_dt, dl_dp)
+
+            f(1) = R - xcyl(1)
+            f(2) = Z - xcyl(3)
+            res_norm = sqrt(f(1)**2 + f(2)**2)
+            if (res_norm < tol_res) exit
+
+            J(1, 1) = dR_ds
+            J(1, 2) = dR_dt
+            J(2, 1) = dZ_ds
+            J(2, 2) = dZ_dt
+            det = J(1, 1)*J(2, 2) - J(1, 2)*J(2, 1)
+            if (abs(det) < 1.0e-14_dp) then
+                ierr = 2
+                return
+            end if
+
+            delta(1) = (-f(1)*J(2, 2) + f(2)*J(1, 2))/det
+            delta(2) = (-J(1, 1)*f(2) + J(2, 1)*f(1))/det
+
+            if (maxval(abs(delta)) < tol_step) exit
+
+            alpha = 1.0_dp
+            do k = 1, 10
+                s_try = min(1.0_dp, max(0.0_dp, s + alpha*delta(1)))
+                theta_try = modulo(theta + alpha*delta(2), TWOPI)
+                call splint_vmec_data(s_try, theta_try, varphi, A_phi, A_theta, &
+                                      dA_phi_ds, dA_theta_ds, aiota, R, Z, alam, &
+                                      dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, &
+                                      dl_ds, dl_dt, dl_dp)
+                res_norm_try = sqrt((R - xcyl(1))**2 + (Z - xcyl(3))**2)
+                if (res_norm_try < res_norm) then
+                    s = s_try
+                    theta = theta_try
+                    exit
+                end if
+                alpha = 0.5_dp*alpha
+            end do
+
+            if (k > 10) then
+                ierr = 1
+                return
+            end if
+        end do
+
+        if (iter > max_iter) then
+            ierr = 1
+            return
+        end if
+
+        u = [s, theta, varphi]
     end subroutine vmec_from_cyl
 
 end submodule libneo_coordinates_vmec

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -333,6 +333,15 @@ set_tests_properties(test_vmec_coordinate_system PROPERTIES
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS setup_vmec_wout)
 
+add_executable(test_vmec_from_cyl.x source/test_vmec_from_cyl.f90)
+target_link_libraries(test_vmec_from_cyl.x neo)
+add_test(NAME test_vmec_from_cyl
+  COMMAND test_vmec_from_cyl.x)
+set_tests_properties(test_vmec_from_cyl PROPERTIES
+  FAIL_REGULAR_EXPRESSION "STOP"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS setup_vmec_wout)
+
 add_executable(test_chartmap_matches_vmec.x source/test_chartmap_matches_vmec.f90)
 target_link_libraries(test_chartmap_matches_vmec.x neo)
 add_test(NAME test_chartmap_matches_vmec

--- a/test/source/chartmap_test_utils.f90
+++ b/test/source/chartmap_test_utils.f90
@@ -3,10 +3,15 @@ module chartmap_test_utils
     use libneo_coordinates, only: make_chartmap_coordinate_system, &
                                   coordinate_system_t, chartmap_coordinate_system_t
     use math_constants, only: TWOPI
+    use new_vmec_stuff_mod, only: netcdffile
+    use spline_vmec_sub, only: spline_vmec_data
+    use libneo_coordinates, only: vmec_coordinate_system_t
+    use nctools_module, only: nc_open, nc_close, nc_get, nc_inq_dim
     implicit none
 
     private
     public :: chartmap_roundtrip_check
+    public :: chartmap_boundary_matches_vmec_check
 
 contains
 
@@ -53,5 +58,95 @@ contains
         end select
     end subroutine chartmap_roundtrip_check
 
-end module chartmap_test_utils
+    subroutine chartmap_boundary_matches_vmec_check(wout_file, chartmap_file, tol_r, tol_z, nerrors)
+        character(len=*), intent(in) :: wout_file
+        character(len=*), intent(in) :: chartmap_file
+        real(dp), intent(in) :: tol_r
+        real(dp), intent(in) :: tol_z
+        integer, intent(inout) :: nerrors
 
+        type(vmec_coordinate_system_t) :: vmec
+        integer :: ncid
+        integer :: nrho, ntheta, nzeta
+        real(dp), allocatable :: rho(:), theta(:), zeta(:)
+        real(dp), allocatable :: x(:, :, :), y(:, :, :), z(:, :, :)
+        real(dp) :: u_vmec(3), x_vmec_cyl(3)
+        real(dp) :: r_chart, z_chart
+        real(dp) :: dr, dz
+        real(dp) :: max_dr, max_dz
+        integer :: ir, it, iz
+        integer :: iz_list(5)
+        integer :: nz, n_used
+        integer :: k
+
+        max_dr = 0.0_dp
+        max_dz = 0.0_dp
+
+        netcdffile = wout_file
+        call spline_vmec_data
+
+        call nc_open(chartmap_file, ncid)
+        call nc_inq_dim(ncid, "rho", nrho)
+        call nc_inq_dim(ncid, "theta", ntheta)
+        call nc_inq_dim(ncid, "zeta", nzeta)
+
+        allocate (rho(nrho), theta(ntheta), zeta(nzeta))
+        call nc_get(ncid, "rho", rho)
+        call nc_get(ncid, "theta", theta)
+        call nc_get(ncid, "zeta", zeta)
+
+        ! NetCDF stores x/y/z in file order (zeta, theta, rho).
+        ! Fortran is column-major; read into reversed dimension order so that
+        ! indexing is natural: x(ir, it, iz) with (rho, theta, zeta).
+        allocate (x(nrho, ntheta, nzeta))
+        allocate (y(nrho, ntheta, nzeta))
+        allocate (z(nrho, ntheta, nzeta))
+        call nc_get(ncid, "x", x)
+        call nc_get(ncid, "y", y)
+        call nc_get(ncid, "z", z)
+        call nc_close(ncid)
+
+        nz = size(zeta)
+        iz_list = [1, 2, max(1, nz/2), max(1, nz - 1), nz]
+        n_used = 0
+        do k = 1, size(iz_list)
+            iz = iz_list(k)
+            if (iz < 1 .or. iz > nz) cycle
+            if (k > 1) then
+                if (any(iz_list(1:k-1) == iz)) cycle
+            end if
+            n_used = n_used + 1
+
+            ir = size(rho)
+            do it = 1, size(theta)
+                r_chart = sqrt(x(ir, it, iz)**2 + y(ir, it, iz)**2)
+                z_chart = z(ir, it, iz)
+
+                u_vmec = [1.0_dp, theta(it), zeta(iz)]
+                call vmec%evaluate_cyl(u_vmec, x_vmec_cyl)
+                dr = abs(r_chart - x_vmec_cyl(1))
+                dz = abs(z_chart - x_vmec_cyl(3))
+                max_dr = max(max_dr, dr)
+                max_dz = max(max_dz, dz)
+            end do
+        end do
+
+        if (n_used < 1) then
+            print *, "  FAIL: no usable zeta slices to compare"
+            nerrors = nerrors + 1
+            return
+        end if
+
+        if (max_dr > tol_r .or. max_dz > tol_z) then
+            print *, "  FAIL: chartmap boundary differs from VMEC"
+            print *, "    max|dR|=", max_dr, " tol=", tol_r
+            print *, "    max|dZ|=", max_dz, " tol=", tol_z
+            nerrors = nerrors + 1
+            return
+        end if
+
+        print *, "  PASS: chartmap boundary matches VMEC max|dR|=", max_dr, &
+            " max|dZ|=", max_dz
+    end subroutine chartmap_boundary_matches_vmec_check
+
+end module chartmap_test_utils

--- a/test/source/test_python_chartmap_generator.f90
+++ b/test/source/test_python_chartmap_generator.f90
@@ -1,12 +1,13 @@
 program test_python_chartmap_generator
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use chartmap_test_utils, only: chartmap_roundtrip_check
+    use chartmap_test_utils, only: chartmap_roundtrip_check, chartmap_boundary_matches_vmec_check
     use libneo_coordinates, only: validate_chartmap_file
     implicit none
 
     integer :: ierr
     integer :: nerrors
     character(len=2048) :: message
+    character(len=*), parameter :: wout_file = "wout.nc"
     character(len=*), parameter :: chartmap_file = "wout_vmec_python.chartmap.nc"
 
     nerrors = 0
@@ -20,6 +21,7 @@ program test_python_chartmap_generator
     end if
 
     call chartmap_roundtrip_check(chartmap_file, 5.0e-2_dp, nerrors)
+    call chartmap_boundary_matches_vmec_check(wout_file, chartmap_file, 1.0e-3_dp, 1.0e-3_dp, nerrors)
 
     if (nerrors > 0) then
         print *, "FAILED: ", nerrors, " error(s) in python chartmap generator test"

--- a/test/source/test_vmec_from_cyl.f90
+++ b/test/source/test_vmec_from_cyl.f90
@@ -1,0 +1,59 @@
+program test_vmec_from_cyl
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use libneo_coordinates, only: vmec_coordinate_system_t
+    use math_constants, only: TWOPI
+    use new_vmec_stuff_mod, only: netcdffile, nper
+    use spline_vmec_sub, only: spline_vmec_data
+    implicit none
+
+    type(vmec_coordinate_system_t) :: vmec
+    integer :: ierr, nerrors
+    integer :: i
+    real(dp) :: u(3), u_back(3), xcyl(3), xcyl_back(3)
+    real(dp) :: zeta_period
+    real(dp) :: max_dr, max_dz
+
+    nerrors = 0
+    max_dr = 0.0_dp
+    max_dz = 0.0_dp
+
+    netcdffile = "wout.nc"
+    call spline_vmec_data
+
+    zeta_period = TWOPI/real(max(1, nper), dp)
+
+    do i = 1, 20
+        u(1) = real(i, dp)/real(21, dp)
+        u(2) = modulo(real(37*i, dp)*0.017_dp*TWOPI, TWOPI)
+        u(3) = modulo(real(29*i, dp)*0.013_dp*zeta_period, zeta_period)
+
+        call vmec%evaluate_cyl(u, xcyl)
+        call vmec%from_cyl(xcyl, u_back, ierr)
+        if (ierr /= 0) then
+            print *, "  FAIL: vmec_from_cyl ierr=", ierr
+            print *, "    u     =", u
+            print *, "    xcyl  =", xcyl
+            nerrors = nerrors + 1
+            cycle
+        end if
+
+        call vmec%evaluate_cyl(u_back, xcyl_back)
+        max_dr = max(max_dr, abs(xcyl_back(1) - xcyl(1)))
+        max_dz = max(max_dz, abs(xcyl_back(3) - xcyl(3)))
+    end do
+
+    if (max_dr > 1.0e-6_dp .or. max_dz > 1.0e-6_dp) then
+        print *, "  FAIL: vmec from_cyl roundtrip mismatch"
+        print *, "    max|dR|=", max_dr
+        print *, "    max|dZ|=", max_dz
+        nerrors = nerrors + 1
+    else
+        print *, "  PASS: vmec from_cyl roundtrip max|dR|=", max_dr, " max|dZ|=", max_dz
+    end if
+
+    if (nerrors > 0) then
+        print *, "FAILED: ", nerrors, " error(s) in VMEC from_cyl test"
+        error stop 1
+    end if
+end program test_vmec_from_cyl
+


### PR DESCRIPTION
### **User description**
This fixes a VMEC convention mismatch in libneo's python VMEC evaluators used by the map2disc chartmap generator, and implements VMEC cylindrical inversion in the Fortran coordinate system.

Changes
- Python VMEC series now uses m*theta - n*zeta (matches Fortran VMEC convention).
- Implement vmec_coordinate_system_t%from_cyl via damped Newton in (s,theta) at fixed varphi.
- Strengthen python chartmap generator test: compare chartmap boundary to Fortran VMEC.
- Add regression test for vmec_from_cyl roundtrip.

Tests
- Ran cmake --build --preset default
[1/1] cd /home/ert/code/libneo/extra/MyMPILib && /home/ert/code/libneo/extra/MyMPILib/Scripts/do_versioning.sh
Versioning MyMPILib...
cd build && ctest
Test project /home/ert/code/libneo/build
      Start  1: test_binsrc
 1/57 Test  #1: test_binsrc .......................................   Passed    0.01 sec
      Start  2: test_boozer_class
 2/57 Test  #2: test_boozer_class .................................   Passed    0.01 sec
      Start  3: test_efit_class
 3/57 Test  #3: test_efit_class ...................................   Passed    0.01 sec
      Start  4: test_geqdsk_tools
 4/57 Test  #4: test_geqdsk_tools .................................   Passed    0.02 sec
      Start  5: test_simpson
 5/57 Test  #5: test_simpson ......................................   Passed    0.01 sec
      Start  6: test_hdf5_tools
 6/57 Test  #6: test_hdf5_tools ...................................   Passed    2.01 sec
      Start  7: test_util
 7/57 Test  #7: test_util .........................................   Passed    0.01 sec
      Start  8: test_interpolate
 8/57 Test  #8: test_interpolate ..................................   Passed    1.16 sec
      Start  9: test_batch_interpolate
 9/57 Test  #9: test_batch_interpolate ............................   Passed    1.17 sec
      Start 10: test_collision_freqs
10/57 Test #10: test_collision_freqs ..............................   Passed    0.01 sec
      Start 11: test_transport
11/57 Test #11: test_transport ....................................   Passed    0.01 sec
      Start 12: test_vmec_modules
12/57 Test #12: test_vmec_modules .................................   Passed    0.01 sec
      Start 13: test_coordinate_systems
13/57 Test #13: test_coordinate_systems ...........................   Passed    0.01 sec
      Start 14: test_analytical_circular
14/57 Test #14: test_analytical_circular ..........................   Passed    0.02 sec
      Start 15: test_nctools_nc_get3
15/57 Test #15: test_nctools_nc_get3 ..............................   Passed    0.01 sec
      Start 16: test_ascot5_compare
16/57 Test #16: test_ascot5_compare ...............................   Passed    9.22 sec
      Start 17: test_arnoldi_setup
17/57 Test #17: test_arnoldi_setup ................................   Passed    0.19 sec
      Start 18: test_arnoldi
18/57 Test #18: test_arnoldi ......................................   Passed    0.05 sec
      Start 19: test_mympilib
19/57 Test #19: test_mympilib .....................................   Passed    0.05 sec
      Start 20: test_system_utility
20/57 Test #20: test_system_utility ...............................   Passed    0.01 sec
      Start 21: setup_chartmap_volume
21/57 Test #21: setup_chartmap_volume .............................   Passed    3.90 sec
      Start 22: setup_vmec_wout
22/57 Test #22: setup_vmec_wout ...................................   Passed    0.14 sec
      Start 23: setup_vmec_chartmap_python
23/57 Test #23: setup_vmec_chartmap_python ........................   Passed    4.43 sec
      Start 24: validate_vmec_map2disc_chartmap_boundary_python
24/57 Test #24: validate_vmec_map2disc_chartmap_boundary_python ...   Passed    0.52 sec
      Start 25: validate_vmec_map2disc_chartmap_boundary_cli
25/57 Test #25: validate_vmec_map2disc_chartmap_boundary_cli ......   Passed    0.51 sec
      Start 26: test_chartmap_coordinates
26/57 Test #26: test_chartmap_coordinates .........................   Passed    0.29 sec
      Start 27: test_chartmap_validator
27/57 Test #27: test_chartmap_validator ...........................   Passed    0.04 sec
      Start 28: test_vmec_chartmap_generator
28/57 Test #28: test_vmec_chartmap_generator ......................   Passed    0.30 sec
      Start 29: test_python_chartmap_generator
29/57 Test #29: test_python_chartmap_generator ....................   Passed    0.23 sec
      Start 30: test_vmec_coordinate_system
30/57 Test #30: test_vmec_coordinate_system .......................   Passed    0.22 sec
      Start 31: test_vmec_from_cyl
31/57 Test #31: test_vmec_from_cyl ................................   Passed    0.22 sec
      Start 32: test_chartmap_matches_vmec
32/57 Test #32: test_chartmap_matches_vmec ........................   Passed    0.95 sec
      Start 33: test_chartmap_vmec_mapping
33/57 Test #33: test_chartmap_vmec_mapping ........................   Passed    0.52 sec
      Start 34: test_chartmap_derivatives
34/57 Test #34: test_chartmap_derivatives .........................   Passed    0.47 sec
      Start 35: test_refcoords_file_detection
35/57 Test #35: test_refcoords_file_detection .....................   Passed    0.03 sec
      Start 36: setup_test_jorek_field
36/57 Test #36: setup_test_jorek_field ............................   Passed    0.01 sec
      Start 45: test_jorek_field
37/57 Test #45: test_jorek_field ..................................   Passed    0.03 sec
      Start 46: test_field
38/57 Test #46: test_field ........................................   Passed    0.03 sec
      Start 37: cleanup_test_jorek_field
39/57 Test #37: cleanup_test_jorek_field ..........................   Passed    0.01 sec
      Start 38: test_biotsavart
40/57 Test #38: test_biotsavart ...................................   Passed    0.21 sec
      Start 39: test_example_field
41/57 Test #39: test_example_field ................................   Passed    0.01 sec
      Start 40: test_biotsavart_field
42/57 Test #40: test_biotsavart_field .............................   Passed    0.01 sec
      Start 41: test_mesh
43/57 Test #41: test_mesh .........................................   Passed    0.01 sec
      Start 42: test_field_mesh
44/57 Test #42: test_field_mesh ...................................   Passed    0.01 sec
      Start 43: test_polylag_field
45/57 Test #43: test_polylag_field ................................   Passed    0.05 sec
      Start 44: test_spline_field
46/57 Test #44: test_spline_field .................................   Passed    0.26 sec
      Start 47: test_stretch_coords
47/57 Test #47: test_stretch_coords ...............................   Passed    0.07 sec
      Start 48: test_coil_tools_biot_savart
48/57 Test #48: test_coil_tools_biot_savart .......................   Passed    5.12 sec
      Start 49: tilted_coil_generate_geometry
49/57 Test #49: tilted_coil_generate_geometry .....................   Passed    0.08 sec
      Start 50: tilted_coil_fourier_modes
50/57 Test #50: tilted_coil_fourier_modes .........................   Passed    3.29 sec
      Start 51: tilted_coil_field_validation
51/57 Test #51: tilted_coil_field_validation ......................   Passed    3.55 sec
      Start 52: test_polylag_5
52/57 Test #52: test_polylag_5 ....................................   Passed    0.01 sec
      Start 53: test_poincare
53/57 Test #53: test_poincare .....................................   Passed    0.02 sec
      Start 54: test_odeint_allroutines_context
54/57 Test #54: test_odeint_allroutines_context ...................   Passed    0.01 sec
      Start 55: test_odeint_thread_safety
55/57 Test #55: test_odeint_thread_safety .........................   Passed    0.01 sec
      Start 56: build_test_golden_record_odeint
56/57 Test #56: build_test_golden_record_odeint ...................   Passed    0.01 sec
      Start 57: test_golden_record_odeint
57/57 Test #57: test_golden_record_odeint .........................   Passed    0.17 sec

100% tests passed, 0 tests failed out of 57

Label Time Summary:
biot_savart     =   5.12 sec*proc (1 test)
build-helper    =   0.01 sec*proc (1 test)
field           =   0.68 sec*proc (10 tests)
magfie          =  12.04 sec*proc (4 tests)
poincare        =   0.02 sec*proc (1 test)
polylag         =   0.01 sec*proc (1 test)
tilted_coil     =   6.92 sec*proc (3 tests)

Total Test time (real) =  39.73 sec (57/57 passed): see


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Implement VMEC cylindrical inversion (from_cyl) using damped Newton method

- Fix Python Fourier phase convention to match Fortran (m*theta - n*zeta)

- Add regression test for vmec_from_cyl roundtrip validation

- Strengthen chartmap boundary validation against Fortran VMEC


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Python Fourier Phase"] -->|"Fix sign: m*theta - n*zeta"| B["Match Fortran Convention"]
  C["Cylindrical Coordinates"] -->|"Damped Newton Inversion"| D["VMEC Coordinates"]
  D -->|"Roundtrip Test"| E["Validation"]
  F["Chartmap Boundary"] -->|"Compare to VMEC"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>libneo_coordinates_vmec.f90</strong><dd><code>Implement VMEC cylindrical coordinate inversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coordinates/libneo_coordinates_vmec.f90

<ul><li>Implement <code>vmec_from_cyl</code> subroutine using damped Newton method in <br>(s,theta) space<br> <li> Add iterative solver with line search for cylindrical to VMEC <br>coordinate inversion<br> <li> Include tolerance checks and error handling for convergence failures<br> <li> Import <code>TWOPI</code> constant for angle normalization</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/189/files#diff-01b9a82034036b8146c8354ae9d13c5a6c187d09a89d759e63fb428ee944b54a">+100/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chartmap_test_utils.f90</strong><dd><code>Add chartmap boundary validation against VMEC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/source/chartmap_test_utils.f90

<ul><li>Add new subroutine <code>chartmap_boundary_matches_vmec_check</code> for boundary <br>validation<br> <li> Compare chartmap boundary coordinates against Fortran VMEC at multiple <br>zeta slices<br> <li> Implement NetCDF I/O for reading chartmap data and computing max <br>deviations<br> <li> Export new public subroutine for test integration</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/189/files#diff-fa5bac57874e187e63527b33c7a6a31920b84b200006f22903168cc6cd7afc2f">+96/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_python_chartmap_generator.f90</strong><dd><code>Integrate chartmap boundary validation test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/source/test_python_chartmap_generator.f90

<ul><li>Import new <code>chartmap_boundary_matches_vmec_check</code> subroutine<br> <li> Add boundary validation test call with tolerance thresholds<br> <li> Define wout_file parameter for VMEC data source</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/189/files#diff-2985d915dbe17588e604fe99608b7f52c093c44ce2d75e6027a7ef9951215fb4">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_vmec_from_cyl.f90</strong><dd><code>Add VMEC from_cyl roundtrip regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/source/test_vmec_from_cyl.f90

<ul><li>Create new test program for vmec_from_cyl roundtrip validation<br> <li> Test 20 random points in VMEC coordinate space with roundtrip <br>conversion<br> <li> Verify cylindrical coordinate inversion accuracy with tolerance checks<br> <li> Report max deviations in R and Z coordinates</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/189/files#diff-0c7719b7b1486428db29d092bcf4cff913007ee12826a886b7f9f678cc759f13">+59/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vmec.py</strong><dd><code>Fix Python Fourier phase convention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/libneo/vmec.py

<ul><li>Fix Fourier phase sign in <code>_cfunct</code> from <code>+</code> to <code>-</code> for xn*zeta term<br> <li> Fix Fourier phase sign in <code>_sfunct</code> from <code>+</code> to <code>-</code> for xn*zeta term<br> <li> Update docstrings to reflect correct convention (m*theta - n*zeta)</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/189/files#diff-8f352eb1a99dacff1a04ff0b299addff1a45dd48982fec81d479bc2d67e5ac08">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vmec_to_efit.py</strong><dd><code>Fix Fourier phase in VMEC to EFIT conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/libneo/vmec_to_efit.py

<ul><li>Fix Fourier phase sign in <code>cfunct</code> from <code>+</code> to <code>-</code> for xn*zeta term<br> <li> Fix Fourier phase sign in <code>sfunct</code> from <code>+</code> to <code>-</code> for xn*zeta term</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/189/files#diff-034cc623a6776c0e7421998c40c4b57cfab3b2327389c7ca4b6964f3a0c7fe9e">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vmec_utils.py</strong><dd><code>Fix Fourier phase in VMEC utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/libneo/vmec_utils.py

<ul><li>Fix Fourier phase sign in <code>cfunct</code> from <code>+</code> to <code>-</code> for xn*zeta term<br> <li> Fix Fourier phase sign in <code>sfunct</code> from <code>+</code> to <code>-</code> for xn*zeta term</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/189/files#diff-f32e5c6002de65f89f32acd026af43427b3c71bbce7f49e5ceed7d0cc66543c9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Register vmec_from_cyl test in CMake</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/CMakeLists.txt

<ul><li>Add new executable target <code>test_vmec_from_cyl.x</code> linking against neo <br>library<br> <li> Register test with CMake and set working directory dependency<br> <li> Configure test properties with failure regex pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/189/files#diff-33394812ba204689144fd2f80832db83853ba1cb32403edb4e15fe4893e675fd">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

