### PR TITLE
Drop GSL dependency from collision_freqs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,6 @@ jobs:
             cmake \
             gfortran \
             libfftw3-dev \
-            libgsl-dev \
             libhdf5-dev \
             libnetcdf-dev \
             libnetcdff-dev \

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,6 @@
           pkgs.openblas
           pkgs.lapack
           pkgs.fftw
-          pkgs.gsl
           hdf5-merged
           pkgs.netcdf
           pkgs.netcdffortran
@@ -86,7 +85,6 @@
 
           packages = nativeDeps ++ buildDeps ++ [
             pkgs.fftw.dev
-            pkgs.gsl.dev
             pkgs.git
             python
           ];

--- a/setup/debian.sh
+++ b/setup/debian.sh
@@ -3,5 +3,5 @@
 # Install dependencies on Debian or Ubuntu systems
 apt-get update && apt-get install -y wget git cmake make gcc g++ gfortran \
     libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev libfftw3-dev \
-    python3 python3-pip python3-numpy python3-scipy ninja-build libgsl-dev \
+    python3 python3-pip python3-numpy python3-scipy ninja-build \
     libopenblas-dev

--- a/src/collisions/CMakeLists.txt
+++ b/src/collisions/CMakeLists.txt
@@ -1,15 +1,12 @@
 add_library(collision_freqs STATIC
     collision_freqs.f90)
 
-find_package(GSL REQUIRED)
-
 set_property(TARGET collision_freqs PROPERTY
     INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Fortran_MODULE_DIRECTORY})
 
 add_library(LIBNEO::collision_freqs ALIAS collision_freqs)
 
 target_link_libraries(collision_freqs PUBLIC
-    GSL::gsl
-    neo 
+    neo
     species
 )

--- a/src/collisions/collision_freqs.f90
+++ b/src/collisions/collision_freqs.f90
@@ -1,28 +1,9 @@
 module libneo_collisions
-   use, intrinsic :: iso_c_binding
    use libneo_species, only: species_t
 
    implicit none
 
    integer, parameter :: dp = kind(1.0d0)
-
-   interface
-      function gsl_sf_gamma(x) bind(c, name='gsl_sf_gamma')
-         import :: c_double
-         implicit none
-         real(c_double), value :: x
-         real(c_double) :: gsl_sf_gamma
-      end function gsl_sf_gamma
-   end interface
-
-   interface
-      function gsl_sf_gamma_inc_P(a, x) bind(c, name='gsl_sf_gamma_inc_P')
-         import :: c_double
-         implicit none
-         real(c_double), value :: a, x
-         real(c_double) :: gsl_sf_gamma_inc_P
-      end function gsl_sf_gamma_inc_P
-   end interface
 
 contains
 
@@ -153,10 +134,77 @@ contains
 
    end subroutine
 
-   function lower_incomplete_gamma(a, x) result(gamma)
-      real(dp), intent(in) :: a, x
-      real(dp) :: gamma
+   function lower_incomplete_gamma(a, x) result(inc_gamma)
+      ! regularized algorithms from DLMF 8.11.4 (series) and 8.9.2
+      ! (continued fraction); series converges fast for x < a + 1,
+      ! the continued fraction elsewhere
 
-      gamma = gsl_sf_gamma_inc_P(a, x)*gsl_sf_gamma(a)
+      real(dp), intent(in) :: a, x
+      real(dp) :: inc_gamma
+
+      if (a <= 0.0d0) stop "lower_incomplete_gamma: a must be positive"
+      if (x < 0.0d0) stop "lower_incomplete_gamma: x must be non-negative"
+
+      if (x == 0.0d0) then
+         inc_gamma = 0.0d0
+      else if (x < a + 1.0d0) then
+         inc_gamma = regularized_gamma_p_series(a, x)*gamma(a)
+      else
+         inc_gamma = (1.0d0 - regularized_gamma_q_contfrac(a, x))*gamma(a)
+      end if
    end function lower_incomplete_gamma
