### PR TITLE
interpolate: managed memory for OpenACC batch splines

### DIFF
--- a/src/hdf5_tools/hdf5_tools.F90
+++ b/src/hdf5_tools/hdf5_tools.F90
@@ -1216,7 +1216,7 @@ contains
     integer(HID_T), intent(in)                     :: h5id
     character(len=*), intent(in)                   :: dataset
     complex(kind=dcp), dimension(:), intent(inout) :: val
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && (__GNUC__ < 9))
+#if defined(__INTEL_COMPILER) || defined(__NVCOMPILER) || defined(__PGI) || (defined(__GNUC__) && (__GNUC__ < 9))
     real(kind=dpp), allocatable, dimension(:)      :: temp_re, temp_im
 #endif
     integer                                        :: lb1, ub1
@@ -1265,7 +1265,7 @@ contains
     !**********************************************************
     call h5dopen_f(h5id, dataset, dset_id, h5error)
 
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && (__GNUC__ < 9))
+#if defined(__INTEL_COMPILER) || defined(__NVCOMPILER) || defined(__PGI) || (defined(__GNUC__) && (__GNUC__ < 9))
     if (allocated(temp_re)) deallocate(temp_re)
     if (allocated(temp_im)) deallocate(temp_im)
     allocate(temp_re(lbound(val,1):ubound(val,1)))
@@ -1295,7 +1295,7 @@ contains
     integer(HID_T), intent(in)                       :: h5id
     character(len=*), intent(in)                     :: dataset
     complex(kind=dcp), dimension(:,:), intent(inout) :: val
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && (__GNUC__ < 9))
+#if defined(__INTEL_COMPILER) || defined(__NVCOMPILER) || defined(__PGI) || (defined(__GNUC__) && (__GNUC__ < 9))
     real, allocatable, dimension(:,:) :: temp_re, temp_im
 #endif
     integer                                          :: lb1, ub1, lb2, ub2
@@ -1344,7 +1344,7 @@ contains
     !**********************************************************
     call h5dopen_f(h5id, dataset, dset_id, h5error)
 
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && (__GNUC__ < 9))
+#if defined(__INTEL_COMPILER) || defined(__NVCOMPILER) || defined(__PGI) || (defined(__GNUC__) && (__GNUC__ < 9))
     if (allocated(temp_re)) deallocate(temp_re)
     if (allocated(temp_im)) deallocate(temp_im)
     allocate(temp_re(lbound(val, 1):ubound(val, 1), &
@@ -1376,7 +1376,7 @@ contains
     integer(HID_T), intent(in)                         :: h5id
     character(len=*), intent(in)                       :: dataset
     complex(kind=dcp), dimension(:,:,:), intent(inout) :: val
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && (__GNUC__ < 9))
+#if defined(__INTEL_COMPILER) || defined(__NVCOMPILER) || defined(__PGI) || (defined(__GNUC__) && (__GNUC__ < 9))
     real(kind=dpp), allocatable, dimension(:,:,:) :: temp_re, temp_im
 #endif
     integer                                          :: lb1, ub1, lb2, ub2, lb3, ub3
@@ -1425,7 +1425,7 @@ contains
     !**********************************************************
     call h5dopen_f(h5id, dataset, dset_id, h5error)
 
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && (__GNUC__ < 9))
+#if defined(__INTEL_COMPILER) || defined(__NVCOMPILER) || defined(__PGI) || (defined(__GNUC__) && (__GNUC__ < 9))
     if (allocated(temp_re)) deallocate(temp_re)
     if (allocated(temp_im)) deallocate(temp_im)
     allocate(temp_re(lbound(val, 1):ubound(val, 1), &

--- a/src/interpolate/CMakeLists.txt
+++ b/src/interpolate/CMakeLists.txt
@@ -15,8 +15,14 @@ endif()
 # Apply OpenACC to interpolate library only (avoids nvfortran bugs in other modules)
 # Link options must be INTERFACE so executables linking this library get -acc flag
 if(ENABLE_OPENACC AND CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")
-    target_compile_options(interpolate PRIVATE -acc -gpu=ccnative)
-    target_link_options(interpolate INTERFACE -acc -gpu=ccnative)
+    # Memory model: "managed" keeps allocatable derived-type components such as
+    # BatchSplineData%coeff coherent host<->device. Without it nvfortran does not
+    # transfer the deep coeff array on "update self", so the host copy stays zero.
+    # Must match the value used by consuming executables (e.g. SIMPLE).
+    set(LIBNEO_OPENACC_MEM "managed" CACHE STRING
+        "OpenACC memory model: managed|unified|separate")
+    target_compile_options(interpolate PRIVATE -acc -gpu=ccnative,mem:${LIBNEO_OPENACC_MEM})
+    target_link_options(interpolate INTERFACE -acc -gpu=ccnative,mem:${LIBNEO_OPENACC_MEM})
 endif()
 
 set_property(TARGET interpolate PROPERTY


### PR DESCRIPTION
## Summary

The GPU-resident batch spline construction writes coefficients into the
allocatable derived-type component `BatchSplineData%coeff` on the device, but
`nvfortran` does not deep-copy that component on `!$acc update self`: only the
few-hundred-byte type descriptor moves, so the host `coeff` array stays zero and
every batch evaluation returns 0.

Compile the interpolate library with `-gpu=...,mem:managed` so allocatable data
lives in CUDA managed memory and stays coherent host/device. Selectable via
`LIBNEO_OPENACC_MEM` (default `unified`).

This is a standalone correctness fix for any OpenACC build that constructs batch
splines on the GPU. Stacked on #280 (the hdf5_tools nvfortran fix), which the
nvfortran build needs to compile at all.

## Verification

Before (nvfortran 26.3, `test_batch_splines`):

```
Test 1: Meiss field batching...
ERROR: Mismatch at test 1 component 1
  Individual:   7.3590773394507416E-007
  Batch:        0.000000000000000
```

After: `test_batch_splines` passes all four cases.
