### PR TITLE
hdf5_tools: nvfortran-compatible complex dataset read

### DIFF
--- a/src/hdf5_tools/hdf5_tools.F90
+++ b/src/hdf5_tools/hdf5_tools.F90
@@ -1216,7 +1216,7 @@ contains
     integer(HID_T), intent(in)                     :: h5id
     character(len=*), intent(in)                   :: dataset
     complex(kind=dcp), dimension(:), intent(inout) :: val
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && (__GNUC__ < 9))
+#if defined(__INTEL_COMPILER) || defined(__NVCOMPILER) || defined(__PGI) || (defined(__GNUC__) && (__GNUC__ < 9))
     real(kind=dpp), allocatable, dimension(:)      :: temp_re, temp_im
 #endif
     integer                                        :: lb1, ub1
@@ -1265,7 +1265,7 @@ contains
     !**********************************************************
     call h5dopen_f(h5id, dataset, dset_id, h5error)
 
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && (__GNUC__ < 9))
+#if defined(__INTEL_COMPILER) || defined(__NVCOMPILER) || defined(__PGI) || (defined(__GNUC__) && (__GNUC__ < 9))
     if (allocated(temp_re)) deallocate(temp_re)
     if (allocated(temp_im)) deallocate(temp_im)
     allocate(temp_re(lbound(val,1):ubound(val,1)))
@@ -1295,7 +1295,7 @@ contains
     integer(HID_T), intent(in)                       :: h5id
     character(len=*), intent(in)                     :: dataset
     complex(kind=dcp), dimension(:,:), intent(inout) :: val
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && (__GNUC__ < 9))
+#if defined(__INTEL_COMPILER) || defined(__NVCOMPILER) || defined(__PGI) || (defined(__GNUC__) && (__GNUC__ < 9))
     real, allocatable, dimension(:,:) :: temp_re, temp_im
 #endif
     integer                                          :: lb1, ub1, lb2, ub2
@@ -1344,7 +1344,7 @@ contains
     !**********************************************************
     call h5dopen_f(h5id, dataset, dset_id, h5error)
 
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && (__GNUC__ < 9))
+#if defined(__INTEL_COMPILER) || defined(__NVCOMPILER) || defined(__PGI) || (defined(__GNUC__) && (__GNUC__ < 9))
     if (allocated(temp_re)) deallocate(temp_re)
     if (allocated(temp_im)) deallocate(temp_im)
     allocate(temp_re(lbound(val, 1):ubound(val, 1), &
@@ -1376,7 +1376,7 @@ contains
     integer(HID_T), intent(in)                         :: h5id
     character(len=*), intent(in)                       :: dataset
     complex(kind=dcp), dimension(:,:,:), intent(inout) :: val
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && (__GNUC__ < 9))
+#if defined(__INTEL_COMPILER) || defined(__NVCOMPILER) || defined(__PGI) || (defined(__GNUC__) && (__GNUC__ < 9))
     real(kind=dpp), allocatable, dimension(:,:,:) :: temp_re, temp_im
 #endif
     integer                                          :: lb1, ub1, lb2, ub2, lb3, ub3
@@ -1425,7 +1425,7 @@ contains
     !**********************************************************
     call h5dopen_f(h5id, dataset, dset_id, h5error)
 
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && (__GNUC__ < 9))
+#if defined(__INTEL_COMPILER) || defined(__NVCOMPILER) || defined(__PGI) || (defined(__GNUC__) && (__GNUC__ < 9))
     if (allocated(temp_re)) deallocate(temp_re)
     if (allocated(temp_im)) deallocate(temp_im)
     allocate(temp_re(lbound(val, 1):ubound(val, 1), &


### PR DESCRIPTION
## Summary

`nvfortran` cannot resolve the `h5dread_f` / `h5dwrite_f` generic interface when
the actual argument is an F2008 complex part designator of an array (`val%re`,
`val%im`). `hdf5_tools.F90` already has a real temp-array workaround guarded for
Intel and GCC < 9; this extends the same guard to NVHPC/PGI so the file compiles
with `nvfortran`.

No behavior change for existing compilers; the workaround path is the one Intel
already uses.

## Verification

Before (nvfortran 26.3):

```
NVFORTRAN-S-0155-Could not resolve generic procedure 'h5dread_f' (hdf5_tools.F90: 1443)
```

After: `hdf5_tools` compiles with `nvfortran 26.3`, and the full libneo +
SIMPLE stack builds. GCC and Intel builds are unaffected (guard unchanged for
them).
