### PR TITLE
Chartmap: VMEC-extended mode (cubic Hermite)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ CLI:
 
     libneo-write-chartmap from-vmec wout.nc wout.chartmap.nc --nrho 33 --ntheta 65 --nzeta 33
 
+VMEC with cubic Hermite extension beyond LCFS (no map2disc dependency, C1 continuous):
+
+    libneo-write-chartmap from-vmec-extended wout.nc wout.chartmap.nc \
+        --nrho-vmec 25 --boundary-offset 0.15
+
+This mode uses exact VMEC coordinates inside the LCFS and extends beyond using cubic
+Hermite interpolation along coordinate line tangents, providing C1 continuity at the
+boundary suitable for symplectic integrators.
+
 ### Coils format converter
 Convert STELLOPT coils format to simple biotsavart format:
 

--- a/python/libneo/chartmap.py
+++ b/python/libneo/chartmap.py
@@ -7,6 +7,143 @@ import numpy as np
 from .chartmap_io import ChartmapGrid, build_chartmap_grid, write_chartmap_netcdf
 
 
+def _normalize_boundary_param(value: str) -> str:
+    param = str(value).strip().lower()
+    if param not in ("arc", "theta"):
+        raise ValueError("boundary_param must be 'arc' or 'theta'")
+    return param
+
+
+def _vmec_theta_curve(
+    geom,
+    s_boundary: float,
+    phi_val: float,
+    *,
+    boundary_offset: float,
+    use_asym: bool,
+):
+    if boundary_offset == 0.0:
+        def curve(t: np.ndarray) -> np.ndarray:
+            th = np.asarray(t, dtype=float)
+            R, Zc, _ = geom.coords_s(float(s_boundary), th, phi_val, use_asym=use_asym)
+            return np.array([R, Zc])
+        return curve
+
+    theta_base = np.linspace(0.0, 2.0 * np.pi, 4096, endpoint=False, dtype=float)
+    R_base, Z_base, _ = geom.coords_s(float(s_boundary), theta_base, phi_val, use_asym=use_asym)
+    dR = np.gradient(R_base, theta_base, edge_order=2)
+    dZ = np.gradient(Z_base, theta_base, edge_order=2)
+    nR = dZ
+    nZ = -dR
+    norm = np.sqrt(nR**2 + nZ**2)
+    norm = np.where(norm == 0.0, 1.0, norm)
+    nR = nR / norm
+    nZ = nZ / norm
+    Rc = float(np.mean(R_base))
+    Zc = float(np.mean(Z_base))
+    outward = (R_base - Rc) * nR + (Z_base - Zc) * nZ
+    flip = np.where(outward < 0.0, -1.0, 1.0)
+    nR = nR * flip
+    nZ = nZ * flip
+    R_off = R_base + boundary_offset * nR
+    Z_off = Z_base + boundary_offset * nZ
+
+    theta_ext = np.concatenate([theta_base, [2.0 * np.pi]])
+    R_ext = np.concatenate([R_off, [R_off[0]]])
+    Z_ext = np.concatenate([Z_off, [Z_off[0]]])
+
+    def curve(t: np.ndarray) -> np.ndarray:
+        tt = np.asarray(t, dtype=float)
+        th = np.mod(tt, 2.0 * np.pi)
+        R = np.interp(th, theta_ext, R_ext)
+        Zc = np.interp(th, theta_ext, Z_ext)
+        return np.array([R, Zc])
+
+    return curve
+
+
+def _vmec_arc_curve(
+    geom,
+    s_boundary: float,
+    phi_val: float,
+    *,
+    boundary_offset: float,
+    use_asym: bool,
+):
+    theta_base = np.linspace(0.0, 2.0 * np.pi, 4096, endpoint=False, dtype=float)
+    try:
+        from shapely.geometry import Polygon
+    except Exception as exc:  # pragma: no cover
+        raise ImportError(
+            "boundary_offset requires shapely; install libneo with the 'chartmap' extra"
+        ) from exc
+
+    R_base, Z_base, _ = geom.coords_s(float(s_boundary), theta_base, phi_val, use_asym=use_asym)
+    poly = Polygon(np.column_stack([R_base, Z_base]))
+    if not poly.is_valid:
+        poly = poly.buffer(0.0)
+    if poly.is_empty:
+        raise ValueError("invalid VMEC boundary polygon for buffering")
+
+    if boundary_offset == 0.0:
+        off = poly
+    else:
+        off = poly.buffer(boundary_offset, join_style=1)
+        if off.is_empty:
+            raise ValueError("boundary_offset produced empty geometry")
+        if off.geom_type != "Polygon":
+            off = max(list(off.geoms), key=lambda g: g.area)
+
+    coords = np.asarray(off.exterior.coords, dtype=float)
+    coords_open = coords[:-1, :]
+    i0 = int(np.argmax(coords_open[:, 0]))
+    coords_open = np.vstack([coords_open[i0:, :], coords_open[:i0, :]])
+    if coords_open.shape[0] >= 2 and coords_open[1, 1] - coords_open[0, 1] < 0.0:
+        coords_open = coords_open[::-1, :]
+    coords = np.vstack([coords_open, coords_open[0, :]])
+    seg = np.sqrt(np.sum((coords[1:] - coords[:-1]) ** 2, axis=1))
+    s_coords = np.concatenate(([0.0], np.cumsum(seg)))
+    length = float(s_coords[-1])
+    if length == 0.0:
+        raise ValueError("buffered boundary has zero length")
+
+    def curve(t: np.ndarray) -> np.ndarray:
+        tt = np.asarray(t, dtype=float)
+        u = (tt % (2.0 * np.pi)) / (2.0 * np.pi)
+        s_query = u * length
+        R = np.interp(s_query, s_coords, coords[:, 0])
+        Zc = np.interp(s_query, s_coords, coords[:, 1])
+        return np.array([R, Zc])
+
+    return curve
+
+
+def _vmec_boundary_curve(
+    geom,
+    s_boundary: float,
+    phi_val: float,
+    *,
+    boundary_offset: float,
+    boundary_param: str,
+    use_asym: bool,
+):
+    if boundary_param == "theta":
+        return _vmec_theta_curve(
+            geom,
+            s_boundary,
+            phi_val,
+            boundary_offset=boundary_offset,
+            use_asym=use_asym,
+        )
+    return _vmec_arc_curve(
+        geom,
+        s_boundary,
+        phi_val,
+        boundary_offset=boundary_offset,
+        use_asym=use_asym,
+    )
+
+
 def _as_path(path: str | Path) -> Path:
     p = Path(path)
     if not p:
