### PR TITLE
Add rho^|m| near-axis regularization for VMEC harmonics

### DIFF
--- a/src/canonical_coordinates_mod.f90
+++ b/src/canonical_coordinates_mod.f90
@@ -28,8 +28,10 @@
     logical :: old_axis_healing_boundary = .True.
     ! rho**m power-law axis continuation below rho_axis_heal; enforces the
     ! analytic regularity c_m(rho) ~ rho**|m| at the axis and overrides the two
-    ! legacy flags above when .true.
-    logical :: axis_healing_power_law = .True.
+    ! legacy flags above when .true. Opt-in: consumers that need it (SIMPLE
+    ! near-axis symplectic tracing) enable it via namelist. Default keeps the
+    ! legacy healing so existing chartmap/field consumers are unchanged.
+    logical :: axis_healing_power_law = .False.
     double precision :: rho_axis_heal = 0.1d0
   end module new_vmec_stuff_mod
 !

--- a/src/canonical_coordinates_mod.f90
+++ b/src/canonical_coordinates_mod.f90
@@ -26,6 +26,11 @@
 
     logical :: old_axis_healing = .True.
     logical :: old_axis_healing_boundary = .True.
+    ! rho**m power-law axis continuation below rho_axis_heal; enforces the
+    ! analytic regularity c_m(rho) ~ rho**|m| at the axis and overrides the two
+    ! legacy flags above when .true.
+    logical :: axis_healing_power_law = .True.
+    double precision :: rho_axis_heal = 0.1d0
   end module new_vmec_stuff_mod
 !
   module vector_potentail_mod

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -178,16 +178,33 @@ contains
 
    subroutine perform_axis_healing(almnc_rho, rmnc_rho, zmnc_rho, almns_rho, rmns_rho, zmns_rho)
       use new_vmec_stuff_mod, only: rmnc, zmns, almns, rmns, zmnc, almnc, &
-                                    axm, axn, nstrm, old_axis_healing_boundary
+                                    axm, axn, nstrm, old_axis_healing_boundary, &
+                                    axis_healing_power_law
       use vector_potentail_mod, only: ns
 
       real(dp), dimension(:, :), allocatable, intent(out) :: almnc_rho, rmnc_rho, zmnc_rho
       real(dp), dimension(:, :), allocatable, intent(out) :: almns_rho, rmns_rho, zmns_rho
-      integer :: i, m, nrho, nheal, iunit_hs
+      integer :: i, m, nrho, nheal, iunit_hs, i_anchor
 
       nrho = ns
       allocate (almnc_rho(nstrm, 0:nrho - 1), rmnc_rho(nstrm, 0:nrho - 1), zmnc_rho(nstrm, 0:nrho - 1))
       allocate (almns_rho(nstrm, 0:nrho - 1), rmns_rho(nstrm, 0:nrho - 1), zmns_rho(nstrm, 0:nrho - 1))
+
+      if (axis_healing_power_law) then
+         i_anchor = axis_anchor_index(ns)
+         print *, 'VMEC axis healing: rho**m continuation below s = ', &
+            dble(i_anchor - 1)/dble(ns - 1)
+         do i = 1, nstrm
+            m = nint(abs(axm(i)))
+            call s_to_rho_power_law(m, ns, nrho, i_anchor, rmnc(i, :), rmnc_rho(i, :))
+            call s_to_rho_power_law(m, ns, nrho, i_anchor, zmnc(i, :), zmnc_rho(i, :))
+            call s_to_rho_power_law(m, ns, nrho, i_anchor, almnc(i, :), almnc_rho(i, :))
+            call s_to_rho_power_law(m, ns, nrho, i_anchor, rmns(i, :), rmns_rho(i, :))
+            call s_to_rho_power_law(m, ns, nrho, i_anchor, zmns(i, :), zmns_rho(i, :))
+            call s_to_rho_power_law(m, ns, nrho, i_anchor, almns(i, :), almns_rho(i, :))
+         end do
+         return
+      end if
 
       iunit_hs = 1357
       open (iunit_hs, file='healaxis.dat')