+
+   function regularized_gamma_p_series(a, x) result(p)
+      real(dp), intent(in) :: a, x
+      real(dp) :: p
+
+      integer, parameter :: max_iter = 500
+      real(dp) :: term, total
+      integer :: n
+
+      term = 1.0d0/a
+      total = term
+      do n = 1, max_iter
+         term = term*x/(a + n)
+         total = total + term
+         if (abs(term) < abs(total)*epsilon(1.0d0)) then
+            p = total*exp(-x + a*log(x) - log_gamma(a))
+            return
+         end if
+      end do
+      stop "lower_incomplete_gamma: series did not converge"
+   end function regularized_gamma_p_series
+
+   function regularized_gamma_q_contfrac(a, x) result(q)
+      ! modified Lentz evaluation of the continued fraction DLMF 8.9.2
+
+      real(dp), intent(in) :: a, x
+      real(dp) :: q
+
+      integer, parameter :: max_iter = 500
+      real(dp), parameter :: tiny_val = 1.0d-300
+      real(dp) :: b, c, d, h, an, del
+      integer :: n
+
+      b = x + 1.0d0 - a
+      c = 1.0d0/tiny_val
+      d = 1.0d0/max(b, tiny_val)
+      h = d
+      do n = 1, max_iter
+         an = -n*(n - a)
+         b = b + 2.0d0
+         d = an*d + b
+         if (abs(d) < tiny_val) d = tiny_val
+         c = b + an/c
+         if (abs(c) < tiny_val) c = tiny_val
+         d = 1.0d0/d
+         del = d*c
+         h = h*del
+         if (abs(del - 1.0d0) < epsilon(1.0d0)) then
+            q = h*exp(-x + a*log(x) - log_gamma(a))
+            return
+         end if
+      end do
+      stop "lower_incomplete_gamma: continued fraction did not converge"
+   end function regularized_gamma_q_contfrac
 end module

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,19 @@ target_link_libraries(test_collision_freqs.x
   util_for_test
 )
 
