### PR TITLE
Add Boozer refcoords detection coverage

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -500,8 +500,7 @@ add_test(NAME test_refcoords_file_detection
   COMMAND test_refcoords_file_detection.x)
 set_tests_properties(test_refcoords_file_detection PROPERTIES
   FAIL_REGULAR_EXPRESSION "STOP"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS "setup_vmec_wout;setup_chartmap_volume")
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_subdirectory(util_for_test)
 add_subdirectory(util_for_test_field)

--- a/test/source/test_refcoords_file_detection.f90
+++ b/test/source/test_refcoords_file_detection.f90
@@ -13,26 +13,51 @@ program test_refcoords_file_detection
 
     nerrors = 0
 
-    call detect_refcoords_file_type("chartmap.nc", file_type, ierr, message)
+    call write_good_chartmap_file("chartmap_refcoords.nc")
+    call detect_refcoords_file_type("chartmap_refcoords.nc", file_type, ierr, &
+                                    message)
     if (ierr /= 0) then
-        print *, "  FAIL: detect_refcoords_file_type(chartmap.nc): ", trim(message)
+        print *, "  FAIL: detect_refcoords_file_type(chartmap_refcoords.nc): ", &
+            trim(message)
         nerrors = nerrors + 1
     else if (file_type /= refcoords_file_chartmap) then
-        print *, "  FAIL: expected CHARTMAP file_type for chartmap.nc, got ", file_type
+        print *, &
+            "  FAIL: expected CHARTMAP file_type for chartmap_refcoords.nc, got ", &
+            file_type
         nerrors = nerrors + 1
     else
-        print *, "  PASS: chartmap.nc detected as CHARTMAP"
+        print *, "  PASS: chartmap_refcoords.nc detected as CHARTMAP"
     end if
 
-    call detect_refcoords_file_type("wout.nc", file_type, ierr, message)
+    call write_good_boozer_file("chartmap_refcoords_boozer.nc")
+    call detect_refcoords_file_type("chartmap_refcoords_boozer.nc", file_type, ierr, &
+                                    message)
     if (ierr /= 0) then
-        print *, "  FAIL: detect_refcoords_file_type(wout.nc): ", trim(message)
+        print *, "  FAIL: detect_refcoords_file_type(chartmap_refcoords_boozer.nc): ", &
+            trim(message)
         nerrors = nerrors + 1
-    else if (file_type /= refcoords_file_vmec_wout) then
-        print *, "  FAIL: expected VMEC_WOUT file_type for wout.nc, got ", file_type
+    else if (file_type /= refcoords_file_chartmap) then
+        print *, &
+            "  FAIL: expected CHARTMAP file_type for chartmap_refcoords_boozer.nc, got ", &
+            file_type
         nerrors = nerrors + 1
     else
-        print *, "  PASS: wout.nc detected as VMEC_WOUT"
+        print *, "  PASS: chartmap_refcoords_boozer.nc detected as CHARTMAP"
+    end if
+
+    call write_good_wout_file("wout_refcoords.nc")
+    call detect_refcoords_file_type("wout_refcoords.nc", file_type, ierr, message)
+    if (ierr /= 0) then
+        print *, "  FAIL: detect_refcoords_file_type(wout_refcoords.nc): ", &
+            trim(message)
+        nerrors = nerrors + 1
+    else if (file_type /= refcoords_file_vmec_wout) then
+        print *, &
+            "  FAIL: expected VMEC_WOUT file_type for wout_refcoords.nc, got ", &
+            file_type
+        nerrors = nerrors + 1
+    else
+        print *, "  PASS: wout_refcoords.nc detected as VMEC_WOUT"
     end if
 
     call write_invalid_chartmap_missing_convention("chartmap_missing_convention.nc")
@@ -123,5 +148,167 @@ contains
         call nc_check(nf90_put_var(ncid, var_num_field_periods, 1))
         call nc_check(nf90_close(ncid))
     end subroutine write_invalid_chartmap_missing_convention
