### PR TITLE
Harden chartmap eval and odeint failure handling

### DIFF
--- a/src/coordinates/libneo_coordinates_chartmap_impl.inc
+++ b/src/coordinates/libneo_coordinates_chartmap_impl.inc
@@ -202,18 +202,35 @@ subroutine chartmap_eval_cart(self, u, vals)
     real(dp) :: phi
     real(dp) :: phi_mod
     real(dp) :: zeta_period
+    real(dp) :: u_eval(3)
+    real(dp) :: x_min(3), x_max(3)
 
     if (self%has_spl_rz) then
-        phi = u(3)
-        zeta_period = TWOPI/real(self%num_field_periods, dp)
+        x_min = self%spl_rz%x_min
+        x_max = self%spl_rz%x_min + self%spl_rz%h_step * &
+                real(self%spl_rz%num_points - 1, dp)
+    else
+        x_min = self%spl_cart%x_min
+        x_max = self%spl_cart%x_min + self%spl_cart%h_step * &
+                real(self%spl_cart%num_points - 1, dp)
+    end if
+
+    u_eval = u
+    u_eval(1) = max(x_min(1), min(u_eval(1), x_max(1)))
+    u_eval(2) = modulo(u_eval(2) - x_min(2), TWOPI) + x_min(2)
+    zeta_period = TWOPI/real(self%num_field_periods, dp)
+    u_eval(3) = modulo(u_eval(3) - x_min(3), zeta_period) + x_min(3)
+
+    if (self%has_spl_rz) then
+        phi = u_eval(3)
         phi_mod = modulo(phi - self%spl_rz%x_min(3), zeta_period) + &
                   self%spl_rz%x_min(3)
-        call evaluate_batch_splines_3d(self%spl_rz, u, rz)
+        call evaluate_batch_splines_3d(self%spl_rz, u_eval, rz)
         vals(1) = rz(1)*cos(phi_mod)
         vals(2) = rz(1)*sin(phi_mod)
         vals(3) = rz(2)
     else
-        call evaluate_batch_splines_3d(self%spl_cart, u, vals)
+        call evaluate_batch_splines_3d(self%spl_cart, u_eval, vals)
     end if
 end subroutine chartmap_eval_cart
 
@@ -229,15 +246,32 @@ subroutine chartmap_eval_cart_der(self, u, vals, dvals)
     real(dp) :: phi_mod
     real(dp) :: cph, sph
     real(dp) :: zeta_period
+    real(dp) :: u_eval(3)
+    real(dp) :: x_min(3), x_max(3)
 
     if (self%has_spl_rz) then
-        phi = u(3)
-        zeta_period = TWOPI/real(self%num_field_periods, dp)
+        x_min = self%spl_rz%x_min
+        x_max = self%spl_rz%x_min + self%spl_rz%h_step * &
+                real(self%spl_rz%num_points - 1, dp)
+    else
+        x_min = self%spl_cart%x_min
+        x_max = self%spl_cart%x_min + self%spl_cart%h_step * &
+                real(self%spl_cart%num_points - 1, dp)
+    end if
+
+    u_eval = u
+    u_eval(1) = max(x_min(1), min(u_eval(1), x_max(1)))
+    u_eval(2) = modulo(u_eval(2) - x_min(2), TWOPI) + x_min(2)
+    zeta_period = TWOPI/real(self%num_field_periods, dp)
+    u_eval(3) = modulo(u_eval(3) - x_min(3), zeta_period) + x_min(3)
+
+    if (self%has_spl_rz) then
+        phi = u_eval(3)
         phi_mod = modulo(phi - self%spl_rz%x_min(3), zeta_period) + &
                   self%spl_rz%x_min(3)
         cph = cos(phi_mod)
         sph = sin(phi_mod)
-        call evaluate_batch_splines_3d_der(self%spl_rz, u, rz, drz)
+        call evaluate_batch_splines_3d_der(self%spl_rz, u_eval, rz, drz)
 
         vals(1) = rz(1)*cph
         vals(2) = rz(1)*sph
@@ -262,7 +296,7 @@ subroutine chartmap_eval_cart_der(self, u, vals, dvals)
         dvals(2, 3) = drz(3, 1)*sph + rz(1)*cph  ! dY/dphi = dR/dphi*sin + R*cos
         dvals(3, 3) = drz(3, 2)            ! dZ/dphi = dZ/dphi
     else
-        call evaluate_batch_splines_3d_der(self%spl_cart, u, vals, dvals)
+        call evaluate_batch_splines_3d_der(self%spl_cart, u_eval, vals, dvals)
     end if
 end subroutine chartmap_eval_cart_der
 
