### PR TITLE
Fix/conditional dependency build

### DIFF
--- a/cmake/BuildExternalDependencies.cmake
+++ b/cmake/BuildExternalDependencies.cmake
@@ -45,6 +45,7 @@ function(build_hdf5)
         SOURCE_DIR ${DEPS_SOURCE_DIR}/hdf5
         BINARY_DIR ${DEPS_BUILD_DIR}/hdf5
         INSTALL_DIR ${DEPS_PREFIX}
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
         CMAKE_ARGS
             ${COMMON_CMAKE_ARGS}
             -DHDF5_BUILD_FORTRAN=ON
@@ -68,12 +69,25 @@ function(build_hdf5)
 
     # Create imported targets that the main build can use
     # HDF5 creates separate C stub libraries for Fortran bindings
-    add_library(hdf5::hdf5 STATIC IMPORTED GLOBAL)
-    add_library(hdf5::hdf5_hl STATIC IMPORTED GLOBAL)
-    add_library(hdf5::hdf5_f90cstub STATIC IMPORTED GLOBAL)
-    add_library(hdf5::hdf5_hl_f90cstub STATIC IMPORTED GLOBAL)
-    add_library(hdf5::hdf5_fortran STATIC IMPORTED GLOBAL)
-    add_library(hdf5::hdf5_hl_fortran STATIC IMPORTED GLOBAL)
+    # Use if(NOT TARGET) guards in case find_package already created these targets
+    if(NOT TARGET hdf5::hdf5)
+        add_library(hdf5::hdf5 STATIC IMPORTED GLOBAL)
+    endif()
+    if(NOT TARGET hdf5::hdf5_hl)
+        add_library(hdf5::hdf5_hl STATIC IMPORTED GLOBAL)
+    endif()
+    if(NOT TARGET hdf5::hdf5_f90cstub)
+        add_library(hdf5::hdf5_f90cstub STATIC IMPORTED GLOBAL)
+    endif()
+    if(NOT TARGET hdf5::hdf5_hl_f90cstub)
+        add_library(hdf5::hdf5_hl_f90cstub STATIC IMPORTED GLOBAL)
+    endif()
+    if(NOT TARGET hdf5::hdf5_fortran)
+        add_library(hdf5::hdf5_fortran STATIC IMPORTED GLOBAL)
+    endif()
+    if(NOT TARGET hdf5::hdf5_hl_fortran)
+        add_library(hdf5::hdf5_hl_fortran STATIC IMPORTED GLOBAL)
+    endif()
 
     # For static linking, specify all dependencies explicitly to ensure correct link order
     set_target_properties(hdf5::hdf5 PROPERTIES
@@ -218,6 +232,7 @@ function(build_fftw)
         SOURCE_DIR ${DEPS_SOURCE_DIR}/fftw
         BINARY_DIR ${DEPS_BUILD_DIR}/fftw
         INSTALL_DIR ${DEPS_PREFIX}
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
         CMAKE_ARGS
             ${COMMON_CMAKE_ARGS}
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Only build external dependencies that are actually needed
  - Wrap build_hdf5(), build_netcdf_c(), build_netcdf_fortran(), and build_fftw() calls with conditional checks for NEED_BUILD_* variables
  - Prevents CMake errors when system libraries are available but only some dependencies need building

- Add robustness guards to HDF5 imported target creation
  - Wrap each add_library() call with if(NOT TARGET) checks to prevent duplicate target errors

- Add DOWNLOAD_EXTRACT_TIMESTAMP to external project downloads
  - Silence CMP0135 policy warnings in HDF5 and FFTW ExternalProject_Add calls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["build_all_external_dependencies"] --> B["Check NEED_BUILD_HDF5"]
  B -->|TRUE| C["build_hdf5"]
  B -->|FALSE| D["Skip HDF5"]
  A --> E["Check NEED_BUILD_NETCDF"]
  E -->|TRUE| F["build_netcdf_c + build_netcdf_fortran"]
  E -->|FALSE| G["Skip NetCDF"]
  A --> H["Check NEED_BUILD_FFTW"]
  H -->|TRUE| I["build_fftw"]
  H -->|FALSE| J["Skip FFTW"]
  C --> K["if NOT TARGET guards on add_library"]
  F --> K
  I --> K
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BuildExternalDependencies.cmake</strong><dd><code>Conditional dependency building with target creation guards</code></dd></summary>
<hr>

cmake/BuildExternalDependencies.cmake

<ul><li>Wrap build_hdf5(), build_netcdf_c(), build_netcdf_fortran(), and <br>build_fftw() function calls with conditional checks for NEED_BUILD_* <br>variables to only build dependencies that are actually needed<br> <li> Add if(NOT TARGET) guards around all six HDF5 imported target creation <br>calls to prevent duplicate target errors when find_package already <br>created them<br> <li> Add DOWNLOAD_EXTRACT_TIMESTAMP TRUE parameter to HDF5 and FFTW <br>ExternalProject_Add calls to silence CMP0135 policy warnings<br> <li> Update function comment to clarify that only needed dependencies are <br>built</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/250/files#diff-b0d15be593dde084c33e0f5f54bf3dd7f1df52d9aefd0d9c685c1c0bcf287b4d">+32/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

