### PR TITLE
feat: explicit STL units (mm/m) for chartmap wall tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ VMEC extended to STL wall boundary (no map2disc dependency, C1 continuous):
     libneo-write-chartmap from-vmec-to-wall wout.nc wall.stl wout.chartmap.nc \
         --rho-lcfs 0.8 --nrho 33 --ntheta 65 --nzeta 33
 
+STL unit handling:
+- STL has no unit metadata; libneo assumes **meters** by default.
+- For engineer CAD STLs in **mm**, pass `--stl-units mm` (or `--stl-scale 1e-3`).
+
 This mode combines VMEC coordinates inside the LCFS with linear interpolation
 to a wall boundary extracted from an STL file. The radial coordinate `rho` ranges from
 0 to 1, where `rho <= rho_lcfs` corresponds to VMEC surfaces (with `s = (rho/rho_lcfs)^2`)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
+norecursedirs =
+    build
+    build_*
+    .venv
 markers =
     network: tests that download data from the internet

--- a/python/libneo/chartmap.py
+++ b/python/libneo/chartmap.py
@@ -974,6 +974,8 @@ def write_chartmap_from_vmec_and_stl(
     rho_lcfs: float | None = None,
     n_boundary_points: int = 512,
     stitch_tol: float = 1.0e-6,
+    stl_units: str | None = None,
+    stl_scale: float = 1.0,
     num_field_periods: int | None = None,
     use_asym: bool = True,
 ) -> None:
@@ -1022,6 +1024,8 @@ def write_chartmap_from_vmec_and_stl(
         n_boundary_points=n_boundary_points,
         stitch_tol=stitch_tol,
         phi_vals=phi_vals,
+        stl_units=stl_units,
+        stl_scale=stl_scale,
     )
 
     wall_rz = []
