### PR TITLE
Fix interval clamping bug at x=xmax boundary

### DIFF
--- a/src/interpolate/interpolate.f90
+++ b/src/interpolate/interpolate.f90
@@ -190,7 +190,7 @@ contains
                 xj = x(ie)
             end if
             x_norm = (xj - spl%x_min) / spl%h_step
-            interval_index = max(0, min(spl%num_points-1, int(x_norm)))
+            interval_index = max(0, min(spl%num_points-2, int(x_norm)))
             x_local = (x_norm - dble(interval_index))*spl%h_step
 
             y(ie) = spl%coeff(spl%order, interval_index+1)
@@ -217,7 +217,7 @@ contains
                 xj = x(ie)
             end if
             x_norm = (xj - spl%x_min) / spl%h_step
-            interval_index = max(0, min(spl%num_points-1, int(x_norm)))
+            interval_index = max(0, min(spl%num_points-2, int(x_norm)))
             x_local = (x_norm - dble(interval_index))*spl%h_step
 
             y(ie) = spl%coeff(spl%order, interval_index+1)
@@ -248,7 +248,7 @@ contains
                 xj = x(ie)
             end if
             x_norm = (xj - spl%x_min) / spl%h_step
-            interval_index = max(0, min(spl%num_points-1, int(x_norm)))
+            interval_index = max(0, min(spl%num_points-2, int(x_norm)))
             x_local = (x_norm - dble(interval_index))*spl%h_step
 
             y(ie) = spl%coeff(spl%order, interval_index+1)
@@ -368,7 +368,7 @@ contains
                     xj = x(j, ie)
                 end if
                 x_norm(j) = (xj - spl%x_min(j))/spl%h_step(j)
-                interval_index(j) = max(0, min(spl%num_points(j)-1, int(x_norm(j))))
+                interval_index(j) = max(0, min(spl%num_points(j)-2, int(x_norm(j))))
                 x_local(j) = (x_norm(j) - dble(interval_index(j)))*spl%h_step(j)
             end do
 
@@ -408,7 +408,7 @@ contains
                     xj = x(j, ie)
                 end if
                 x_norm(j) = (xj - spl%x_min(j))/spl%h_step(j)
-                interval_index(j) = max(0, min(spl%num_points(j)-1, int(x_norm(j))))
+                interval_index(j) = max(0, min(spl%num_points(j)-2, int(x_norm(j))))
                 x_local(j) = (x_norm(j) - dble(interval_index(j)))*spl%h_step(j)
             end do
 
@@ -594,7 +594,7 @@ contains
                     xj = x(j, ie)
                 end if
                 x_norm(j) = (xj - spl%x_min(j))/spl%h_step(j)
-                interval_index(j) = max(0, min(spl%num_points(j)-1, int(x_norm(j))))
+                interval_index(j) = max(0, min(spl%num_points(j)-2, int(x_norm(j))))
                 x_local(j) = (x_norm(j) - dble(interval_index(j)))*spl%h_step(j)
             end do
 
@@ -642,7 +642,7 @@ contains
                     xj = x(j, ie)
                 end if
                 x_norm(j) = (xj - spl%x_min(j))/spl%h_step(j)
-                interval_index(j) = max(0, min(spl%num_points(j)-1, int(x_norm(j))))
+                interval_index(j) = max(0, min(spl%num_points(j)-2, int(x_norm(j))))
                 x_local(j) = (x_norm(j) - dble(interval_index(j)))*spl%h_step(j)
             end do
 
@@ -726,7 +726,7 @@ contains
                     xj = x(j, ie)
                 end if
                 x_norm(j) = (xj - spl%x_min(j))/spl%h_step(j)
-                interval_index(j) = max(0, min(spl%num_points(j)-1, int(x_norm(j))))
+                interval_index(j) = max(0, min(spl%num_points(j)-2, int(x_norm(j))))
                 x_local(j) = (x_norm(j) - dble(interval_index(j)))*spl%h_step(j)
             end do
 


### PR DESCRIPTION
## Summary
- Fix out-of-bounds interval access at x=xmax in individual spline evaluation functions
- The batch implementation already had correct clamping (`num_points-2`), this makes individual implementation consistent

## Problem
For N data points, there are N-1 valid spline intervals (indices 0 to N-2). At x=xmax:
- `x_norm = N-1`
- `int(x_norm) = N-1`
- **OLD**: `min(num_points-1, N-1) = N-1` → accesses invalid interval
- **NEW**: `min(num_points-2, N-1) = N-2` → accesses last valid interval

## Changes
All 8 evaluation functions fixed:
- `evaluate_splines_1d_many`, `_der`, `_der2`
- `evaluate_splines_2d_many`, `_der`
- `evaluate_splines_3d_many`, `_der`, `_der2`

## Testing
- All 62 libneo tests pass (100%)
- SIMPLE test_batch_splines now passes with proper tolerance