+find_package(GSL QUIET)
+if(GSL_FOUND)
+  add_executable(test_incomplete_gamma_gsl_oracle.x
+    collisions/test_incomplete_gamma_gsl_oracle.f90
+  )
+  target_link_libraries(test_incomplete_gamma_gsl_oracle.x
+    neo
+    collision_freqs
+    util_for_test
+    GSL::gsl
+  )
+endif()
+
 add_executable(test_arnoldi.x source/test_arnoldi.f90)
 target_link_libraries(test_arnoldi.x
   ${COMMON_LIBS}
@@ -210,6 +223,11 @@ add_test(NAME test_batch_interpolate_oracle COMMAND test_batch_interpolate_oracl
 add_test(NAME test_batch_eval_oracle COMMAND test_batch_eval_oracle.x)
 add_test(NAME test_spline_performance COMMAND test_spline_performance.x)
 add_test(NAME test_collision_freqs COMMAND test_collision_freqs.x)
+if(GSL_FOUND)
+  add_test(NAME test_incomplete_gamma_gsl_oracle
+    COMMAND test_incomplete_gamma_gsl_oracle.x
+  )
+endif()
 add_test(NAME test_transport COMMAND test_transport.x)
 add_test(NAME test_vmec_modules COMMAND test_vmec_modules.x)
 add_test(NAME test_coordinate_systems COMMAND test_coordinate_systems.x)

--- a/test/collisions/test_collision_freqs.f90
+++ b/test/collisions/test_collision_freqs.f90
@@ -2,11 +2,12 @@ program test_collision_freqs
 
     use libneo_kinds, only : dp
     use libneo_collisions, only: calc_perp_coll_freq_slow_limit_ee, calc_perp_coll_freq_fast_limit_ee, &
-        calc_coulomb_log, calc_perp_coll_freq
+        calc_coulomb_log, calc_perp_coll_freq, lower_incomplete_gamma
     use util_for_test, only: print_test, print_ok, print_fail
 
     implicit none
 
+    call test_lower_incomplete_gamma
     call test_calc_coulomb_log
     call test_calc_perp_coll_freq
     !call test_calc_perp_coll_freq_slow_limit
@@ -14,6 +15,60 @@ program test_collision_freqs
     call test_fill_species_arr_coulomb_log
 
     contains
+
+    subroutine test_lower_incomplete_gamma
+
+        ! reference values from mpmath.gammainc(a, 0, x) at 40 digits
+
+        implicit none
+
+        integer, parameter :: n = 32
+        real(dp), dimension(n), parameter :: a_ref = [ &
+            0.5d0, 0.5d0, 0.5d0, 0.5d0, 0.5d0, 0.5d0, 0.5d0, 0.5d0, &
+            1.5d0, 1.5d0, 1.5d0, 1.5d0, 1.5d0, 1.5d0, 1.5d0, 1.5d0, &
+            2.5d0, 2.5d0, 2.5d0, 2.5d0, 2.5d0, 2.5d0, 2.5d0, 2.5d0, &
+            5.0d0, 5.0d0, 5.0d0, 5.0d0, 5.0d0, 5.0d0, 5.0d0, 5.0d0]
+        real(dp), dimension(n), parameter :: x_ref = [ &
+            1.0d-6, 0.1d0, 0.5d0, 1.0d0, 2.0d0, 5.0d0, 10.0d0, 50.0d0, &
+            1.0d-6, 0.1d0, 0.5d0, 1.0d0, 2.0d0, 5.0d0, 10.0d0, 50.0d0, &
+            1.0d-6, 0.1d0, 0.5d0, 1.0d0, 2.0d0, 5.0d0, 10.0d0, 50.0d0, &
+            1.0d-6, 0.1d0, 0.5d0, 1.0d0, 2.0d0, 5.0d0, 10.0d0, 50.0d0]
+        real(dp), dimension(n), parameter :: g_ref = [ &
+            0.0019999993333335333d0, 0.61199136611177178d0, &
+            1.2100356193111089d0, 1.4936482656248541d0, &
+            1.6918067329451983d0, 1.7696792476451032d0, &
+            1.7724401246392806d0, 1.7724538509055160d0, &
+            6.6666626666680952d-10, 0.019860967741930695d0, &
+            0.17613586717520105d0, 0.37894469164098470d0, &
+            0.65451037345177732d0, 0.86977311630380579d0, &
+            0.88607649513597917d0, 0.88622692545275801d0, &
+            3.9999971428582540d-16, 0.0011779800815005226d0, &
+            0.049762829522624881d0, 0.20053759629003473d0, &
+            0.59897957413602228d0, 1.2293271368619796d0, &
+            1.3276790708673576d0, 1.3293403881791370d0, &
+            1.9999983333340476d-31, 1.8402724046854341d-6, &
+            0.0041307751189401787d0, 0.087836323856249096d0, &
+            1.2636724162490678d0, 13.428161158434902d0, &
+            23.297935486152934d0, 23.999999999999999d0]
+        real(dp), parameter :: rel_tol = 1.0d-12
+
+        real(dp) :: g
+        integer :: i
+
+        call print_test("test_lower_incomplete_gamma")
+
+        do i = 1, n
+            g = lower_incomplete_gamma(a_ref(i), x_ref(i))
+            if (abs(g - g_ref(i)) > rel_tol*g_ref(i)) then
+                call print_fail
+                print *, "a = ", a_ref(i), ", x = ", x_ref(i)
+                print *, "got ", g, ", expected ", g_ref(i)
+                stop "lower_incomplete_gamma deviates from reference"
+            end if
+        end do
+        call print_ok
+
+    end subroutine
 
     subroutine test_calc_coulomb_log
 

--- a/test/collisions/test_incomplete_gamma_gsl_oracle.f90
+++ b/test/collisions/test_incomplete_gamma_gsl_oracle.f90
@@ -1,0 +1,54 @@
+program test_incomplete_gamma_gsl_oracle
+
+    ! compares the in-tree lower_incomplete_gamma against GSL; built only
+    ! when GSL is available, so GSL stays a test oracle, not a dependency
+
+    use, intrinsic :: iso_c_binding, only: c_double
+    use libneo_kinds, only: dp
+    use libneo_collisions, only: lower_incomplete_gamma
+    use util_for_test, only: print_test, print_ok, print_fail
+
+    implicit none
+
+    interface
+        function gsl_sf_gamma(x) bind(c, name='gsl_sf_gamma')
+            import :: c_double
+            implicit none
+            real(c_double), value :: x
+            real(c_double) :: gsl_sf_gamma
+        end function gsl_sf_gamma
+    end interface
+
+    interface
+        function gsl_sf_gamma_inc_P(a, x) bind(c, name='gsl_sf_gamma_inc_P')
+            import :: c_double
+            implicit none
+            real(c_double), value :: a, x
+            real(c_double) :: gsl_sf_gamma_inc_P
+        end function gsl_sf_gamma_inc_P
+    end interface
+
+    integer, parameter :: n_a = 24, n_x = 81
+    real(dp), parameter :: rel_tol = 1.0d-12
+    real(dp) :: a, x, ours, oracle
+    integer :: i, j
+
+    call print_test("test_incomplete_gamma_gsl_oracle")
+
+    do i = 1, n_a
+        a = 0.25d0*i
+        do j = 1, n_x
+            x = 10.0d0**(-8.0d0 + 0.125d0*(j - 1))
+            ours = lower_incomplete_gamma(a, x)
+            oracle = gsl_sf_gamma_inc_P(a, x)*gsl_sf_gamma(a)
+            if (abs(ours - oracle) > rel_tol*oracle) then
+                call print_fail
+                print *, "a = ", a, ", x = ", x
+                print *, "got ", ours, ", GSL gives ", oracle
+                stop "lower_incomplete_gamma deviates from GSL"
+            end if
+        end do
+    end do
+    call print_ok
+
+end program test_incomplete_gamma_gsl_oracle


### PR DESCRIPTION
Closes #285.

`collision_freqs` linked GPLv3 GSL with `PUBLIC` visibility for one routine, the
lower incomplete gamma in the Chandrasekhar function. The GPL obligation reached
every MIT-licensed downstream consumer (SIMPLE, NEO-2, NEO-RT, MEPHIT, KAMEL,
rabe), including SIMPLE's published binary wheels.

Changes:

- `gsl_sf_gamma` replaced by the Fortran 2008 intrinsic `gamma()`.
- `gsl_sf_gamma_inc_P` replaced by an in-tree regularized lower incomplete
  gamma, written from scratch: DLMF 8.11.4 series for `x < a + 1`, DLMF 8.9.2
  continued fraction (modified Lentz) otherwise.
- `find_package(GSL REQUIRED)` and `GSL::gsl` removed from
  `src/collisions/CMakeLists.txt`; `libgsl-dev` removed from CI and
  `setup/debian.sh`; `gsl` removed from `flake.nix`.
- GSL stays as an optional test oracle: with `find_package(GSL QUIET)` found,
  `test_incomplete_gamma_gsl_oracle.x` compares the in-tree function against
  `gsl_sf_gamma_inc_P * gsl_sf_gamma` at 1944 points (`a` in [0.25, 6], `x` in
  [1e-8, 100]) with relative tolerance 1e-12. Without GSL the test is skipped
  and nothing links it.
- `test_collision_freqs.x` gains a reference-value test for
  `lower_incomplete_gamma` against 32 mpmath values (40-digit precision),
  relative tolerance 1e-12, so the function is verified on systems without GSL.

The existing `calc_perp_coll_freq` expected values, produced by the GSL-backed
implementation, pass unchanged.

## Verification

Before (main): configure without GSL fails.

```
$ cmake -S . -B build_nogsl -G Ninja -DCMAKE_DISABLE_FIND_PACKAGE_GSL=TRUE
CMake Error at src/collisions/CMakeLists.txt:4 (find_package):
  find_package for module GSL called with REQUIRED, but
  CMAKE_DISABLE_FIND_PACKAGE_GSL is enabled.  A REQUIRED package cannot be
  disabled.
```

After (this branch): same configuration succeeds, build and tests pass without
GSL.

```
$ cmake -S . -B build_nogsl -G Ninja -DCMAKE_DISABLE_FIND_PACKAGE_GSL=TRUE
configure exit: 0
$ ctest -R "collision|incomplete"
1/1 Test #19: test_collision_freqs .............   Passed    0.30 sec
100% tests passed, 0 tests failed out of 1
```

After, with GSL present (Homebrew GSL 2.8): oracle agrees with the in-tree
implementation.

```
$ ctest -R "collision|incomplete_gamma|transport" --output-on-failure
1/3 Test #19: test_collision_freqs ...............   Passed    0.28 sec
2/3 Test #20: test_incomplete_gamma_gsl_oracle ...   Passed    0.26 sec
3/3 Test #21: test_transport .....................   Passed    0.24 sec
100% tests passed, 0 tests failed out of 3
```

GSL appears on no link line except the optional oracle test:

```
$ rg -n "gsl" build.ninja | grep -v incomplete_gamma_gsl_oracle | grep LINK
(no output)
```

Full suite: 56/70 pass; the 14 failures (chartmap/map2disc, tilted_coil) fail
identically on unmodified `origin/main` in this environment (missing optional
`map2disc` Python module) and are unrelated to this change.
