### PR TITLE
Fix boozer_coordinates_mod exports for SIMPLE v1.5.1

### DIFF
--- a/src/canonical_coordinates_mod.f90
+++ b/src/canonical_coordinates_mod.f90
@@ -66,14 +66,24 @@
   end module canonical_coordinates_new_mod
 !
   module boozer_coordinates_mod
-    logical :: use_B_r=.false., use_del_tp_B=.false.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use canonical_coordinates_mod, only: ns_max, derf1, derf2, derf3
+
+    implicit none
+
+    logical :: use_B_r = .false.
+    logical :: use_del_tp_B = .false.
 
     integer :: ns_s_B,ns_tp_B
     integer :: ns_B,n_theta_B,n_phi_B
-    double precision :: hs_B,h_theta_B,h_phi_B
+    real(dp) :: hs_B, h_theta_B, h_phi_B
 
 ! spline coefficients for Boozer $B_\vartheta$ and $B_\varphi$:
-    double precision, dimension(:,:,:),         allocatable :: s_Bcovar_tp_B
+    real(dp), allocatable :: s_Bcovar_tp_B(:, :, :)
+    real(dp), allocatable :: s_Bmod_B(:, :, :, :, :, :)
+    real(dp), allocatable :: s_Bcovar_r_B(:, :, :, :, :, :)
+    real(dp), allocatable :: s_delt_delp_V(:, :, :, :, :, :, :)
+    real(dp), allocatable :: s_delt_delp_B(:, :, :, :, :, :, :)
   end module boozer_coordinates_mod
 !
   module velo_mod

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,13 @@ target_link_libraries(test_binsrc.x
   ${COMMON_LIBS}
 )
 
+add_executable(test_boozer_coordinates_exports.x
+  source/test_boozer_coordinates_exports.f90
+)
+target_link_libraries(test_boozer_coordinates_exports.x
+  neo
+)
+
 add_executable(test_geqdsk_tools.x source/test_geqdsk_tools.f90)
 target_link_libraries(test_geqdsk_tools.x
   ${MAIN_LIB}
@@ -176,6 +183,9 @@ target_link_libraries(test_nctools_nc_get3.x
 ## Standard tests according to standard libneo Fortran test convention.
 
 add_test(NAME test_binsrc COMMAND test_binsrc.x)
+add_test(NAME test_boozer_coordinates_exports
+  COMMAND test_boozer_coordinates_exports.x
+)
 add_test(NAME test_geqdsk_tools COMMAND test_geqdsk_tools.x)
 add_test(NAME test_simpson COMMAND test_simpson.x)
 add_test(NAME test_hdf5_tools COMMAND test_hdf5_tools.x)

--- a/test/source/test_boozer_coordinates_exports.f90
+++ b/test/source/test_boozer_coordinates_exports.f90
@@ -1,0 +1,66 @@
+program test_boozer_coordinates_exports
+
+    use boozer_coordinates_mod, only: ns_s_B, ns_tp_B, ns_B, n_theta_B, n_phi_B
+    use boozer_coordinates_mod, only: hs_B, h_theta_B, h_phi_B
+    use boozer_coordinates_mod, only: s_Bcovar_tp_B, s_Bmod_B, s_Bcovar_r_B
+    use boozer_coordinates_mod, only: s_delt_delp_V, s_delt_delp_B
+    use boozer_coordinates_mod, only: ns_max, derf1, derf2, derf3
+    use boozer_coordinates_mod, only: use_B_r, use_del_tp_B
+    use libneo_kinds, only: dp
+
+    implicit none
+
+    logical :: ok
+
+    ok = .true.
+
+    ns_s_B = 3
+    ns_tp_B = 3
+    ns_B = 2
+    n_theta_B = 4
+    n_phi_B = 5
+
+    hs_B = 1.0_dp
+    h_theta_B = 1.0_dp
+    h_phi_B = 1.0_dp
+
+    use_B_r = .true.
+    use_del_tp_B = .true.
+
+    if (.not. allocated(s_Bcovar_tp_B)) then
+        allocate (s_Bcovar_tp_B(2, ns_s_B + 1, ns_B))
+    end if
+
+    if (.not. allocated(s_Bmod_B)) then
+        allocate (s_Bmod_B(ns_s_B + 1, ns_tp_B + 1, ns_tp_B + 1, ns_B, &
+            n_theta_B, n_phi_B))
+    end if
+
+    if (.not. allocated(s_Bcovar_r_B)) then
+        allocate (s_Bcovar_r_B(ns_s_B + 1, ns_tp_B + 1, ns_tp_B + 1, ns_B, &
+            n_theta_B, n_phi_B))
+    end if
+
+    if (.not. allocated(s_delt_delp_V)) then
+        allocate (s_delt_delp_V(2, ns_s_B + 1, ns_tp_B + 1, ns_tp_B + 1, ns_B, &
+            n_theta_B, n_phi_B))
+    end if
+
+    if (.not. allocated(s_delt_delp_B)) then
+        allocate (s_delt_delp_B(2, ns_s_B + 1, ns_tp_B + 1, ns_tp_B + 1, ns_B, &
+            n_theta_B, n_phi_B))
+    end if
+
+    derf1 = 0.0_dp
+    derf2 = 0.0_dp
+    derf3 = 0.0_dp
+
+    if (size(derf1) /= ns_max) ok = .false.
+    if (size(derf2) /= ns_max) ok = .false.
+    if (size(derf3) /= ns_max) ok = .false.
+
+    if (.not. ok) then
+        error stop "ERROR boozer_coordinates_mod exports are inconsistent."
+    end if
+
+end program test_boozer_coordinates_exports


### PR DESCRIPTION
## Why
SIMPLE v1.5.1 fails to compile against current libneo because `boozer_coordinates_mod` no longer exports several variables that SIMPLE imports (e.g. `s_Bmod_B`, `s_Bcovar_r_B`, `s_delt_delp_V`, `s_delt_delp_B`, `ns_max`, `derf1..derf3`).

## What
- Restore the missing export surface in `boozer_coordinates_mod` by adding the allocatable arrays and re-exporting `ns_max`, `derf1`, `derf2`, `derf3`.
- Add a regression test that compiles and exercises allocation of the exported arrays.

## Evidence
- `make test` (libneo): 63/63 tests passed.
- SIMPLE v1.5.1 build in `/tmp/SIMPLE-v1.5.1` now completes (previously failed at `src/boozer_converter.F90` with missing symbols from `boozer_coordinates_mod`).

## How to reproduce
- Build SIMPLE v1.5.1 with local libneo (via `CODE=/home/ert/code`):
  - `cmake -S /tmp/SIMPLE-v1.5.1 -B /tmp/SIMPLE-v1.5.1/build -G Ninja`
  - `cmake --build /tmp/SIMPLE-v1.5.1/build -j32`