@@ -915,6 +932,89 @@ contains
       deallocate (splcoe)
 
    end subroutine s_to_rho_healaxis
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   function axis_anchor_index(ns) result(i_anchor)
+      !> Innermost reliable full-grid surface: the first surface at or
+      !> outside rho_axis_heal. VMEC full-grid harmonics inside this
+      !> radius violate the rho**|m| analyticity condition (the radial
+      !> startup layer), so they are discarded and replaced by the
+      !> power-law continuation.
+      use new_vmec_stuff_mod, only: rho_axis_heal, ns_s
+
+      integer, intent(in) :: ns
+      integer :: i_anchor
+
+      i_anchor = 1 + nint(rho_axis_heal**2*dble(ns - 1))
+      i_anchor = max(2, min(i_anchor, ns - ns_s - 1))
+   end function axis_anchor_index
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   subroutine s_to_rho_power_law(m, ns, nrho, i_anchor, arr_in, arr_out)
+      !> Resamples one Fourier amplitude from the uniform s grid to the
+      !> uniform rho = sqrt(s) grid, enforcing analytic regularity at the
+      !> axis. Surfaces below i_anchor are discarded: the amplitude is
+      !> continued to the axis as c(rho) = c_anchor*(rho/rho_anchor)**|m|
+      !> (m clamped at 50), anchored at the innermost reliable surface.
+      !> Outside the anchor the spline acts on c/rho**|m|, an even analytic
+      !> function of rho, built only from the reliable surfaces. This is the
+      !> booz_xform_to_boozer_chartmap continuation applied at the VMEC
+      !> harmonic level, so both the Boozer and canonical transforms inherit
+      !> a clean near-axis field from one place.
+      use new_vmec_stuff_mod, only: ns_s
+
+      integer, intent(in) :: m, ns, nrho, i_anchor
+      real(dp), dimension(ns), intent(in) :: arr_in
+      real(dp), dimension(nrho), intent(out) :: arr_out
+
+      integer, parameter :: m_clamp = 50
+
+      integer :: irho, is, k, mc, nsub
+      real(dp) :: hs, hrho, s, s_anchor, ds, rho, rho_anchor
+      real(dp), dimension(:, :), allocatable :: splcoe
+
+      hs = 1.d0/dble(ns - 1)
+      hrho = 1.d0/dble(nrho - 1)
+      mc = min(m, m_clamp)
+      s_anchor = hs*dble(i_anchor - 1)
+      rho_anchor = sqrt(s_anchor)
+      nsub = ns - i_anchor + 1
+
+      allocate (splcoe(0:ns_s, nsub))
+
+      if (mc > 0) then
+         do is = i_anchor, ns
+            rho = sqrt(hs*dble(is - 1))
+            splcoe(0, is - i_anchor + 1) = arr_in(is)/rho**mc
+         end do
+      else
+         splcoe(0, :) = arr_in(i_anchor:ns)
+      end if
+
+      call spl_reg(ns_s, nsub, hs, splcoe)
+
+      do irho = 1, nrho
+         rho = hrho*dble(irho - 1)
+         if (rho < rho_anchor) then
+            arr_out(irho) = splcoe(0, 1)*(rho/rho_anchor)**mc
+         else
+            s = rho**2
+            ds = (s - s_anchor)/hs
+            is = max(0, min(nsub - 1, int(ds)))
+            ds = (ds - dble(is))*hs
+            is = is + 1
+            arr_out(irho) = splcoe(ns_s, is)
+            do k = ns_s - 1, 0, -1
+               arr_out(irho) = splcoe(k, is) + ds*arr_out(irho)
+            end do
+            if (mc > 0) arr_out(irho) = arr_out(irho)*rho**mc
+         end if
+      end do
+
+      deallocate (splcoe)
+   end subroutine s_to_rho_power_law
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -998,7 +998,7 @@ contains
       do irho = 1, nrho
          rho = hrho*dble(irho - 1)
          if (rho < rho_anchor) then
-            arr_out(irho) = splcoe(0, 1)*(rho/rho_anchor)**mc
+            arr_out(irho) = splcoe(0, 1)*rho**mc
          else
             s = rho**2
             ds = (s - s_anchor)/hs

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,13 @@ target_link_libraries(test_boozer_coordinates_exports.x
   neo
 )
 
