### PR TITLE
Route collision_freqs incomplete gamma through fortnum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ if(NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
         GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-        GIT_TAG main
+        GIT_TAG v0.1.0
     )
     FetchContent_MakeAvailable(fortnum)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,19 @@ endif()
 # Falls back to building from source if system libraries are incompatible.
 include(${PROJECT_SOURCE_DIR}/cmake/DetectDependencies.cmake)
 
+# fortnum: numerical core (special functions, quadrature, ODE). Guarded so a
+# repo that also pulls fortnum transitively via libneo does not double-declare
+# the target.
+if(NOT TARGET fortnum)
+    include(FetchContent)
+    FetchContent_Declare(
+        fortnum
+        GIT_REPOSITORY git@github.com:lazy-fortran/fortnum.git
+        GIT_TAG main
+    )
+    FetchContent_MakeAvailable(fortnum)
+endif()
+
 # Libraries that libneo depends on
 add_subdirectory(src/hdf5_tools)
 add_subdirectory(src/polylag)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ if(NOT TARGET fortnum)
     include(FetchContent)
     FetchContent_Declare(
         fortnum
-        GIT_REPOSITORY git@github.com:lazy-fortran/fortnum.git
+        GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
         GIT_TAG main
     )
     FetchContent_MakeAvailable(fortnum)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ if(NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
         GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-        GIT_TAG v0.1.0
+        GIT_TAG 92de6e949a772cfffc73bb5295fe5e2b056b9c18
     )
     FetchContent_MakeAvailable(fortnum)
 endif()

--- a/src/collisions/CMakeLists.txt
+++ b/src/collisions/CMakeLists.txt
@@ -1,15 +1,13 @@
 add_library(collision_freqs STATIC
     collision_freqs.f90)
 
-find_package(GSL REQUIRED)
-
 set_property(TARGET collision_freqs PROPERTY
     INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Fortran_MODULE_DIRECTORY})
 
 add_library(LIBNEO::collision_freqs ALIAS collision_freqs)
 
 target_link_libraries(collision_freqs PUBLIC
-    GSL::gsl
-    neo 
+    fortnum
+    neo
     species
 )

--- a/src/collisions/collision_freqs.f90
+++ b/src/collisions/collision_freqs.f90
@@ -1,28 +1,9 @@
 module libneo_collisions
-   use, intrinsic :: iso_c_binding
    use libneo_species, only: species_t
 
    implicit none
 
    integer, parameter :: dp = kind(1.0d0)
-
-   interface
-      function gsl_sf_gamma(x) bind(c, name='gsl_sf_gamma')
-         import :: c_double
-         implicit none
-         real(c_double), value :: x
-         real(c_double) :: gsl_sf_gamma
-      end function gsl_sf_gamma
-   end interface
-
-   interface
-      function gsl_sf_gamma_inc_P(a, x) bind(c, name='gsl_sf_gamma_inc_P')
-         import :: c_double
-         implicit none
-         real(c_double), value :: a, x
-         real(c_double) :: gsl_sf_gamma_inc_P
-      end function gsl_sf_gamma_inc_P
-   end interface
 
 contains
 
@@ -154,9 +135,10 @@ contains
    end subroutine
 
    function lower_incomplete_gamma(a, x) result(gamma)
+      use fortnum_special, only: gamma_lower
       real(dp), intent(in) :: a, x
       real(dp) :: gamma
 
-      gamma = gsl_sf_gamma_inc_P(a, x)*gsl_sf_gamma(a)
+      gamma = gamma_lower(a, x)
    end function lower_incomplete_gamma
 end module


### PR DESCRIPTION
## Merge order

Merge sequence: #316 -> #317 -> #318.

Each PR is based on `main` individually, so each diff is cumulative against `main` and the three share code. Merge them in order. Once a predecessor merges, the next PR's diff shrinks to its own increment.

