### PR TITLE
interpolate: make batch spline evaluators acc routine seq

### DIFF
--- a/src/interpolate/batch_interpolate_1d.f90
+++ b/src/interpolate/batch_interpolate_1d.f90
@@ -724,6 +724,7 @@ contains
    end subroutine evaluate_batch_splines_1d_der
 
    recursive subroutine evaluate_batch_splines_1d_der2(spl, x, y_batch, dy_batch, d2y_batch)
+       !$acc routine seq
       type(BatchSplineData1D), intent(in) :: spl
       real(dp), intent(in) :: x
       real(dp), intent(out) :: y_batch(:), dy_batch(:), d2y_batch(:)
@@ -780,6 +781,7 @@ contains
 
    recursive subroutine evaluate_batch_splines_1d_der3(spl, x, y_batch, dy_batch, d2y_batch, &
                                              d3y_batch)
+       !$acc routine seq
       type(BatchSplineData1D), intent(in) :: spl
       real(dp), intent(in) :: x
       real(dp), intent(out) :: y_batch(:), dy_batch(:), d2y_batch(:), d3y_batch(:)

--- a/src/interpolate/batch_interpolate_3d.f90
+++ b/src/interpolate/batch_interpolate_3d.f90
@@ -1031,6 +1031,7 @@ contains
     end subroutine evaluate_batch_splines_3d_many_resident
 
     recursive subroutine evaluate_batch_splines_3d_many_der(spl, x, y_batch, dy_batch)
+        !$acc routine seq
         type(BatchSplineData3D), intent(in) :: spl
         real(dp), intent(in) :: x(:, :)           ! (3, npts)
         real(dp), intent(out) :: y_batch(:, :)    ! (nq, npts)
@@ -1065,6 +1066,7 @@ contains
     end subroutine evaluate_batch_splines_3d_many_der2
 
     recursive subroutine evaluate_batch_splines_3d_der(spl, x, y_batch, dy_batch)
+        !$acc routine seq
         type(BatchSplineData3D), intent(in) :: spl
         real(dp), intent(in) :: x(3)
         real(dp), intent(out) :: y_batch(:)     ! (n_quantities)
@@ -1081,6 +1083,7 @@ contains
     end subroutine evaluate_batch_splines_3d_der
 
     recursive subroutine evaluate_batch_splines_3d_der_core(spl, x, y_batch, dy_batch)
+        !$acc routine seq
         type(BatchSplineData3D), intent(in) :: spl
         real(dp), intent(in) :: x(3)
         real(dp), intent(out) :: y_batch(:)     ! (n_quantities)
@@ -1234,6 +1237,7 @@ contains
     end subroutine evaluate_batch_splines_3d_der_core
 
     recursive subroutine evaluate_batch_splines_3d_der2(spl, x, y_batch, dy_batch, d2y_batch)
+        !$acc routine seq
         type(BatchSplineData3D), intent(in) :: spl
         real(dp), intent(in) :: x(3)
         real(dp), intent(out) :: y_batch(:)      ! (n_quantities)
@@ -1478,6 +1482,7 @@ contains
 
     recursive subroutine evaluate_batch_splines_3d_der2_core(spl, x, y_batch, dy_batch, &
                                                    d2y_batch)
+        !$acc routine seq
         type(BatchSplineData3D), intent(in) :: spl
         real(dp), intent(in) :: x(3)
         real(dp), intent(out) :: y_batch(:)      ! (n_quantities)
@@ -1502,6 +1507,7 @@ contains
 
     recursive subroutine evaluate_batch_splines_3d_der2_core_nq1(spl, x, y_batch, &
                                                        dy_batch, d2y_batch)
+        !$acc routine seq
         type(BatchSplineData3D), intent(in) :: spl
         real(dp), intent(in) :: x(3)
         real(dp), intent(out) :: y_batch(:)      ! (n_quantities)
@@ -1953,6 +1959,7 @@ contains
 
     recursive subroutine evaluate_batch_splines_3d_der2_core_nq1_o555(spl, x, y_batch, &
                                                             dy_batch, d2y_batch)
+        !$acc routine seq
         type(BatchSplineData3D), intent(in) :: spl
         real(dp), intent(in) :: x(3)
         real(dp), intent(out) :: y_batch(:)      ! (n_quantities)
@@ -2011,6 +2018,7 @@ contains
 
     recursive subroutine evaluate_batch_splines_3d_der2_core_o555(spl, x, y_batch, dy_batch, &
                                                         d2y_batch)
+        !$acc routine seq
         type(BatchSplineData3D), intent(in) :: spl
         real(dp), intent(in) :: x(3)
         real(dp), intent(out) :: y_batch(:)      ! (n_quantities)
@@ -2072,6 +2080,7 @@ contains
 
     recursive subroutine evaluate_batch_splines_3d_der2_core_general(spl, x, y_batch, &
                                                            dy_batch, d2y_batch)
+        !$acc routine seq
         type(BatchSplineData3D), intent(in) :: spl
         real(dp), intent(in) :: x(3)
         real(dp), intent(out) :: y_batch(:)      ! (n_quantities)


### PR DESCRIPTION
## Summary

Add `!$acc routine seq` to the single-point batch spline evaluators (1D
`der2`/`der3`, 3D `der`/`der2`, and their `_core` variants) so they can be
called per particle from inside an OpenACC compute region. Pure arithmetic over
the managed coefficient array; no host-only I/O on these paths.

Enables per-particle GPU orbit tracing in SIMPLE. Stacked on #282 (managed
memory) and #280 (hdf5 nvfortran fix).

## Verification

A device-evaluation test in SIMPLE evaluates 4096 points inside an
`!$acc parallel loop` calling `evaluate_batch_splines_3d_der2` and matches the
host result bitwise:

```
max |host - device| (value+der+der2) = 0.0000E+00
PASSED: device batch spline evaluation matches host
```