+
+    subroutine write_good_chartmap_file(filename)
+        character(len=*), intent(in) :: filename
+
+        integer :: ncid
+        integer :: dim_rho, dim_theta, dim_zeta
+        integer :: var_rho, var_theta, var_zeta, var_x, var_y, var_z
+        integer :: var_num_field_periods
+        integer, parameter :: nrho = 3, ntheta = 4, nzeta = 5
+        real(dp) :: rho(nrho), theta(ntheta), zeta(nzeta)
+        real(dp) :: x(nrho, ntheta, nzeta), y(nrho, ntheta, nzeta), z(nrho, &
+                                                                      ntheta, nzeta)
+        real(dp) :: rho_val, theta_val, zeta_val, rmaj, zpos, period
+        integer :: i, ir, it, iz
+
+        period = TWOPI
+
+        do i = 1, nrho
+            rho(i) = real(i - 1, dp)/real(nrho - 1, dp)
+        end do
+        do i = 1, ntheta
+            theta(i) = TWOPI*real(i - 1, dp)/real(ntheta, dp)
+        end do
+        do i = 1, nzeta
+            zeta(i) = period*real(i - 1, dp)/real(nzeta, dp)
+        end do
+
+        do iz = 1, nzeta
+            zeta_val = zeta(iz)
+            do it = 1, ntheta
+                theta_val = theta(it)
+                do ir = 1, nrho
+                    rho_val = rho(ir)
+                    rmaj = 150.0_dp + 35.0_dp*rho_val*cos(theta_val)
+                    zpos = 35.0_dp*rho_val*sin(theta_val)
+
+                    x(ir, it, iz) = rmaj*cos(zeta_val)
+                    y(ir, it, iz) = rmaj*sin(zeta_val)
+                    z(ir, it, iz) = zpos
+                end do
+            end do
+        end do
+
+        call nc_check(nf90_create(trim(filename), NF90_NETCDF4, ncid))
+        call nc_check(nf90_put_att(ncid, NF90_GLOBAL, "zeta_convention", "cyl"))
+        call nc_check(nf90_def_dim(ncid, "rho", nrho, dim_rho))
+        call nc_check(nf90_def_dim(ncid, "theta", ntheta, dim_theta))
+        call nc_check(nf90_def_dim(ncid, "zeta", nzeta, dim_zeta))
+        call nc_check(nf90_def_var(ncid, "rho", NF90_DOUBLE, [dim_rho], var_rho))
+        call nc_check(nf90_def_var(ncid, "theta", NF90_DOUBLE, [dim_theta], var_theta))
+        call nc_check(nf90_def_var(ncid, "zeta", NF90_DOUBLE, [dim_zeta], var_zeta))
+        call nc_check(nf90_def_var(ncid, "x", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_x))
+        call nc_check(nf90_def_var(ncid, "y", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_y))
+        call nc_check(nf90_def_var(ncid, "z", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_z))
+        call nc_check(nf90_def_var(ncid, "num_field_periods", NF90_INT, &
+                                   var_num_field_periods))
+        call nc_check(nf90_put_att(ncid, var_x, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_y, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_z, "units", "cm"))
+        call nc_check(nf90_enddef(ncid))
+
+        call nc_check(nf90_put_var(ncid, var_rho, rho))
+        call nc_check(nf90_put_var(ncid, var_theta, theta))
+        call nc_check(nf90_put_var(ncid, var_zeta, zeta))
+        call nc_check(nf90_put_var(ncid, var_x, x))
+        call nc_check(nf90_put_var(ncid, var_y, y))
+        call nc_check(nf90_put_var(ncid, var_z, z))
+        call nc_check(nf90_put_var(ncid, var_num_field_periods, 1))
+        call nc_check(nf90_close(ncid))
+    end subroutine write_good_chartmap_file
+
+    subroutine write_good_wout_file(filename)
+        character(len=*), intent(in) :: filename
+
+        integer :: ncid
+        integer :: var_rmnc
+
+        call nc_check(nf90_create(trim(filename), NF90_NETCDF4, ncid))
+        call nc_check(nf90_def_var(ncid, "rmnc", NF90_DOUBLE, var_rmnc))
+        call nc_check(nf90_put_var(ncid, var_rmnc, 0.0_dp))
+        call nc_check(nf90_close(ncid))
+    end subroutine write_good_wout_file
+
+    subroutine write_good_boozer_file(filename)
+        character(len=*), intent(in) :: filename
+
+        integer :: ncid
+        integer :: dim_rho, dim_theta, dim_zeta
+        integer :: var_rho, var_theta, var_zeta, var_x, var_y, var_z
+        integer :: var_num_field_periods
+        integer, parameter :: nrho = 3, ntheta = 5, nzeta = 6, nfp = 2
+        real(dp) :: rho(nrho), theta(ntheta), zeta(nzeta)
+        real(dp) :: x(nrho, ntheta, nzeta), y(nrho, ntheta, nzeta), z(nrho, &
+                                                                      ntheta, nzeta)
+        real(dp) :: rho_val, theta_val, zeta_val, phi_geom, rmaj, zpos, period
+        integer :: i, ir, it, iz
+
+        period = TWOPI/real(nfp, dp)
+
+        do i = 1, nrho
+            rho(i) = real(i - 1, dp)/real(nrho - 1, dp)
+        end do
+        do i = 1, ntheta
+            theta(i) = TWOPI*real(i - 1, dp)/real(ntheta, dp)
+        end do
+        do i = 1, nzeta
+            zeta(i) = period*real(i - 1, dp)/real(nzeta, dp)
+        end do
+
+        do iz = 1, nzeta
+            zeta_val = zeta(iz)
+            do it = 1, ntheta
+                theta_val = theta(it)
+                do ir = 1, nrho
+                    rho_val = rho(ir)
+                    phi_geom = zeta_val + 0.08_dp*rho_val*sin(theta_val)
+                    rmaj = 150.0_dp + 35.0_dp*rho_val*cos(theta_val)
+                    zpos = 35.0_dp*rho_val*sin(theta_val)
+
+                    x(ir, it, iz) = rmaj*cos(phi_geom)
+                    y(ir, it, iz) = rmaj*sin(phi_geom)
+                    z(ir, it, iz) = zpos
+                end do
+            end do
+        end do
+
+        call nc_check(nf90_create(trim(filename), NF90_NETCDF4, ncid))
+        call nc_check(nf90_put_att(ncid, NF90_GLOBAL, "zeta_convention", "boozer"))
+        call nc_check(nf90_put_att(ncid, NF90_GLOBAL, "rho_convention", "rho_tor"))
+        call nc_check(nf90_put_att(ncid, NF90_GLOBAL, "boozer_field", 1))
+        call nc_check(nf90_put_att(ncid, NF90_GLOBAL, "rmajor", 150.0_dp))
+        call nc_check(nf90_def_dim(ncid, "rho", nrho, dim_rho))
+        call nc_check(nf90_def_dim(ncid, "theta", ntheta, dim_theta))
+        call nc_check(nf90_def_dim(ncid, "zeta", nzeta, dim_zeta))
+        call nc_check(nf90_def_var(ncid, "rho", NF90_DOUBLE, [dim_rho], var_rho))
+        call nc_check(nf90_def_var(ncid, "theta", NF90_DOUBLE, [dim_theta], var_theta))
+        call nc_check(nf90_def_var(ncid, "zeta", NF90_DOUBLE, [dim_zeta], var_zeta))
+        call nc_check(nf90_def_var(ncid, "x", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_x))
+        call nc_check(nf90_def_var(ncid, "y", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_y))
+        call nc_check(nf90_def_var(ncid, "z", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_z))
+        call nc_check(nf90_def_var(ncid, "num_field_periods", NF90_INT, &
+                                   var_num_field_periods))
+        call nc_check(nf90_put_att(ncid, var_x, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_y, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_z, "units", "cm"))
+        call nc_check(nf90_enddef(ncid))
+
+        call nc_check(nf90_put_var(ncid, var_rho, rho))
+        call nc_check(nf90_put_var(ncid, var_theta, theta))
+        call nc_check(nf90_put_var(ncid, var_zeta, zeta))
+        call nc_check(nf90_put_var(ncid, var_x, x))
+        call nc_check(nf90_put_var(ncid, var_y, y))
+        call nc_check(nf90_put_var(ncid, var_z, z))
+        call nc_check(nf90_put_var(ncid, var_num_field_periods, nfp))
+        call nc_check(nf90_close(ncid))
+    end subroutine write_good_boozer_file
 
 end program test_refcoords_file_detection


### PR DESCRIPTION
Self-contained regression coverage for refcoords file detection. Boozer chartmaps stay classified as chartmaps, and the detector no longer depends on external setup fixtures for this test.

## Verification
### Test fails on main
```sh
ctest -R test_refcoords_file_detection --output-on-failure
Test project /home/ert/code/libneo/build
    Start 50: test_refcoords_file_detection
1/1 Test #50: test_refcoords_file_detection ....***Failed  Error regular expression found in output. Regex=[STOP]  0.12 sec
   FAIL: detect_refcoords_file_type(chartmap.nc): open failed: No such file or directory
 FAILED:            1  error(s) detected in refcoords file detection
ERROR STOP 1
```
### Test passes after fix
```sh
ctest -R test_refcoords_file_detection --output-on-failure
Test project /home/ert/code/libneo/build
    Start 50: test_refcoords_file_detection
1/1 Test #50: test_refcoords_file_detection ....   Passed    0.08 sec

100% tests passed, 0 tests failed out of 1
```