### PR TITLE
Fix missing OpenACC preprocessor guards for acc_is_present calls

### DIFF
--- a/src/interpolate/batch_interpolate_2d.f90
+++ b/src/interpolate/batch_interpolate_2d.f90
@@ -495,9 +495,11 @@ contains
                  size(spl%coeff, 3) /= N2_order + 1 .or. &
                  size(spl%coeff, 4) /= n1 .or. &
                  size(spl%coeff, 5) /= n2) then
+#ifdef _OPENACC
             if (acc_is_present(spl%coeff)) then
                 !$acc exit data delete(spl%coeff)
             end if
+#endif
             deallocate(spl%coeff)
             allocate(spl%coeff(n_quantities, 0:N1_order, 0:N2_order, n1, n2), stat=istat)
             if (istat /= 0) then

--- a/src/interpolate/batch_interpolate_3d.f90
+++ b/src/interpolate/batch_interpolate_3d.f90
@@ -670,9 +670,11 @@ contains
                  size(spl%coeff, 6) /= n2 .or. &
                  size(spl%coeff, 7) /= n3) then
             ! Size mismatch - need to reallocate
+#ifdef _OPENACC
             if (acc_is_present(spl%coeff)) then
                 !$acc exit data delete(spl%coeff)
             end if
+#endif
             deallocate(spl%coeff)
             allocate(spl%coeff(n_quantities, 0:N1_order, 0:N2_order, 0:N3_order, &
                 n1, n2, n3), stat=istat)


### PR DESCRIPTION
## Summary
- Add missing `#ifdef _OPENACC` guards around `acc_is_present()` calls in batch_interpolate_2d.f90 and batch_interpolate_3d.f90
- Fixes compilation errors when building with GCC configured with nvptx offload support but without explicitly enabling OpenACC

## Background
When using GCC 16 built with nvptx offload support, the compiler attempts to process OpenACC directives even without explicit `-fopenacc` flag. The `acc_is_present()` function requires the `openacc` module, which is only available when OpenACC is actually enabled.

## Test plan
- [x] libneo tests pass (62/62)
- [x] SIMPLE builds successfully with GCC 16 and `-DENABLE_OPENACC=OFF`