@@ -341,6 +375,23 @@ subroutine initialize_chartmap(ccs, filename)
     call chartmap_read_zeta_convention(ncid, zeta_convention)
     call chartmap_read_rho_convention(ncid, rho_convention)
     call nc_close(ncid)
+
+    if (num_field_periods == 1 .and. nzeta >= 2) then
+        block
+            real(dp) :: dz, period_est, nfp_est_real
+            integer :: nfp_est
+
+            dz = zeta(2) - zeta(1)
+            period_est = (zeta(nzeta) - zeta(1)) + dz
+            if (period_est > 0.0_dp) then
+                nfp_est_real = TWOPI/period_est
+                nfp_est = max(1, nint(nfp_est_real))
+                if (abs(nfp_est_real - real(nfp_est, dp)) < 0.25_dp) then
+                    num_field_periods = nfp_est
+                end if
+            end if
+        end block
+    end if
 
     order = [3, 3, 3]
 
@@ -1126,4 +1177,3 @@ subroutine chartmap_solve_slice(self, x_target, zeta, rho, theta, ierr, trace)
         ierr = chartmap_from_cyl_err_max_iter
     end if
 end subroutine chartmap_solve_slice
-


### PR DESCRIPTION
### **User description**
Scope:
- Clamp/periodize chartmap spline evaluation inputs to valid grid.
- Improve odeint state allocation correctness.

Notes:
- Stacked on #239.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Clamp and periodize chartmap spline evaluation inputs to valid grid bounds
  - Compute grid bounds from spline metadata
  - Clamp first coordinate, periodize second and third coordinates

- Improve odeint failure handling with graceful degradation
  - Add status tracking with `odeint_failed` flag and query functions
  - Return early on step size underflow instead of error stop

- Auto-detect field periods from zeta grid spacing during initialization
  - Estimate number of field periods when metadata value is 1
  - Validate estimate within tolerance before updating


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Input coordinates u"] --> B["Compute grid bounds<br/>from spline metadata"]
  B --> C["Clamp/periodize<br/>u_eval"]
  C --> D["Evaluate splines<br/>with safe inputs"]
  D --> E["Output vals"]
  F["ODE step fails"] --> G["Set odeint_failed flag"]
  G --> H["Return early<br/>with current state"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>libneo_coordinates_chartmap.f90</strong><dd><code>Harden chartmap evaluation with input bounds checking</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coordinates/libneo_coordinates_chartmap.f90

<ul><li>Add input clamping and periodization logic to <code>chartmap_eval_cart</code> and <br><code>chartmap_eval_cart_der</code> subroutines<br> <li> Compute grid bounds from spline metadata (<code>x_min</code>, <code>h_step</code>, <code>num_points</code>)<br> <li> Clamp first coordinate to valid range, periodize second and third <br>coordinates<br> <li> Add auto-detection of field periods in <code>initialize_chartmap</code> based on <br>zeta grid spacing</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/240/files#diff-ee712e2206187619d99f188701cbe455ad4a9f4da743260ffc73f1c8efa4aed1">+59/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>odeint_allroutines.f90</strong><dd><code>Add graceful ODE integration failure handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/odeint_allroutines.f90

<ul><li>Add module-level <code>odeint_failed</code> flag to track integration failures<br> <li> Implement <code>odeint_clear_status</code> and <code>odeint_has_failed</code> public functions <br>for status management<br> <li> Replace <code>error stop</code> with graceful failure handling in <code>adjust_step_size</code> <br>when step size underflows<br> <li> Add early return logic in <code>integrate_adaptive</code> and <br><code>integrate_adaptive_with_context</code> when failure is detected</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/240/files#diff-63980df8b587304fb8d30bb4ab6cbc7200e63501cb0c2e40860486139af0c954">+24/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>libneo_coordinates_chartmap_impl.inc</strong><dd><code>Sync chartmap hardening to implementation include file</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coordinates/libneo_coordinates_chartmap_impl.inc

<ul><li>Mirror all chartmap evaluation hardening changes from main Fortran <br>file<br> <li> Add input clamping and periodization to <code>chartmap_eval_cart</code> and <br><code>chartmap_eval_cart_der</code><br> <li> Add field period auto-detection in <code>initialize_chartmap</code><br> <li> Maintain consistency with primary implementation file</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/240/files#diff-5080a999b30f0ed23c55de83a51e310232d8538237a41da03047984a1a724b4f">+59/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