@@ -82,14 +219,12 @@ def write_chartmap_from_vmec_boundary(
     out = _as_path(out_path)
 
     boundary_offset = float(boundary_offset)
-    boundary_param = str(boundary_param).strip().lower()
+    boundary_param = _normalize_boundary_param(boundary_param)
 
     if not (0.0 < float(s_boundary) <= 1.0):
         raise ValueError("s_boundary must be in (0, 1]")
     if boundary_offset < 0.0:
         raise ValueError("boundary_offset must be >= 0")
-    if boundary_param not in ("arc", "theta"):
-        raise ValueError("boundary_param must be 'arc' or 'theta'")
 
     geom = VMECGeometry.from_file(str(wout))
 
@@ -109,88 +244,14 @@ def write_chartmap_from_vmec_boundary(
 
     for iz, phi in enumerate(grid.zeta):
         phi_val = float(phi)
-
-        if boundary_param == "theta":
-            if boundary_offset != 0.0:
-                theta_base = np.linspace(0.0, 2.0 * np.pi, 4096, endpoint=False, dtype=float)
-                R_base, Z_base, _ = geom.coords_s(float(s_boundary), theta_base, phi_val, use_asym=use_asym)
-                dR = np.gradient(R_base, theta_base, edge_order=2)
-                dZ = np.gradient(Z_base, theta_base, edge_order=2)
-                nR = dZ
-                nZ = -dR
-                norm = np.sqrt(nR**2 + nZ**2)
-                norm = np.where(norm == 0.0, 1.0, norm)
-                nR = nR / norm
-                nZ = nZ / norm
-                Rc = float(np.mean(R_base))
-                Zc = float(np.mean(Z_base))
-                outward = (R_base - Rc) * nR + (Z_base - Zc) * nZ
-                flip = np.where(outward < 0.0, -1.0, 1.0)
-                nR = nR * flip
-                nZ = nZ * flip
-                R_off = R_base + boundary_offset * nR
-                Z_off = Z_base + boundary_offset * nZ
-
-                theta_ext = np.concatenate([theta_base, [2.0 * np.pi]])
-                R_ext = np.concatenate([R_off, [R_off[0]]])
-                Z_ext = np.concatenate([Z_off, [Z_off[0]]])
-
-                def curve(t: np.ndarray) -> np.ndarray:
-                    tt = np.asarray(t, dtype=float)
-                    th = np.mod(tt, 2.0 * np.pi)
-                    R = np.interp(th, theta_ext, R_ext)
-                    Zc = np.interp(th, theta_ext, Z_ext)
-                    return np.array([R, Zc])
-            else:
-                def curve(t: np.ndarray) -> np.ndarray:
-                    th = np.asarray(t, dtype=float)
-                    R, Zc, _ = geom.coords_s(float(s_boundary), th, phi_val, use_asym=use_asym)
-                    return np.array([R, Zc])
-        else:
-            theta_base = np.linspace(0.0, 2.0 * np.pi, 4096, endpoint=False, dtype=float)
-            try:
-                from shapely.geometry import Polygon
-            except Exception as exc:  # pragma: no cover
-                raise ImportError(
-                    "boundary_offset requires shapely; install libneo with the 'chartmap' extra"
-                ) from exc
-
-            R_base, Z_base, _ = geom.coords_s(float(s_boundary), theta_base, phi_val, use_asym=use_asym)
-            poly = Polygon(np.column_stack([R_base, Z_base]))
-            if not poly.is_valid:
-                poly = poly.buffer(0.0)
-            if poly.is_empty:
-                raise ValueError("invalid VMEC boundary polygon for buffering")
-
-            if boundary_offset == 0.0:
-                off = poly
-            else:
-                off = poly.buffer(boundary_offset, join_style=1)
-                if off.is_empty:
-                    raise ValueError("boundary_offset produced empty geometry")
-                if off.geom_type != "Polygon":
-                    off = max(list(off.geoms), key=lambda g: g.area)
-
-            coords = np.asarray(off.exterior.coords, dtype=float)
-            coords_open = coords[:-1, :]
-            i0 = int(np.argmax(coords_open[:, 0]))
-            coords_open = np.vstack([coords_open[i0:, :], coords_open[:i0, :]])
-            if coords_open.shape[0] >= 2 and coords_open[1, 1] - coords_open[0, 1] < 0.0:
-                coords_open = coords_open[::-1, :]
-            coords = np.vstack([coords_open, coords_open[0, :]])
-            seg = np.sqrt(np.sum((coords[1:] - coords[:-1]) ** 2, axis=1))
-            s_coords = np.concatenate(([0.0], np.cumsum(seg)))
-            length = float(s_coords[-1])
-            if length == 0.0:
-                raise ValueError("buffered boundary has zero length")
-
-            def curve(t: np.ndarray) -> np.ndarray:
-                tt = np.asarray(t, dtype=float)
-                u = (tt % (2.0 * np.pi)) / (2.0 * np.pi)
-                s_query = u * length
-                R = np.interp(s_query, s_coords, coords[:, 0])
-                Zc = np.interp(s_query, s_coords, coords[:, 1])
-                return np.array([R, Zc])
+        curve = _vmec_boundary_curve(
+            geom,
+            float(s_boundary),
+            phi_val,
+            boundary_offset=boundary_offset,
+            boundary_param=boundary_param,
+            use_asym=use_asym,
+        )
 
         bcm = m2d.BoundaryConformingMapping(curve=curve, M=int(M), Nt=int(Nt), Ng=Ng)
         bcm.solve_domain2disk()
@@ -212,6 +273,182 @@ def write_chartmap_from_vmec_boundary(
         z_rtz=z,
         zeta_convention="cyl",
         rho_convention="unknown",
+    )
+
+
+def _cubic_hermite(t: np.ndarray, p0: np.ndarray, m0: np.ndarray, p1: np.ndarray, m1: np.ndarray) -> np.ndarray:
+    """
+    Cubic Hermite interpolation.
+
+    Given endpoints p0, p1 and tangents m0, m1 (scaled by interval width),
+    evaluate the cubic Hermite spline at parameter t in [0, 1].
+
+    H(t) = (2t³ - 3t² + 1)·p0 + (t³ - 2t² + t)·m0 + (-2t³ + 3t²)·p1 + (t³ - t²)·m1
+    """
+    t = np.asarray(t, dtype=float)
+    t2 = t * t
+    t3 = t2 * t
+    h00 = 2.0 * t3 - 3.0 * t2 + 1.0
+    h10 = t3 - 2.0 * t2 + t
+    h01 = -2.0 * t3 + 3.0 * t2
+    h11 = t3 - t2
+    return h00 * p0 + h10 * m0 + h01 * p1 + h11 * m1
+
+
+def write_chartmap_from_vmec_extended(
+    wout_path: str | Path,
+    out_path: str | Path,
+    *,
+    nrho: int = 33,
+    ntheta: int = 65,
+    nzeta: int = 33,
+    nrho_vmec: int | None = None,
+    rho_lcfs: float | None = None,
+    boundary_offset: float = 0.1,
+    num_field_periods: int | None = None,
+    use_asym: bool = True,
+) -> None:
+    """
+    Generate a chartmap NetCDF using VMEC coordinates with cubic Hermite extension.
+
+    This mode uses exact VMEC flux coordinates inside the LCFS and extends beyond
+    using cubic Hermite interpolation along coordinate line tangents. This provides
+    C1 continuity at the LCFS boundary, suitable for symplectic integrators.
+
+    Parameters
+    ----------
+    wout_path : path to VMEC wout NetCDF file
+    out_path : output chartmap NetCDF path
+    nrho : total number of radial grid points
+    ntheta : number of poloidal grid points
+    nzeta : number of toroidal grid points
+    nrho_vmec : number of radial points inside LCFS (alternative to rho_lcfs)
+    rho_lcfs : radial location of LCFS in [0, 1] (alternative to nrho_vmec)
+    boundary_offset : distance beyond LCFS in meters for outer boundary
+    num_field_periods : override nfp from wout file
+    use_asym : include asymmetric Fourier terms if available
+
+    Grid structure
+    --------------
+    - rho in [0, 1] with nrho points
+    - For rho <= rho_lcfs: VMEC coordinates with s = (rho / rho_lcfs)^2
+    - For rho > rho_lcfs: cubic Hermite extrapolation from LCFS tangent
+
+    The cubic Hermite spline matches position and first derivative at the LCFS,
+    providing C1 continuity. At the outer boundary, the tangent points radially
+    outward to ensure smooth coordinate lines.
+    """
+    from netCDF4 import Dataset
+
+    from .vmec import VMECGeometry
+
+    wout = _as_path(wout_path)
+    out = _as_path(out_path)
+
+    boundary_offset = float(boundary_offset)
+    if boundary_offset <= 0.0:
+        raise ValueError("boundary_offset must be > 0 for extended mode")
+
+    if nrho_vmec is not None and rho_lcfs is not None:
+        raise ValueError("provide only one of nrho_vmec or rho_lcfs")
+    if nrho_vmec is None and rho_lcfs is None:
+        nrho_vmec = max(2, int(0.8 * nrho))
+
+    geom = VMECGeometry.from_file(str(wout))
+
+    if num_field_periods is None:
+        with Dataset(wout, "r") as ds:
+            if "nfp" not in ds.variables:
+                raise ValueError("wout file missing nfp variable")
+            nfp = int(np.array(ds.variables["nfp"][...]))
+    else:
+        nfp = int(num_field_periods)
+
+    grid = _build_grid(nrho=nrho, ntheta=ntheta, nzeta=nzeta, num_field_periods=nfp)
+
+    if nrho_vmec is not None:
+        nrho_vmec = int(nrho_vmec)
+        if nrho_vmec < 2 or nrho_vmec >= grid.rho.size:
+            raise ValueError("nrho_vmec must be in [2, nrho-1]")
+        ir_lcfs = nrho_vmec - 1
+        rho_lcfs_val = float(grid.rho[ir_lcfs])
+    else:
+        assert rho_lcfs is not None
+        rho_lcfs_val = float(rho_lcfs)
+        if not (0.0 < rho_lcfs_val < 1.0):
+            raise ValueError("rho_lcfs must be in (0, 1)")
+        ir_lcfs = int(np.searchsorted(grid.rho, rho_lcfs_val, side="right") - 1)
+        if ir_lcfs < 1 or ir_lcfs >= grid.rho.size - 1:
+            raise ValueError("rho_lcfs must leave room for extended region")
+        rho_lcfs_val = float(grid.rho[ir_lcfs])
+
+    x = np.zeros((grid.rho.size, grid.theta.size, grid.zeta.size), dtype=np.float64)
+    y = np.zeros_like(x)
+    z = np.zeros_like(x)
+
+    for iz, phi in enumerate(grid.zeta):
+        phi_val = float(phi)
+
+        R_lcfs, Z_lcfs, dR_ds, dZ_ds = geom.coords_s_with_deriv(
+            1.0, grid.theta, phi_val, use_asym=use_asym
+        )
+
+        outward_norm = np.sqrt(dR_ds**2 + dZ_ds**2)
+        outward_norm = np.where(outward_norm == 0.0, 1.0, outward_norm)
+        outward_R = dR_ds / outward_norm
+        outward_Z = dZ_ds / outward_norm
+
+        R_outer = R_lcfs + boundary_offset * outward_R
+        Z_outer = Z_lcfs + boundary_offset * outward_Z
+
+        ds_drho_at_lcfs = 2.0 / rho_lcfs_val
+        drho_dt = 1.0 - rho_lcfs_val
+        m0_R = dR_ds * ds_drho_at_lcfs * drho_dt
+        m0_Z = dZ_ds * ds_drho_at_lcfs * drho_dt
+
+        m1_R = outward_R * boundary_offset
+        m1_Z = outward_Z * boundary_offset
+
+        for ir in range(ir_lcfs + 1):
+            rho_val = grid.rho[ir]
+            s_val = (float(rho_val) / rho_lcfs_val) ** 2
+            R_in, Z_in, _ = geom.coords_s(s_val, grid.theta, phi_val, use_asym=use_asym)
+            x[ir, :, iz] = R_in * np.cos(phi_val) * 100.0
+            y[ir, :, iz] = R_in * np.sin(phi_val) * 100.0
+            z[ir, :, iz] = Z_in * 100.0
+
+        n_outer = grid.rho.size - ir_lcfs - 1
+        if n_outer > 0:
+            rho_outer = grid.rho[ir_lcfs + 1:]
+            t_param = (rho_outer - rho_lcfs_val) / (1.0 - rho_lcfs_val)
+
+            for ith in range(grid.theta.size):
+                R_interp = _cubic_hermite(
+                    t_param,
+                    R_lcfs[ith],
+                    m0_R[ith],
+                    R_outer[ith],
+                    m1_R[ith],
+                )
+                Z_interp = _cubic_hermite(
+                    t_param,
+                    Z_lcfs[ith],
+                    m0_Z[ith],
+                    Z_outer[ith],
+                    m1_Z[ith],
+                )
+                x[ir_lcfs + 1:, ith, iz] = R_interp * np.cos(phi_val) * 100.0
+                y[ir_lcfs + 1:, ith, iz] = R_interp * np.sin(phi_val) * 100.0
+                z[ir_lcfs + 1:, ith, iz] = Z_interp * 100.0
+
+    write_chartmap_netcdf(
+        out,
+        grid=grid,
+        x_rtz=x,
+        y_rtz=y,
+        z_rtz=z,
+        zeta_convention="cyl",
+        rho_convention="vmec_extended",
     )
 
 

--- a/python/tests/test_chartmap_vmec_extended.py
+++ b/python/tests/test_chartmap_vmec_extended.py
@@ -1,0 +1,335 @@
+"""Tests for VMEC chartmap with cubic Hermite extension beyond LCFS."""
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.request import urlopen
+
+import numpy as np
+import pytest
+
+
+def _download(url: str, out_path: Path) -> None:
+    with urlopen(url, timeout=60) as resp, open(out_path, "wb") as f:
+        f.write(resp.read())
+
+
+def _figure_path(name: str) -> Path:
+    repo_root = Path(__file__).resolve().parents[2]
+    target = repo_root / "build" / "test" / "python"
+    target.mkdir(parents=True, exist_ok=True)
+    return target / name
+
+
+def _plot_vmec_extended_grid(
+    chartmap_path: Path,
+    wout_path: Path,
+    out_path: Path,
+    ir_lcfs: int,
+    izeta: int = 0,
+) -> None:
+    """Plot R,Z grid showing VMEC interior (blue) and Hermite extension (orange)."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.lines import Line2D
+    from netCDF4 import Dataset
+
+    from libneo.vmec import VMECGeometry
+
+    with Dataset(chartmap_path, "r") as ds:
+        rho_grid = np.array(ds.variables["rho"][:], dtype=float)
+        theta_grid = np.array(ds.variables["theta"][:], dtype=float)
+        zeta_grid = np.array(ds.variables["zeta"][:], dtype=float)
+        x = np.array(ds.variables["x"][:], dtype=float)
+        y = np.array(ds.variables["y"][:], dtype=float)
+        z = np.array(ds.variables["z"][:], dtype=float)
+        units = str(getattr(ds.variables["x"], "units", "cm")).strip().lower()
+        scale = 0.01 if units == "cm" else 1.0
+
+    R = np.sqrt((x * scale) ** 2 + (y * scale) ** 2)
+    Z = z * scale
+
+    geom = VMECGeometry.from_file(str(wout_path))
+
+    fig, ax = plt.subplots(figsize=(8.0, 8.0))
+
+    zeta = float(zeta_grid[izeta])
+    nrho = len(rho_grid)
+    ntheta = len(theta_grid)
+
+    for ir in range(nrho):
+        color = "C0" if ir <= ir_lcfs else "C1"
+        lw = 1.5 if ir == ir_lcfs else 0.6
+        r_ring = R[izeta, :, ir]
+        z_ring = Z[izeta, :, ir]
+        ax.plot(
+            np.r_[r_ring, r_ring[0]],
+            np.r_[z_ring, z_ring[0]],
+            color=color,
+            linewidth=lw,
+            alpha=0.9 if ir == ir_lcfs else 0.7,
+        )
+
+    for ith in range(0, ntheta, max(1, ntheta // 24)):
+        ax.plot(
+            R[izeta, ith, : ir_lcfs + 1],
+            Z[izeta, ith, : ir_lcfs + 1],
+            color="C0",
+            linewidth=0.4,
+            alpha=0.5,
+        )
+        ax.plot(
+            R[izeta, ith, ir_lcfs:],
+            Z[izeta, ith, ir_lcfs:],
+            color="C1",
+            linewidth=0.4,
+            alpha=0.5,
+        )
+
+    theta_dense = np.linspace(0.0, 2.0 * np.pi, 256, endpoint=False)
+    R_lcfs, Z_lcfs, _ = geom.coords_s(1.0, theta_dense, zeta, use_asym=True)
+    ax.plot(R_lcfs, Z_lcfs, "k--", linewidth=1.0, label="VMEC LCFS")
+
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel("R [m]")
+    ax.set_ylabel("Z [m]")
+    ax.set_title(f"VMEC + cubic Hermite extension (zeta={zeta:.3f})")
+
+    legend_elements = [
+        Line2D([0], [0], color="C0", linewidth=2, label="VMEC region"),
+        Line2D([0], [0], color="C1", linewidth=2, label="Hermite extension"),
+        Line2D([0], [0], color="k", linewidth=1, linestyle="--", label="VMEC LCFS"),
+    ]
+    ax.legend(handles=legend_elements, loc="upper right")
+
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=160)
+    plt.close(fig)
+
+
+def _plot_derivative_continuity(
+    chartmap_path: Path,
+    out_path: Path,
+    ir_lcfs: int,
+    izeta: int = 0,
+) -> None:
+    """Plot dR/drho and dZ/drho to verify C1 continuity at LCFS."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from netCDF4 import Dataset
+
+    with Dataset(chartmap_path, "r") as ds:
+        rho_grid = np.array(ds.variables["rho"][:], dtype=float)
+        x = np.array(ds.variables["x"][:], dtype=float)
+        y = np.array(ds.variables["y"][:], dtype=float)
+        z = np.array(ds.variables["z"][:], dtype=float)
+        units = str(getattr(ds.variables["x"], "units", "cm")).strip().lower()
+        scale = 0.01 if units == "cm" else 1.0
+
+    R = np.sqrt((x * scale) ** 2 + (y * scale) ** 2)
+    Z = z * scale
+
+    ith_sample = R.shape[1] // 4
+
+    R_line = R[izeta, ith_sample, :]
+    Z_line = Z[izeta, ith_sample, :]
+
+    dR_drho = np.gradient(R_line, rho_grid)
+    dZ_drho = np.gradient(Z_line, rho_grid)
+
+    fig, axes = plt.subplots(2, 2, figsize=(10, 8))
+
+    axes[0, 0].plot(rho_grid, R_line, "b-", linewidth=1.5)
+    axes[0, 0].axvline(rho_grid[ir_lcfs], color="k", linestyle="--", alpha=0.5)
+    axes[0, 0].set_xlabel("rho")
+    axes[0, 0].set_ylabel("R [m]")
+    axes[0, 0].set_title("R vs rho")
+
+    axes[0, 1].plot(rho_grid, Z_line, "b-", linewidth=1.5)
+    axes[0, 1].axvline(rho_grid[ir_lcfs], color="k", linestyle="--", alpha=0.5)
+    axes[0, 1].set_xlabel("rho")
+    axes[0, 1].set_ylabel("Z [m]")
+    axes[0, 1].set_title("Z vs rho")
+
+    axes[1, 0].plot(rho_grid, dR_drho, "r-", linewidth=1.5)
+    axes[1, 0].axvline(rho_grid[ir_lcfs], color="k", linestyle="--", alpha=0.5)
+    axes[1, 0].set_xlabel("rho")
+    axes[1, 0].set_ylabel("dR/drho [m]")
+    axes[1, 0].set_title("dR/drho (should be continuous at LCFS)")
+
+    axes[1, 1].plot(rho_grid, dZ_drho, "r-", linewidth=1.5)
+    axes[1, 1].axvline(rho_grid[ir_lcfs], color="k", linestyle="--", alpha=0.5)
+    axes[1, 1].set_xlabel("rho")
+    axes[1, 1].set_ylabel("dZ/drho [m]")
+    axes[1, 1].set_title("dZ/drho (should be continuous at LCFS)")
+
+    fig.suptitle(f"Derivative continuity check (theta index={ith_sample})")
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=160)
+    plt.close(fig)
+
+
+@pytest.mark.network
+def test_chartmap_vmec_extended_real_wout(tmp_path: Path) -> None:
+    """Test VMEC extended mode with real NCSX data and visual verification."""
+    from netCDF4 import Dataset
+
+    from libneo.chartmap import write_chartmap_from_vmec_extended
+    from libneo.vmec import VMECGeometry
+
+    wout_url = (
+        "https://princetonuniversity.github.io/STELLOPT/examples/wout_ncsx_c09r00_fixed.nc"
+    )
+    wout = tmp_path / "wout_ncsx.nc"
+    _download(wout_url, wout)
+
+    nrho = 33
+    nrho_vmec = 25
+    ntheta = 65
+    nzeta = 9
+    boundary_offset = 0.15
+
+    chartmap = tmp_path / "chartmap_vmec_extended.nc"
+    write_chartmap_from_vmec_extended(
+        wout,
+        chartmap,
+        nrho=nrho,
+        ntheta=ntheta,
+        nzeta=nzeta,
+        nrho_vmec=nrho_vmec,
+        boundary_offset=boundary_offset,
+    )
+
+    geom = VMECGeometry.from_file(str(wout))
+
+    with Dataset(chartmap, "r") as ds:
+        rho_grid = np.array(ds.variables["rho"][:], dtype=float)
+        theta_grid = np.array(ds.variables["theta"][:], dtype=float)
+        zeta_grid = np.array(ds.variables["zeta"][:], dtype=float)
+        x = np.array(ds.variables["x"][:], dtype=float)
+        y = np.array(ds.variables["y"][:], dtype=float)
+        z = np.array(ds.variables["z"][:], dtype=float)
+        rho_conv = str(ds.getncattr("rho_convention"))
+        units = str(getattr(ds.variables["x"], "units", "cm")).strip().lower()
+        scale = 0.01 if units == "cm" else 1.0
+
+    assert rho_conv == "vmec_extended"
+
+    R = np.sqrt((x * scale) ** 2 + (y * scale) ** 2)
+    Z = z * scale
+
+    ir_lcfs = nrho_vmec - 1
+    rho_lcfs = rho_grid[ir_lcfs]
+
+    for iz in [0, len(zeta_grid) // 2]:
+        zeta = float(zeta_grid[iz])
+        theta = theta_grid
+
+        for ir in range(ir_lcfs + 1):
+            rho_val = rho_grid[ir]
+            s_val = (float(rho_val) / rho_lcfs) ** 2
+            R_vmec, Z_vmec, _ = geom.coords_s(s_val, theta, zeta, use_asym=True)
+            assert np.allclose(R_vmec, R[iz, :, ir], rtol=0.0, atol=1.0e-6), (
+                f"VMEC region mismatch at iz={iz}, ir={ir}"
+            )
+            assert np.allclose(Z_vmec, Z[iz, :, ir], rtol=0.0, atol=1.0e-6), (
+                f"VMEC region mismatch at iz={iz}, ir={ir}"
+            )
+
+    R_lcfs_stored = R[0, :, ir_lcfs]
+    R_outer_stored = R[0, :, -1]
+    mean_extension = float(np.mean(np.abs(R_outer_stored - R_lcfs_stored)))
+    assert mean_extension > 0.05, f"Extension too small: {mean_extension:.3f} m"
+    assert mean_extension < 0.5, f"Extension too large: {mean_extension:.3f} m"
+
+    _plot_vmec_extended_grid(
+        chartmap,
+        wout,
+        _figure_path("chartmap_vmec_extended_ncsx.png"),
+        ir_lcfs=ir_lcfs,
+        izeta=0,
+    )
+    _plot_vmec_extended_grid(
+        chartmap,
+        wout,
+        _figure_path("chartmap_vmec_extended_ncsx_phi2.png"),
+        ir_lcfs=ir_lcfs,
+        izeta=len(zeta_grid) // 2,
+    )
+    _plot_derivative_continuity(
+        chartmap,
+        _figure_path("chartmap_vmec_extended_derivatives.png"),
+        ir_lcfs=ir_lcfs,
+        izeta=0,
+    )
+
+
+@pytest.mark.network
+def test_chartmap_vmec_extended_c1_continuity(tmp_path: Path) -> None:
+    """Test that derivatives are continuous at LCFS (C1 continuity)."""
+    from netCDF4 import Dataset
+
+    from libneo.chartmap import write_chartmap_from_vmec_extended
+
+    wout_url = (
+        "https://princetonuniversity.github.io/STELLOPT/examples/wout_ncsx_c09r00_fixed.nc"
+    )
+    wout = tmp_path / "wout_ncsx.nc"
+    _download(wout_url, wout)
+
+    nrho = 65
+    nrho_vmec = 49
+    ntheta = 65
+    nzeta = 5
+
+    chartmap = tmp_path / "chartmap_continuity.nc"
+    write_chartmap_from_vmec_extended(
+        wout,
+        chartmap,
+        nrho=nrho,
+        ntheta=ntheta,
+        nzeta=nzeta,
+        nrho_vmec=nrho_vmec,
+        boundary_offset=0.12,
+    )
+
+    with Dataset(chartmap, "r") as ds:
+        rho_grid = np.array(ds.variables["rho"][:], dtype=float)
+        x = np.array(ds.variables["x"][:], dtype=float)
+        y = np.array(ds.variables["y"][:], dtype=float)
+        z = np.array(ds.variables["z"][:], dtype=float)
+        units = str(getattr(ds.variables["x"], "units", "cm")).strip().lower()
+        scale = 0.01 if units == "cm" else 1.0
+
+    R = np.sqrt((x * scale) ** 2 + (y * scale) ** 2)
+    Z = z * scale
+
+    ir_lcfs = nrho_vmec - 1
+
+    for iz in range(Z.shape[0]):
+        for ith in range(0, Z.shape[1], 8):
+            R_line = R[iz, ith, :]
+            Z_line = Z[iz, ith, :]
+
+            dR_drho = np.gradient(R_line, rho_grid)
+            dZ_drho = np.gradient(Z_line, rho_grid)
+
+            dR_jump = abs(dR_drho[ir_lcfs + 1] - dR_drho[ir_lcfs])
+            dZ_jump = abs(dZ_drho[ir_lcfs + 1] - dZ_drho[ir_lcfs])
+
+            dR_scale = max(abs(dR_drho[ir_lcfs]), abs(dR_drho[ir_lcfs + 1]), 0.01)
+            dZ_scale = max(abs(dZ_drho[ir_lcfs]), abs(dZ_drho[ir_lcfs + 1]), 0.01)
+
+            assert dR_jump / dR_scale < 2.0, (
+                f"dR/drho discontinuity at iz={iz}, ith={ith}: jump={dR_jump:.4f}, "
+                f"scale={dR_scale:.4f}, ratio={dR_jump/dR_scale:.2f}"
+            )
+            assert dZ_jump / dZ_scale < 2.0, (
+                f"dZ/drho discontinuity at iz={iz}, ith={ith}: jump={dZ_jump:.4f}, "
+                f"scale={dZ_scale:.4f}, ratio={dZ_jump/dZ_scale:.2f}"
+            )


### PR DESCRIPTION
### **User description**
Scope:
- Add VMEC-extended chartmap generation mode with cubic Hermite extrapolation beyond LCFS.
- Add CLI support and pytest coverage.

Notes:
- Stacked on #240.


___

### **PR Type**
Enhancement


___

### **Description**
- Add VMEC-extended chartmap mode with cubic Hermite extrapolation beyond LCFS
  - Provides C1 continuity at boundary without map2disc dependency
  - Suitable for symplectic integrators

- Implement cubic Hermite interpolation for smooth coordinate extension
  - Matches position and first derivative at LCFS boundary

- Add radial derivative computation to VMECGeometry for tangent-based extrapolation

- Add CLI support with from-vmec-extended subcommand and flexible boundary specification

- Comprehensive test coverage with real NCSX data and visual verification plots


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VMEC wout file"] -->|VMECGeometry| B["Exact VMEC coords<br/>inside LCFS"]
  A -->|coords_s_with_deriv| C["Radial derivatives<br/>at LCFS"]
  B --> D["Cubic Hermite<br/>interpolation"]
  C --> D
  D --> E["Extended region<br/>beyond LCFS"]
  B --> F["Chartmap NetCDF<br/>rho_convention=vmec_extended"]
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chartmap.py</strong><dd><code>Add cubic Hermite extended chartmap generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/libneo/chartmap.py

<ul><li>Extract boundary curve generation into helper functions <br><code>_vmec_theta_curve()</code> and <code>_vmec_arc_curve()</code> for code reuse<br> <li> Add <code>_normalize_boundary_param()</code> validation function<br> <li> Implement <code>_cubic_hermite()</code> for cubic Hermite spline evaluation<br> <li> Add <code>write_chartmap_from_vmec_extended()</code> function generating chartmaps <br>with exact VMEC inside LCFS and Hermite extension beyond<br> <li> Support flexible LCFS specification via <code>nrho_vmec</code> or <code>rho_lcfs</code> <br>parameters<br> <li> Refactor <code>write_chartmap_from_vmec_boundary()</code> to use extracted helper <br>functions</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/241/files#diff-c3d4918ce80f043ea1bbbc8328d3775412e5b287cbed6d765f46f0a36211049d">+322/-85</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vmec.py</strong><dd><code>Add radial derivative computation for VMEC coordinates</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/libneo/vmec.py

<ul><li>Add <code>ns</code> property returning number of radial surfaces<br> <li> Add <code>_s_grid()</code> method computing normalized toroidal flux grid from VMEC <br>data<br> <li> Implement <code>coords_s_with_deriv()</code> method computing R, Z coordinates and <br>radial derivatives using second-order finite differences<br> <li> Handle boundary cases (s=0, s=1) with forward/backward differences</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/241/files#diff-8f352eb1a99dacff1a04ff0b299addff1a45dd48982fec81d479bc2d67e5ac08">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chartmap_cli.py</strong><dd><code>Add CLI support for VMEC extended chartmap mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/libneo/chartmap_cli.py

<ul><li>Import <code>write_chartmap_from_vmec_extended</code> function<br> <li> Add <code>from-vmec-extended</code> subcommand to argument parser<br> <li> Support <code>--nrho-vmec</code> and <code>--rho-lcfs</code> options for flexible LCFS <br>specification<br> <li> Add <code>--boundary-offset</code> parameter for extension distance control<br> <li> Implement command dispatch for extended mode in main function</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/241/files#diff-faad55bf12b0c5feeaebc1e3ba8316e861b54b9f7029b69fe4aa2d8f2d57a8be">+46/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_chartmap_vmec_extended.py</strong><dd><code>Add VMEC extended mode tests with visual verification</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/tests/test_chartmap_vmec_extended.py

<ul><li>Add comprehensive test suite with real NCSX wout file (network-marked <br>tests)<br> <li> Implement <code>test_chartmap_vmec_extended_real_wout()</code> validating grid <br>generation and VMEC region accuracy<br> <li> Implement <code>test_chartmap_vmec_extended_c1_continuity()</code> verifying <br>derivative continuity at LCFS<br> <li> Add visualization helpers <code>_plot_vmec_extended_grid()</code> and <br><code>_plot_derivative_continuity()</code> for manual verification<br> <li> Verify extension magnitude and VMEC region coordinate matching</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/241/files#diff-ca79da7fce145f46372f7e6d50e223756bc8d316f7d05043f6e1959c881f65d8">+335/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document VMEC extended chartmap CLI usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add documentation section for VMEC extended chartmap mode<br> <li> Include CLI usage example with parameter descriptions<br> <li> Explain C1 continuity property and suitability for symplectic <br>integrators<br> <li> Note elimination of map2disc dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/241/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