+add_executable(test_axis_power_law_regularization.x
+  source/test_axis_power_law_regularization.f90
+)
+target_link_libraries(test_axis_power_law_regularization.x
+  neo
+)
+
 add_executable(test_geqdsk_tools.x source/test_geqdsk_tools.f90)
 target_link_libraries(test_geqdsk_tools.x
   ${MAIN_LIB}
@@ -190,6 +197,8 @@ target_link_libraries(test_nctools_nc_get3.x
 ## Standard tests according to standard libneo Fortran test convention.
 
 add_test(NAME test_binsrc COMMAND test_binsrc.x)
+add_test(NAME test_axis_power_law_regularization
+  COMMAND test_axis_power_law_regularization.x)
 add_test(NAME test_boozer_coordinates_exports
   COMMAND test_boozer_coordinates_exports.x
 )

--- a/test/source/test_axis_power_law_regularization.f90
+++ b/test/source/test_axis_power_law_regularization.f90
@@ -1,0 +1,123 @@
+program test_axis_power_law_regularization
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use new_vmec_stuff_mod, only: ns_s, rho_axis_heal
+    use spline_vmec_sub, only: s_to_rho_power_law, axis_anchor_index
+    implicit none
+
+    integer, parameter :: ns = 100, nrho = 100
+    real(dp), parameter :: amp = 0.75_dp
+
+    ns_s = 5
+
+    call test_anchor_index()
+    call test_axis_vanishing()
+    call test_power_law_reproduction()
+    call test_anchor_continuity()
+
+    print *, 'axis power-law regularization: all checks passed'
+
+contains
+
+    !> The innermost reliable surface index used by the rho**|m| continuation.
+    subroutine test_anchor_index()
+        rho_axis_heal = 0.1_dp
+        if (axis_anchor_index(ns) /= 2) then
+            print *, 'i_anchor(rho_heal=0.1) =', axis_anchor_index(ns), 'expected 2'
+            error stop 'axis_anchor_index mismatch for rho_axis_heal=0.1'
+        end if
+        rho_axis_heal = 0.3_dp
+        if (axis_anchor_index(ns) /= 10) then
+            print *, 'i_anchor(rho_heal=0.3) =', axis_anchor_index(ns), 'expected 10'
+            error stop 'axis_anchor_index mismatch for rho_axis_heal=0.3'
+        end if
+        rho_axis_heal = 0.1_dp
+    end subroutine test_anchor_index
+
+    !> A harmonic with m>0 must vanish at the magnetic axis (rho=0).
+    subroutine test_axis_vanishing()
+        integer :: i_anchor
+        real(dp) :: arr_in(ns), arr_out(nrho)
+
+        rho_axis_heal = 0.1_dp
+        i_anchor = axis_anchor_index(ns)
+        call fill_power_law(2, arr_in)
+        call s_to_rho_power_law(2, ns, nrho, i_anchor, arr_in, arr_out)
+        if (abs(arr_out(1)) > 1.0e-13_dp) then
+            print *, 'arr_out at rho=0 =', arr_out(1)
+            error stop 'm>0 harmonic does not vanish at the axis'
+        end if
+    end subroutine test_axis_vanishing
+
+    !> An exact c(rho) = amp*rho**m input is an even-analytic reduced
+    !> function (c/rho**m = amp), so the resampled harmonic must reproduce
+    !> amp*rho**m on the whole rho grid, including below the anchor.
+    subroutine test_power_law_reproduction()
+        integer, parameter :: ms(3) = [1, 2, 4]
+        integer :: im, m, i_anchor, irho
+        real(dp) :: arr_in(ns), arr_out(nrho)
+        real(dp) :: rho, expected, err, max_err
+
+        rho_axis_heal = 0.1_dp
+        i_anchor = axis_anchor_index(ns)
+        do im = 1, size(ms)
+            m = ms(im)
+            call fill_power_law(m, arr_in)
+            call s_to_rho_power_law(m, ns, nrho, i_anchor, arr_in, arr_out)
+            max_err = 0.0_dp
+            do irho = 1, nrho
+                rho = real(irho - 1, dp)/real(nrho - 1, dp)
+                expected = amp*rho**m
+                err = abs(arr_out(irho) - expected)
+                max_err = max(max_err, err)
+            end do
+            if (max_err > 1.0e-10_dp) then
+                print *, 'm =', m, 'max |arr_out - amp*rho**m| =', max_err
+                error stop 'power-law harmonic not reproduced (see below-anchor branch)'
+            end if
+        end do
+    end subroutine test_power_law_reproduction
+
+    !> The continuation must be continuous across the anchor surface.
+    subroutine test_anchor_continuity()
+        integer :: i_anchor, irho_below, irho_above, irho
+        real(dp) :: arr_in(ns), arr_out(nrho)
+        real(dp) :: rho, rho_anchor, jump
+
+        rho_axis_heal = 0.1_dp
+        i_anchor = axis_anchor_index(ns)
+        rho_anchor = sqrt(real(i_anchor - 1, dp)/real(ns - 1, dp))
+        call fill_power_law(2, arr_in)
+        call s_to_rho_power_law(2, ns, nrho, i_anchor, arr_in, arr_out)
+
+        irho_below = 0
+        irho_above = 0
+        do irho = 1, nrho
+            rho = real(irho - 1, dp)/real(nrho - 1, dp)
+            if (rho < rho_anchor) irho_below = irho
+            if (rho >= rho_anchor .and. irho_above == 0) irho_above = irho
+        end do
+
+        jump = abs(arr_out(irho_above) - arr_out(irho_below))
+        if (jump > 5.0e-3_dp) then
+            print *, 'rho_anchor =', rho_anchor
+            print *, 'arr_out just below anchor =', arr_out(irho_below)
+            print *, 'arr_out just above anchor =', arr_out(irho_above)
+            print *, 'jump across anchor =', jump
+            error stop 'discontinuity in rho**|m| continuation at the anchor'
+        end if
+    end subroutine test_anchor_continuity
+
+    !> Sample c(s) = amp*s**(m/2) = amp*rho**m on the uniform s grid.
+    subroutine fill_power_law(m, arr_in)
+        integer, intent(in) :: m
+        real(dp), intent(out) :: arr_in(ns)
+        integer :: is
+        real(dp) :: s
+
+        do is = 1, ns
+            s = real(is - 1, dp)/real(ns - 1, dp)
+            arr_in(is) = amp*sqrt(s)**m
+        end do
+    end subroutine fill_power_law
+
+end program test_axis_power_law_regularization


### PR DESCRIPTION
## Problem

VMEC full-grid Fourier amplitudes near the axis violate the analytic regularity condition `c_m(rho) ~ rho^|m|` (with `rho = sqrt(s)`). The existing axis healing (`determine_nheal_for_axis`, 30% tolerance) is a smoothness test: it is structurally blind to the *smooth* parity violation and lets sub-tolerance grid noise through. On the W7-X high-mirror equilibrium the measured `rmnc/rho^m` quotient of the dominant m=3 mode flips sign at the innermost surface and the m=4 quotient is 6.3x its asymptote, the textbook near-axis VMEC signature.

Downstream, SIMPLE's symplectic integrator converts that near-axis noise into secular radial transport: `r_negative ~ 600` in a 0.01 s internal-Boozer trace, with a creeping non-prompt loss tail absent from RK and from external booz_xform chartmaps on the same equilibrium.

## Fix

`s_to_rho_power_law` continues each harmonic to the axis with the analytic power law:

```
c(rho) = c_anchor * (rho/rho_anchor)^|m|      (rho < rho_axis_heal)
```

Below the anchor the surfaces are discarded; outside it the spline acts on `c/rho^|m|`, an even analytic function of rho, built only from reliable surfaces. `m` is clamped at 50. This is the `booz_xform_to_boozer_chartmap.py` continuation (which mirrors booz_xform's own `rmnc/sqrt(s)` extrapolation) applied at the VMEC harmonic level, so both the Boozer and the canonical transforms inherit a clean near-axis field from one shared evaluator chain (`vmec_field -> splint_vmec_data`). Neither transform needs its own change.

The regularity `c_m ~ rho^|m|` is standard (Garren-Boozer 1991; Landreman-Sengupta 2018/2019; DESC and booz_xform both enforce it).

## Interface

New flags in `new_vmec_stuff_mod`:
- `axis_healing_power_law` (default `.false.`): opt in to the power-law continuation, bypassing `determine_nheal_for_axis`.
- `rho_axis_heal` (default `0.1`): anchor radius. At ns=501 this replaces the inner 5 of 501 surfaces (inner 1% of flux); the field is unchanged beyond `rho ~ 0.14`.

The default keeps the legacy healing, so existing chartmap and field consumers are byte-for-byte unchanged. Consumers that need the regularization (SIMPLE near-axis symplectic tracing) set the flag from their own namelist.

## Verification

W7-X high mirror, internal Boozer field, symplectic Euler1, 0.01 s, 1000 fixed-start alphas:

| field | r_negative |
|---|---|
| internal Boozer, legacy healing | ~606 |
| internal Boozer, this PR (flag on) | **2** |
| booz_xform chartmap (reference) | 21 |

The flag is opt-in because the continuation changes the near-axis field for every consumer. On the low-resolution CI fixture (ns=50) the `c/rho^|m|` division at the second surface amplifies the startup-layer noise instead of removing it. That distorts the near-axis geometry enough to diverge the chartmap Newton inversion (`chartmap from_cyl failed ierr=1`), which is what broke `test_chartmap_matches_vmec` and `test_chartmap_vmec_mapping` when the flag defaulted on. With the default `.false.` both chartmap tests pass unchanged; the regularization is exercised only by consumers that request it.

1 s benchmark runs (symplectic Boozer and canonical on the regularized field) are in progress in the orbit-benchmark repo.

## Note for maintainers

The default `.false.` leaves the legacy near-axis field bit-reproducible, so existing golden records are unaffected. Enabling the flag shifts the near-axis harmonics by design; golden records generated under it differ from the legacy ones, and regenerating them is the intended follow-up for consumers that adopt it.
