### PR TITLE
Fix golden-record odeint path after the src/odeint/ move

### DIFF
--- a/test/odeint/fetch_golden_record.sh
+++ b/test/odeint/fetch_golden_record.sh
@@ -23,9 +23,10 @@ echo "Latest tag: $LATEST_TAG"
 # Fetch only that tagged commit (no-op if already available locally)
 git fetch origin tag "$LATEST_TAG" --no-tags
 
-# Fetch the old implementation
+# Fetch the old implementation. odeint moved to src/odeint/ before v2026.04.13,
+# so read it from the current path (the old top-level path is gone from the tag).
 echo "Fetching odeint_allroutines.f90 from $LATEST_TAG..."
-git show "$LATEST_TAG:src/odeint_allroutines.f90" > "$GOLDEN_FILE"
+git show "$LATEST_TAG:src/odeint/odeint_allroutines.f90" > "$GOLDEN_FILE"
 
 # Rename modules to avoid conflicts
 echo "Adapting golden record for testing..."


### PR DESCRIPTION
The `build_test_golden_record_odeint` job on `main` was red. `fetch_golden_record.sh`
read `src/odeint_allroutines.f90` from the latest tag, but odeint moved to
`src/odeint/odeint_allroutines.f90` before v2026.04.13. The old top-level path is
gone from the tag, so `git show "$LATEST_TAG:src/odeint_allroutines.f90"` produced an
empty golden file and the regression comparison broke. This was the first `main.yml`
run since the move surfaced it.

One-line fix: read the post-move path. v2026.04.13 contains
`src/odeint/odeint_allroutines.f90`, and the module names still match the script's
seds, so the golden-record comparison keeps doing its job.

Split out of #278 so it can merge first and unbreak `main` independently of the
release-gate change.

## Verification

Failing before, on `main` (golden file empty, comparison fails):
```
$ git show v2026.04.13:src/odeint_allroutines.f90
fatal: path 'src/odeint_allroutines.f90' does not exist in 'v2026.04.13'
```

Passing after (post-move path exists in the tag):
```
$ git show v2026.04.13:src/odeint/odeint_allroutines.f90 | head -1
!> High-Performance ODE Integration Module
```

The identical commit on #278 turned `build_test_golden_record_odeint` green
(full CI: build+test, Sphinx docs, dashboard, Pages deploy). CI on this branch
is running.
