### PR TITLE
fix: make cyl_to_geoflux consistent with cached forward transform

### DIFF
--- a/src/coordinates/libneo_coordinates_geoflux.f90
+++ b/src/coordinates/libneo_coordinates_geoflux.f90
@@ -1,5 +1,6 @@
 submodule (libneo_coordinates) libneo_coordinates_geoflux
-    use geoflux_coordinates, only: geoflux_to_cyl, assign_geoflux_to_cyl_jacobian
+    use geoflux_coordinates, only: geoflux_to_cyl, assign_geoflux_to_cyl_jacobian, &
+                                   cyl_to_geoflux
     use cylindrical_cartesian, only: cyl_to_cart
     implicit none
 
@@ -116,7 +117,11 @@ contains
         real(dp), intent(out) :: u(3)
         integer, intent(out) :: ierr
 
-        error stop "geoflux_from_cyl: not implemented"
+        associate(unused => self)
+        end associate
+
+        call cyl_to_geoflux(xcyl, u)
+        ierr = 0
     end subroutine geoflux_from_cyl
 
 end submodule libneo_coordinates_geoflux


### PR DESCRIPTION
### **User description**
## Summary
- Add `invert_cached_surface()` which uses Newton-Raphson iteration to find (s, θ) such that the cache interpolation maps back to a given (R, Z) point
- Modify `cyl_to_geoflux` and `cyl_to_geoflux_internal` to use cache-consistent inversion when cache is built
- Implement `geoflux_from_cyl` in the OOP interface to use the module's `cyl_to_geoflux`

## Problem
The `cyl_to_geoflux` function was using direct psi evaluation while `geoflux_to_cyl` uses bilinear interpolation in the (s, θ) → (R, Z) cache. This caused roundtrip inconsistency because bilinear interpolation of (R, Z) between flux surface points gives points that are NOT on any flux surface (due to surface curvature).

## Solution
When the cache is built, the inverse transformation now uses Newton-Raphson iteration to find the exact (s, θ) that maps through the cache interpolation to the given (R, Z) point. This makes the forward and inverse transformations mathematically consistent.

## Test plan
- [x] All existing tests pass (74/74)
- [x] geoflux tests pass


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add Newton-Raphson iteration for cache-consistent inverse transformation

- Implement `invert_cached_surface()` to find (s, θ) from (R, Z) coordinates

- Modify `cyl_to_geoflux` and `cyl_to_geoflux_internal` to use cache inversion

- Implement `geoflux_from_cyl` in OOP interface using module function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["(R, Z) input"] --> B["Cache built?"]
  B -->|Yes| C["invert_cached_surface<br/>Newton-Raphson iteration"]
  B -->|No| D["Direct psi evaluation"]
  C --> E["(s, θ) output"]
  D --> E
  F["geoflux_from_cyl<br/>OOP interface"] --> G["cyl_to_geoflux<br/>module function"]
  G --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>geoflux_coordinates.f90</strong><dd><code>Add cache-consistent inverse transformation with Newton-Raphson</code></dd></summary>
<hr>

src/coordinates/geoflux_coordinates.f90

<ul><li>Add <code>invert_cached_surface()</code> subroutine using Newton-Raphson iteration <br>with finite differences<br> <li> Modify <code>cyl_to_geoflux()</code> to use cache-consistent inversion when cache <br>is built<br> <li> Modify <code>cyl_to_geoflux_internal()</code> to use cache-consistent inversion <br>when cache is built<br> <li> Fallback to direct psi evaluation when cache is not available</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/252/files#diff-70924d6b77d3bbff0e7be5213577fafc24f33b13b97d22b889c85a3041dc5c13">+61/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>libneo_coordinates_geoflux.f90</strong><dd><code>Implement geoflux_from_cyl OOP interface method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coordinates/libneo_coordinates_geoflux.f90

<ul><li>Import <code>cyl_to_geoflux</code> from <code>geoflux_coordinates</code> module<br> <li> Implement <code>geoflux_from_cyl()</code> subroutine using the module's <br><code>cyl_to_geoflux</code> function<br> <li> Replace error stop with functional implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/libneo/pull/252/files#diff-5019446ee0ae6a9997c3a8932e2aff2543ab8e0d1438cbd23b5561102d7faa32">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