`collision_freqs` linked GPLv3 GSL for one routine: the unnormalized lower
incomplete gamma in the Chandrasekhar function. The GPL obligation reached
every MIT-licensed downstream consumer (SIMPLE, NEO-2, NEO-RT, MEPHIT, KAMEL,
rabe), including SIMPLE's published binary wheels.

This routes that single math call to the fortnum numerical core instead of a
libneo-internal replacement. Consumers depend on fortnum directly.

`lower_incomplete_gamma` returned `gsl_sf_gamma_inc_P(a, x) * gsl_sf_gamma(a)`,
the unnormalized lower incomplete gamma. That product is fortnum
`gamma_lower(a, x)`, a pure function with the same domain (`error stop` on
`a <= 0` or `x < 0`, per fortnum `docs/migration_libneo.md`). The public
interface of `lower_incomplete_gamma` is unchanged, so callers compile without
edits.

Changes:

- Replace the two `bind(c)` GSL interfaces and the line-160 product with a
  single `use fortnum_special, only: gamma_lower`. The now-dead
  `iso_c_binding` import is removed.
- Drop `find_package(GSL REQUIRED)` and the `GSL::gsl` link from
  `src/collisions/CMakeLists.txt`; link the fortnum Fortran target instead.
- Fetch fortnum via `FetchContent` from `git@github.com:lazy-fortran/fortnum.git`
  at `main`, guarded by `if(NOT TARGET fortnum)` so a repo that also pulls
  fortnum transitively via libneo does not double-declare the target. This
  mirrors how NEO-2 PR #90 wires fortnum.

This was libneo's only GSL site (no FGSL/SLATEC/AMOS/C-GSL elsewhere), so GSL
is fully dropped.

Supersedes #286: that PR dropped GSL with a libneo-internal reimplementation;
this one routes the same call to the shared fortnum core.

## Verification

Environment: gfortran, system HDF5 2.1.1, NetCDF, FFTW, OpenBLAS, fortnum
fetched fresh from `lazy-fortran/fortnum` `main` (`8f4c71c`).

Configure (fortnum fetched and built):

```
$ cmake -S . -B build -G Ninja -DLIBNEO_BUILD_TESTING=ON
...
-- Performing Test FORTNUM_HAVE_HEAP_TRAMPOLINES - Success
...
-- Configuring done (7.5s)
-- Generating done (0.2s)
configure exit: 0
```

Full build:

```
$ cmake --build build -j$(nproc)
[362/362] Linking Fortran shared module _efit_to_boozer.cpython-314-x86_64-linux-gnu.so
full build exit: 0
```

GSL appears on no link line in the generated build:

```
$ grep -ri "gsl" build/build.ninja | grep -iE "link|gsl::"
(no output)
```

The migrated routine is exercised by `test_collision_freqs`
(`calc_perp_coll_freq` -> `psi_of_x` -> `lower_incomplete_gamma` ->
`gamma_lower`), whose expected values were produced by the prior GSL-backed
implementation. They pass unchanged:

```
$ ctest -R "test_collision_freqs|test_transport" --output-on-failure
    Start 19: test_collision_freqs
1/2 Test #19: test_collision_freqs .............   Passed    0.07 sec
    Start 20: test_transport
2/2 Test #20: test_transport ...................   Passed    0.06 sec
100% tests passed, 0 tests failed out of 2
```

Full suite: 57/69 pass. The 12 failures (chartmap / map2disc / vector
conversion / refcoords) come from a missing optional `map2disc` Python module
(`ModuleNotFoundError: No module named 'map2disc'`) and the chartmap fixtures
that depend on it. They fail identically on unmodified `origin/main` built in
the same environment:

```
$ diff <main failed set> <branch failed set>
IDENTICAL FAILURE SETS
branch count: 12  main count: 12
```

None of the 12 touch `collision_freqs`, `species`, `transport`, or `fortnum`.

Note: fortnum pin updated to current main (92de6e9) after a fortnum history rewrite; old shas no longer resolve.