@@ -1252,6 +1256,8 @@ def write_chartmap_from_stl(
     num_field_periods: int = 1,
     n_boundary_points: int = 512,
     stitch_tol: float = 1.0e-6,
+    stl_units: str | None = None,
+    stl_scale: float = 1.0,
     M: int = 16,
     Nt: int = 256,
     Ng: tuple[int, int] = (256, 256),
@@ -1279,6 +1285,8 @@ def write_chartmap_from_stl(
         axis_xy=axis_xy,
         stitch_tol=float(stitch_tol),
         phi_vals=phi_vals,
+        stl_units=stl_units,
+        stl_scale=stl_scale,
     )
     _write_from_slices(
         slices,

--- a/python/libneo/chartmap_cli.py
+++ b/python/libneo/chartmap_cli.py
@@ -49,6 +49,8 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     p_stl.add_argument("--M", type=int, default=16)
     p_stl.add_argument("--Nt", type=int, default=256)
     p_stl.add_argument("--Ng", type=int, nargs=2, default=(256, 256))
+    p_stl.add_argument("--stl-units", choices=["m", "mm"], default=None)
+    p_stl.add_argument("--stl-scale", type=float, default=1.0)
 
     p_ext = sub.add_parser(
         "from-vmec-extended",
@@ -105,6 +107,8 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         default=1.0e-6,
         help="Tolerance for stitching open contours",
     )
+    p_wall.add_argument("--stl-units", choices=["m", "mm"], default=None)
+    p_wall.add_argument("--stl-scale", type=float, default=1.0)
     p_wall.add_argument("--num-field-periods", type=int)
 
     return p.parse_args(argv)
@@ -147,6 +151,8 @@ def main(argv: list[str] | None = None) -> int:
             num_field_periods=int(args.num_field_periods),
             n_boundary_points=int(args.n_boundary_points),
             stitch_tol=float(args.stitch_tol),
+            stl_units=None if args.stl_units is None else str(args.stl_units),
+            stl_scale=float(args.stl_scale),
             M=int(args.M),
             Nt=int(args.Nt),
             Ng=(int(args.Ng[0]), int(args.Ng[1])),
@@ -178,6 +184,8 @@ def main(argv: list[str] | None = None) -> int:
             rho_lcfs=None if args.rho_lcfs is None else float(args.rho_lcfs),
             n_boundary_points=int(args.n_boundary_points),
             stitch_tol=float(args.stitch_tol),
+            stl_units=None if args.stl_units is None else str(args.stl_units),
+            stl_scale=float(args.stl_scale),
             num_field_periods=None if args.num_field_periods is None else int(args.num_field_periods),
         )
         return 0


### PR DESCRIPTION
### **User description**
Implements `#248` (explicit STL unit handling for wall/chartmap workflows).

## Changes
- Adds `--stl-units {m,mm}` (and `--stl-scale`) to STL boundary slicing + chartmap CLIs.
- Propagates STL scaling through chartmap generators so the wall boundary is consistent.
- Documents unit behavior in README.

## Evidence
- `make test`: `100% tests passed, 0 tests failed out of 71` (log: `/tmp/libneo_make_test.log`).
- `pytest python/tests -q`: `29 passed, 1 skipped` (log: `/tmp/libneo_pytest_python_tests.log`).
- `pytest test/python -q`: `38 passed, 9 skipped` (log: `/tmp/libneo_pytest_test_python.log`).


___

### **PR Type**
Enhancement


___

### **Description**
- Add `--stl-units` and `--stl-scale` parameters to chartmap and STL boundary tools

- Support explicit STL unit handling (meters/millimeters) with automatic scaling

- Propagate STL scaling through boundary extraction and visualization functions

- Add test coverage for STL unit conversion and update pytest configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Arguments<br/>--stl-units/--stl-scale"]
  CHARTMAP["Chartmap Functions<br/>write_chartmap_from_stl<br/>write_chartmap_from_vmec_and_stl"]
  EXTRACT["extract_boundary_slices<br/>STL Scaling Logic"]
  PLOT["plot_mesh_3d<br/>Visualization"]
  CLI -- "passes parameters" --> CHARTMAP
  CHARTMAP -- "forwards to" --> EXTRACT
  EXTRACT -- "applies scaling" --> PLOT
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chartmap.py</strong><dd><code>Add STL unit parameters to chartmap functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/libneo/chartmap.py

<ul><li>Add <code>stl_units</code> and <code>stl_scale</code> parameters to <br><code>write_chartmap_from_vmec_and_stl()</code> function<br> <li> Add <code>stl_units</code> and <code>stl_scale</code> parameters to <code>write_chartmap_from_stl()</code> <br>function<br> <li> Forward these parameters to <code>extract_boundary_slices()</code> calls</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/249/files#diff-c3d4918ce80f043ea1bbbc8328d3775412e5b287cbed6d765f46f0a36211049d">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chartmap_cli.py</strong><dd><code>Add STL unit CLI arguments to chartmap commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/libneo/chartmap_cli.py

<ul><li>Add <code>--stl-units</code> (choices: m, mm) and <code>--stl-scale</code> CLI arguments to both <br><code>from-stl</code> and <code>from-vmec-to-wall</code> subcommands<br> <li> Pass parsed arguments to corresponding chartmap functions with proper <br>type conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/249/files#diff-faad55bf12b0c5feeaebc1e3ba8316e861b54b9f7029b69fe4aa2d8f2d57a8be">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stl_boundary.py</strong><dd><code>Implement STL scaling in boundary extraction and visualization</code></dd></summary>
<hr>

python/libneo/stl_boundary.py

<ul><li>Implement STL unit conversion logic in <code>extract_boundary_slices()</code> with <br>validation (m/mm units or custom scale)<br> <li> Apply mesh scaling using <code>trimesh.apply_scale()</code> when units or scale <br>factor provided<br> <li> Add <code>stl_scale</code> parameter to <code>plot_mesh_3d()</code> function and apply scaling <br>to mesh before visualization<br> <li> Add <code>--stl-units</code> and <code>--stl-scale</code> CLI arguments to stl_boundary command<br> <li> Forward parameters through main() function to <br>extract_boundary_slices() and plot_mesh_3d()</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/249/files#diff-56156ce2a1a0b0249656f6757892a00025e8f07eb5dd18c2294ab2e5a71fc9d2">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_stl_boundary.py</strong><dd><code>Add test for STL unit conversion functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/tests/test_stl_boundary.py

<ul><li>Add <code>test_extract_boundary_slices_stl_units_mm()</code> test that verifies STL <br>unit conversion<br> <li> Test creates torus meshes in both meters and millimeters, extracts <br>boundaries with unit conversion, and validates numerical equivalence</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/249/files#diff-c807fb052b8116de01bde644a3ccf96282ec7a48f36caa3bf94d8311ee2e9c89">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document STL unit handling in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add documentation section explaining STL unit handling behavior<br> <li> Document default assumption of meters and provide examples for <br>millimeter CAD files<br> <li> Show usage of <code>--stl-units mm</code> and <code>--stl-scale 1e-3</code> options</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/249/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pytest.ini</strong><dd><code>Configure pytest to skip build directories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pytest.ini

<ul><li>Add <code>norecursedirs</code> configuration to exclude build directories and <br>virtual environments from test discovery</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/249/files#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

