### PR TITLE
Always FetchContent dependencies; drop $ENV{CODE} local-source bypass

### DIFF
--- a/cmake/Modules/Util.cmake
+++ b/cmake/Modules/Util.cmake
@@ -2,9 +2,9 @@ include(FetchContent)
 
 function(find_or_fetch DEPENDENCY)
 
-    if(DEFINED ENV{CODE} AND EXISTS $ENV{CODE}/${DEPENDENCY})
-        set(SOURCE_DIR $ENV{CODE}/${DEPENDENCY})
-        message(STATUS "Using ${DEPENDENCY} in $ENV{CODE}/${DEPENDENCY}")
+    if(${DEPENDENCY}_SOURCE_DIR AND EXISTS ${${DEPENDENCY}_SOURCE_DIR})
+        set(SOURCE_DIR ${${DEPENDENCY}_SOURCE_DIR})
+        message(STATUS "Using ${DEPENDENCY} from ${${DEPENDENCY}_SOURCE_DIR}")
     else()
         fetch(${DEPENDENCY} SOURCE_DIR)
     endif()


### PR DESCRIPTION
## Summary

`find_or_fetch` in `cmake/Modules/Util.cmake` silently substituted a local checkout at `$ENV{CODE}/<dep>` whenever `CODE` was set in the shell. Dependency resolution then depended on ambient environment state rather than the declared ref, which is a hermeticity footgun.

This change makes the helper default to FetchContent (fetch each dependency at its pinned/declared ref). A local source is used only when explicitly requested via the `-D<DEP>_SOURCE_DIR=<dir>` CMake cache variable, matching the cache-variable override convention already used in `BuildExternalDependencies.cmake`. The environment is never read.

## Verification

Confirmed no `$ENV{CODE}` remains in the cmake sources:

```
$ rg -i '\$ENV\{CODE\}' cmake
(no matches)
```

Fresh configure with `CODE` set to a sentinel path does not reference it and succeeds:

```
$ CODE=/tmp/should-not-be-used cmake -S . -B /tmp/libneo-cfg -G Ninja
...
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/libneo-cfg
```

No "Using ... in /tmp/should-not-be-used" message appears; dependencies resolve via FetchContent / system detection.