### PR TITLE
Near-axis field: enum healing modes and polyfit regularization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,11 @@ add_executable(vmec_to_chartmap.x
 )
 target_link_libraries(vmec_to_chartmap.x neo)
 
+add_executable(near_axis_field_diag.x
+    app/near_axis_field_diag.f90
+)
+target_link_libraries(near_axis_field_diag.x neo)
+
 
 if(LIBNEO_BUILD_TESTING)
     add_subdirectory(test)

--- a/app/near_axis_field_diag.f90
+++ b/app/near_axis_field_diag.f90
@@ -1,0 +1,85 @@
+program near_axis_field_diag
+    !> Near-axis VMEC field diagnostic. Splines the field with a chosen axis
+    !> healing variant and dumps a radial cut at fixed (theta, varphi) so the
+    !> continuity and rho^|m| behaviour can be inspected. One row per rho point:
+    !>   rho s theta A_theta A_phi dA_theta_ds dA_phi_ds Bmod Bcov_theta Bcov_phi
+    !> Radial derivatives are taken in post from the fine rho grid.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use new_vmec_stuff_mod, only: netcdffile, ns_s, ns_tp, multharm, &
+                                  old_axis_healing, old_axis_healing_boundary, &
+                                  axis_healing_power_law, rho_axis_heal
+    use spline_vmec_sub, only: spline_vmec_data, vmec_field
+    implicit none
+
+    character(len=1024) :: wout_file, variant, outfile, arg
+    integer :: nrho, irho, itheta
+    real(dp) :: rho, s, theta, varphi, rho_min, rho_max
+    real(dp) :: A_theta, A_phi, dA_theta_ds, dA_phi_ds, aiota
+    real(dp) :: sqg, alam, dl_ds, dl_dt, dl_dp
+    real(dp) :: Bctr_th, Bctr_ph, Bcov_s, Bcov_th, Bcov_ph, Bmod2, Bmod
+    real(dp), parameter :: pi = 3.14159265358979d0
+    real(dp) :: thetas(3)
+
+    call get_command_argument(1, wout_file)
+    call get_command_argument(2, variant)
+    call get_command_argument(3, outfile)
+    if (len_trim(wout_file) == 0 .or. len_trim(variant) == 0 .or. len_trim(outfile) == 0) then
+        print *, "Usage: near_axis_field_diag.x <wout.nc> <power|oldheal|oldbnd> <out.dat> [rho_axis_heal]"
+        error stop 1
+    end if
+
+    ! Geometry/resolution matching the benchmark runs (mh5 ns3).
+    ns_s = 3
+    ns_tp = 3
+    multharm = 5
+    rho_axis_heal = 0.1d0
+    call get_command_argument(4, arg)
+    if (len_trim(arg) > 0) read (arg, *) rho_axis_heal
+
+    select case (trim(variant))
+    case ('power')
+        axis_healing_power_law = .True.
+        old_axis_healing = .True.
+        old_axis_healing_boundary = .True.
+    case ('oldheal')
+        axis_healing_power_law = .False.
+        old_axis_healing = .True.
+        old_axis_healing_boundary = .False.
+    case ('oldbnd')
+        axis_healing_power_law = .False.
+        old_axis_healing = .True.
+        old_axis_healing_boundary = .True.
+    case default
+        print *, "unknown variant: ", trim(variant)
+        error stop 2
+    end select
+
+    netcdffile = trim(wout_file)
+    call spline_vmec_data
+
+    thetas = [0.0d0, 0.5d0*pi, pi]
+    varphi = 0.0d0
+    nrho = 4000
+    rho_min = 1.0d-4
+    rho_max = 0.40d0
+
+    open (unit=21, file=trim(outfile), status='replace', action='write')
+    write (21, '(A)') '# rho s theta A_theta A_phi dA_theta_ds dA_phi_ds Bmod Bcov_theta Bcov_phi'
+    do itheta = 1, 3
+        theta = thetas(itheta)
+        do irho = 0, nrho
+            rho = rho_min + (rho_max - rho_min)*dble(irho)/dble(nrho)
+            s = rho*rho
+            call vmec_field(s, theta, varphi, A_theta, A_phi, dA_theta_ds, dA_phi_ds, &
+                            aiota, sqg, alam, dl_ds, dl_dt, dl_dp, Bctr_th, Bctr_ph, &
+                            Bcov_s, Bcov_th, Bcov_ph)
+            Bmod2 = Bctr_th*Bcov_th + Bctr_ph*Bcov_ph
+            Bmod = sqrt(max(Bmod2, 0.0d0))
+            write (21, '(10ES20.11)') rho, s, theta, A_theta, A_phi, dA_theta_ds, &
+                dA_phi_ds, Bmod, Bcov_th, Bcov_ph
+        end do
+        write (21, '(A)') ''
+    end do
+    close (21)
+    print *, 'wrote ', trim(outfile), ' variant=', trim(variant), ' rho_axis_heal=', rho_axis_heal
+end program near_axis_field_diag

--- a/app/near_axis_field_diag.f90
+++ b/app/near_axis_field_diag.f90
@@ -6,9 +6,8 @@ program near_axis_field_diag
     !> Radial derivatives are taken in post from the fine rho grid.
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use new_vmec_stuff_mod, only: netcdffile, ns_s, ns_tp, multharm, &
-                                  old_axis_healing, old_axis_healing_boundary, &
-                                  axis_healing_power_law, rho_axis_heal, &
-                                  axis_healing_polyfit, axis_healing_polyfit_degree
+                                  axis_healing, s_axis_heal, rho_axis_heal, &
+                                  axis_healing_polyfit_degree
     use spline_vmec_sub, only: spline_vmec_data, vmec_field
     implicit none
 
@@ -25,7 +24,7 @@ program near_axis_field_diag
     call get_command_argument(2, variant)
     call get_command_argument(3, outfile)
     if (len_trim(wout_file) == 0 .or. len_trim(variant) == 0 .or. len_trim(outfile) == 0) then
-        print *, "Usage: near_axis_field_diag.x <wout.nc> <power|oldheal|oldbnd> <out.dat> [rho_axis_heal]"
+        print *, "Usage: near_axis_field_diag.x <wout.nc> <polyfit|powerlaw|legacy|legacy_adaptive> <out.dat> [s_axis_heal]"
         error stop 1
     end if
 
@@ -33,27 +32,21 @@ program near_axis_field_diag
     ns_s = 3
     ns_tp = 3
     multharm = 5
-    rho_axis_heal = 0.1d0
+    s_axis_heal = 1.0d-2
+    rho_axis_heal = -1.0d0
     call get_command_argument(4, arg)
-    if (len_trim(arg) > 0) read (arg, *) rho_axis_heal
+    if (len_trim(arg) > 0) read (arg, *) s_axis_heal
 
     select case (trim(variant))
     case ('polyfit')
-        axis_healing_polyfit = .True.
+        axis_healing = 'polyfit'
         axis_healing_polyfit_degree = 3
-        axis_healing_power_law = .False.
-    case ('power')
-        axis_healing_power_law = .True.
-        old_axis_healing = .True.
-        old_axis_healing_boundary = .True.
-    case ('oldheal')
-        axis_healing_power_law = .False.
-        old_axis_healing = .True.
-        old_axis_healing_boundary = .False.
-    case ('oldbnd')
-        axis_healing_power_law = .False.
-        old_axis_healing = .True.
-        old_axis_healing_boundary = .True.
+    case ('power', 'powerlaw')
+        axis_healing = 'powerlaw'
+    case ('oldbnd', 'legacy')
+        axis_healing = 'legacy'
+    case ('oldheal', 'legacy_adaptive')
+        axis_healing = 'legacy_adaptive'
     case default
         print *, "unknown variant: ", trim(variant)
         error stop 2
@@ -86,5 +79,5 @@ program near_axis_field_diag
         write (21, '(A)') ''
     end do
     close (21)
-    print *, 'wrote ', trim(outfile), ' variant=', trim(variant), ' rho_axis_heal=', rho_axis_heal
+    print *, 'wrote ', trim(outfile), ' variant=', trim(variant), ' s_axis_heal=', s_axis_heal
 end program near_axis_field_diag

--- a/app/near_axis_field_diag.f90
+++ b/app/near_axis_field_diag.f90
@@ -7,7 +7,8 @@ program near_axis_field_diag
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use new_vmec_stuff_mod, only: netcdffile, ns_s, ns_tp, multharm, &
                                   old_axis_healing, old_axis_healing_boundary, &
-                                  axis_healing_power_law, rho_axis_heal
+                                  axis_healing_power_law, rho_axis_heal, &
+                                  axis_healing_polyfit, axis_healing_polyfit_degree
     use spline_vmec_sub, only: spline_vmec_data, vmec_field
     implicit none
 
@@ -37,6 +38,10 @@ program near_axis_field_diag
     if (len_trim(arg) > 0) read (arg, *) rho_axis_heal
 
     select case (trim(variant))
+    case ('polyfit')
+        axis_healing_polyfit = .True.
+        axis_healing_polyfit_degree = 3
+        axis_healing_power_law = .False.
     case ('power')
         axis_healing_power_law = .True.
         old_axis_healing = .True.

--- a/app/vmec_to_chartmap.f90
+++ b/app/vmec_to_chartmap.f90
@@ -1,5 +1,4 @@
 program vmec_to_chartmap
-    use, intrinsic :: iso_fortran_env, only: dp => real64
     use libneo_chartmap_vmec_generator, only: write_chartmap_from_vmec
     implicit none
 

--- a/bench/spline_many/src/util_bench_args.f90
+++ b/bench/spline_many/src/util_bench_args.f90
@@ -1,5 +1,4 @@
 module util_bench_args
-    use, intrinsic :: iso_fortran_env, only: int64
     implicit none
     private
 
@@ -26,4 +25,3 @@ contains
     end function get_env_int
 
 end module util_bench_args
-

--- a/src/canonical_coordinates_mod.f90
+++ b/src/canonical_coordinates_mod.f90
@@ -33,6 +33,15 @@
     ! legacy healing so existing chartmap/field consumers are unchanged.
     logical :: axis_healing_power_law = .False.
     double precision :: rho_axis_heal = 0.1d0
+    ! rho**|m| * (least-squares polynomial in s) axis continuation below
+    ! rho_axis_heal. Same analytic regularity as the power-law path, but the
+    ! rescaled amplitude c_m/rho**|m| is extrapolated to the axis by a smooth
+    ! degree-axis_healing_polyfit_degree fit to the reliable surfaces and then
+    ! splined over the full grid, avoiding the noise amplification and anchor
+    ! roughness of the pure power-law continuation. Overrides the flags above
+    ! when .true.
+    logical :: axis_healing_polyfit = .False.
+    integer :: axis_healing_polyfit_degree = 3
   end module new_vmec_stuff_mod
 !
   module vector_potentail_mod

--- a/src/canonical_coordinates_mod.f90
+++ b/src/canonical_coordinates_mod.f90
@@ -24,24 +24,32 @@
 !
     double precision, dimension(:,:,:,:,:,:), allocatable :: sR,sZ,slam
 
+    ! Near-axis healing of the VMEC harmonics. Preferred selector:
+    !   axis_healing = 'legacy'   - skip the innermost unreliable surfaces and
+    !                               extrapolate the rescaled amplitude (old default).
+    !                  'powerlaw' - rho**|m| continuation below rho_axis_heal
+    !                               (analytic regularity, but amplifies near-axis
+    !                               noise; superseded by 'polyfit').
+    !                  'polyfit'  - rho**|m| * least-squares poly(s) continuation
+    !                               below rho_axis_heal: same regularity, smooth,
+    !                               no anchor noise. Recommended.
+    ! axis_healing_boundary selects the legacy reliability boundary (where the
+    ! VMEC data is no longer trusted near the axis):
+    !   'fixed'    - discard the innermost min(|m|,4) surfaces.
+    !   'adaptive' - detect the noisy surface via determine_nheal_for_axis.
+    ! Empty strings mean "unset": the deprecated logical switches below are
+    ! mapped to a mode with a one-time warning (see resolve_axis_healing_mode).
+    character(len=16) :: axis_healing = ''
+    character(len=16) :: axis_healing_boundary = ''
+    double precision :: rho_axis_heal = 0.1d0      ! anchor radius for powerlaw/polyfit
+    integer :: axis_healing_polyfit_degree = 3     ! polyfit polynomial degree in s
+    ! DEPRECATED boolean switches (use axis_healing / axis_healing_boundary). Kept
+    ! for back-compat and mapped to a mode with a deprecation warning; the next
+    ! SIMPLE release will remove them and default axis_healing to 'polyfit'.
     logical :: old_axis_healing = .True.
     logical :: old_axis_healing_boundary = .True.
-    ! rho**m power-law axis continuation below rho_axis_heal; enforces the
-    ! analytic regularity c_m(rho) ~ rho**|m| at the axis and overrides the two
-    ! legacy flags above when .true. Opt-in: consumers that need it (SIMPLE
-    ! near-axis symplectic tracing) enable it via namelist. Default keeps the
-    ! legacy healing so existing chartmap/field consumers are unchanged.
     logical :: axis_healing_power_law = .False.
-    double precision :: rho_axis_heal = 0.1d0
-    ! rho**|m| * (least-squares polynomial in s) axis continuation below
-    ! rho_axis_heal. Same analytic regularity as the power-law path, but the
-    ! rescaled amplitude c_m/rho**|m| is extrapolated to the axis by a smooth
-    ! degree-axis_healing_polyfit_degree fit to the reliable surfaces and then
-    ! splined over the full grid, avoiding the noise amplification and anchor
-    ! roughness of the pure power-law continuation. Overrides the flags above
-    ! when .true.
     logical :: axis_healing_polyfit = .False.
-    integer :: axis_healing_polyfit_degree = 3
   end module new_vmec_stuff_mod
 !
   module vector_potentail_mod

--- a/src/canonical_coordinates_mod.f90
+++ b/src/canonical_coordinates_mod.f90
@@ -25,27 +25,24 @@
     double precision, dimension(:,:,:,:,:,:), allocatable :: sR,sZ,slam
 
     ! Near-axis healing of the VMEC harmonics. Preferred selector:
-    !   axis_healing = 'legacy'   - skip the innermost unreliable surfaces and
-    !                               extrapolate the rescaled amplitude (old default).
-    !                  'powerlaw' - rho**|m| continuation below rho_axis_heal
-    !                               (analytic regularity, but amplifies near-axis
-    !                               noise; superseded by 'polyfit').
-    !                  'polyfit'  - rho**|m| * least-squares poly(s) continuation
-    !                               below rho_axis_heal: same regularity, smooth,
-    !                               no anchor noise. Recommended.
-    ! axis_healing_boundary selects the legacy reliability boundary (where the
-    ! VMEC data is no longer trusted near the axis):
-    !   'fixed'    - discard the innermost min(|m|,4) surfaces.
-    !   'adaptive' - detect the noisy surface via determine_nheal_for_axis.
-    ! Empty strings mean "unset": the deprecated logical switches below are
-    ! mapped to a mode with a one-time warning (see resolve_axis_healing_mode).
+    !   axis_healing = 'legacy'          - old default: discard min(|m|,4)
+    !                                      surfaces and extrapolate.
+    !                  'legacy_adaptive' - old adaptive boundary from
+    !                                      determine_nheal_for_axis.
+    !                  'powerlaw'        - rho**|m| continuation below
+    !                                      s_axis_heal.
+    !                  'polyfit'         - rho**|m| * least-squares poly(s)
+    !                                      below s_axis_heal. Recommended.
+    ! The empty string means "unset": deprecated logical switches below are
+    ! mapped to a mode with a warning (see resolve_axis_healing_mode).
     character(len=16) :: axis_healing = ''
-    character(len=16) :: axis_healing_boundary = ''
-    double precision :: rho_axis_heal = 0.1d0      ! anchor radius for powerlaw/polyfit
+    double precision :: s_axis_heal = 1.0d-2       ! anchor flux for powerlaw/polyfit
+    double precision :: rho_axis_heal = -1.0d0     ! deprecated; use s_axis_heal
     integer :: axis_healing_polyfit_degree = 3     ! polyfit polynomial degree in s
-    ! DEPRECATED boolean switches (use axis_healing / axis_healing_boundary). Kept
-    ! for back-compat and mapped to a mode with a deprecation warning; the next
-    ! SIMPLE release will remove them and default axis_healing to 'polyfit'.
+    logical :: rho_axis_heal_warning_printed = .False.
+    ! DEPRECATED boolean switches (use axis_healing). Kept for back-compat and
+    ! mapped to a mode with a deprecation warning; the next SIMPLE release will
+    ! remove them and default axis_healing to 'polyfit'.
     logical :: old_axis_healing = .True.
     logical :: old_axis_healing_boundary = .True.
     logical :: axis_healing_power_law = .False.

--- a/src/coordinates/libneo_coordinates_file_detection.f90
+++ b/src/coordinates/libneo_coordinates_file_detection.f90
@@ -1,5 +1,4 @@
 module libneo_coordinates_file_detection
-    use, intrinsic :: iso_fortran_env, only: dp => real64
     use libneo_coordinates_base, only: refcoords_file_unknown, refcoords_file_chartmap, &
                                        refcoords_file_vmec_wout
     use libneo_coordinates_validator, only: validate_chartmap_file

--- a/src/efit_to_boozer/f2py_interfaces/f2py_efit_to_boozer.f90
+++ b/src/efit_to_boozer/f2py_interfaces/f2py_efit_to_boozer.f90
@@ -3,7 +3,6 @@ module efit_to_boozer
    use efit_to_boozer_mod, only: psimax, nlabel, ntheta, nspl, twopi, rbeg, &
                                  rsmall, qsaf, psi_pol, psi_tor_vac, psi_tor, C_const, R_spl, Z_spl, &
                                  bmod_spl, sqgnorm_spl, Gfunc_spl, rmn, rmx, zmn, zmx, raxis, zaxis
-   use input_files, only: gfile
    use field_mod, only: icall
    use field_c_mod, only: icall_c
    use field_eq_mod, only: reset_field_eq_state

--- a/src/magfie/coil_convert.f90
+++ b/src/magfie/coil_convert.f90
@@ -1,6 +1,6 @@
 program coil_convert
   use iso_fortran_env, only: error_unit
-  use coil_tools, only: coil_t, coil_init, coil_deinit, coils_append, &
+  use coil_tools, only: coil_t, coil_deinit, coils_append, &
     process_fixed_number_of_args, check_number_of_args, &
     coils_write_AUG, coils_read_AUG, coils_write_nemov, coils_read_nemov, &
     coils_write_GPEC, coils_read_GPEC

--- a/src/magfie/vacfield.f90
+++ b/src/magfie/vacfield.f90
@@ -4,7 +4,7 @@ program vacfield
   use ieee_arithmetic, only: ieee_value, ieee_quiet_nan
   use hdf5_tools, only: h5_init, h5_deinit, h5overwrite
   use math_constants, only: current_si_to_cgs, C
-  use coil_tools, only: coil_t, coil_init, coil_deinit, coils_append, &
+  use coil_tools, only: coil_t, coil_deinit, coils_append, &
     process_fixed_number_of_args, check_number_of_args, &
     coils_read_AUG, coils_read_nemov, coils_read_GPEC, &
     read_currents, biot_savart_sum_coils, write_Bvac_nemov, &

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -178,8 +178,9 @@ contains
 
    subroutine perform_axis_healing(almnc_rho, rmnc_rho, zmnc_rho, almns_rho, rmns_rho, zmns_rho)
       use new_vmec_stuff_mod, only: rmnc, zmns, almns, rmns, zmnc, almnc, &
-                                    axm, nstrm, old_axis_healing_boundary, &
-                                    axis_healing_power_law
+                                    axm, axn, nstrm, old_axis_healing_boundary, &
+                                    axis_healing_power_law, axis_healing_polyfit, &
+                                    axis_healing_polyfit_degree
       use vector_potentail_mod, only: ns
 
       real(dp), dimension(:, :), allocatable, intent(out) :: almnc_rho, rmnc_rho, zmnc_rho
@@ -189,6 +190,22 @@ contains
       nrho = ns
       allocate (almnc_rho(nstrm, 0:nrho - 1), rmnc_rho(nstrm, 0:nrho - 1), zmnc_rho(nstrm, 0:nrho - 1))
       allocate (almns_rho(nstrm, 0:nrho - 1), rmns_rho(nstrm, 0:nrho - 1), zmns_rho(nstrm, 0:nrho - 1))
+
+      if (axis_healing_polyfit) then
+         i_anchor = axis_anchor_index(ns)
+         print *, 'VMEC axis healing: rho**m * polyfit(s) continuation below s = ', &
+            dble(i_anchor - 1)/dble(ns - 1), ' degree ', axis_healing_polyfit_degree
+         do i = 1, nstrm
+            m = nint(abs(axm(i)))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, rmnc(i, :), rmnc_rho(i, :))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, zmnc(i, :), zmnc_rho(i, :))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, almnc(i, :), almnc_rho(i, :))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, rmns(i, :), rmns_rho(i, :))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, zmns(i, :), zmns_rho(i, :))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, almns(i, :), almns_rho(i, :))
+         end do
+         return
+      end if
 
       if (axis_healing_power_law) then
          i_anchor = axis_anchor_index(ns)
@@ -1322,6 +1339,166 @@ contains
       deallocate (splcoe)
 
    end subroutine s_to_rho_healaxis
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   subroutine s_to_rho_polyfit(m, ns, nrho, i_anchor, ndeg, arr_in, arr_out)
+      !> Resamples one Fourier amplitude from the uniform s grid to the uniform
+      !> rho = sqrt(s) grid, enforcing analytic axis regularity without the noise
+      !> amplification of the pure power-law continuation. The rescaled amplitude
+      !> g(s) = c(s)/rho**|m| is even-analytic in rho, hence smooth in s. Surfaces
+      !> inside i_anchor are unreliable; g there is replaced by a least-squares
+      !> polynomial in s (a Zernike radial polynomial once rho**|m| is restored)
+      !> fitted to a window of reliable surfaces just outside i_anchor. g is then
+      !> splined over the full grid and rho**|m| restored: c(rho) = rho**|m|*P(s),
+      !> exact rho**|m| at the axis, smooth across the match, reproducing the
+      !> reliable surfaces.
+      use new_vmec_stuff_mod, only: ns_s
+
+      integer, intent(in) :: m, ns, nrho, i_anchor, ndeg
+      real(dp), dimension(ns), intent(in) :: arr_in
+      real(dp), dimension(nrho), intent(out) :: arr_out
+
+      integer, parameter :: m_clamp = 50
+      integer :: irho, is, k, mc, nwin, d, j
+      real(dp) :: hs, hrho, s, ds, rho, u, s_c, s_scale
+      real(dp), dimension(:), allocatable :: g, swin, gwin, coef
+      real(dp), dimension(:, :), allocatable :: splcoe
+
+      hs = 1.d0/dble(ns - 1)
+      hrho = 1.d0/dble(nrho - 1)
+      mc = min(m, m_clamp)
+
+      allocate (g(ns))
+      if (mc > 0) then
+         do is = i_anchor, ns
+            rho = sqrt(hs*dble(is - 1))
+            g(is) = arr_in(is)/rho**mc
+         end do
+      else
+         g(i_anchor:ns) = arr_in(i_anchor:ns)
+      end if
+
+      ! Least-squares polynomial in s through a window of reliable surfaces,
+      ! used to extrapolate g smoothly inward to the axis.
+      d = max(0, min(ndeg, ns - i_anchor))
+      nwin = min(ns - i_anchor + 1, 2*(d + 1) + 2)
+      allocate (swin(nwin), gwin(nwin), coef(0:d))
+      do j = 1, nwin
+         swin(j) = hs*dble(i_anchor - 1 + j - 1)
+         gwin(j) = g(i_anchor + j - 1)
+      end do
+      call polyfit_s(swin, gwin, nwin, d, coef, s_c, s_scale)
+      do is = 1, i_anchor - 1
+         s = hs*dble(is - 1)
+         u = (s - s_c)/s_scale
+         g(is) = coef(d)
+         do k = d - 1, 0, -1
+            g(is) = coef(k) + u*g(is)
+         end do
+      end do
+
+      allocate (splcoe(0:ns_s, ns))
+      splcoe(0, :) = g
+      call spl_reg(ns_s, ns, hs, splcoe)
+      do irho = 1, nrho
+         rho = hrho*dble(irho - 1)
+         s = rho**2
+         ds = s/hs
+         is = max(0, min(ns - 1, int(ds)))
+         ds = (ds - dble(is))*hs
+         is = is + 1
+         arr_out(irho) = splcoe(ns_s, is)
+         do k = ns_s - 1, 0, -1
+            arr_out(irho) = splcoe(k, is) + ds*arr_out(irho)
+         end do
+         if (mc > 0) arr_out(irho) = arr_out(irho)*rho**mc
+      end do
+
+      deallocate (g, swin, gwin, coef, splcoe)
+   end subroutine s_to_rho_polyfit
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   subroutine polyfit_s(s, g, n, d, coef, s_c, s_scale)
+      !> Least-squares fit g(j) ~ sum_k coef(k)*u**k with u=(s-s_c)/s_scale,
+      !> degree d, via the normal equations. Centering and scaling keep the
+      !> Vandermonde well conditioned for the small near-axis s window.
+      integer, intent(in) :: n, d
+      real(dp), intent(in) :: s(n), g(n)
+      real(dp), intent(out) :: coef(0:d), s_c, s_scale
+
+      integer :: i, k, l
+      real(dp) :: u
+      real(dp), allocatable :: mat(:, :), rhs(:), upow(:)
+
+      s_c = sum(s)/dble(n)
+      s_scale = 0.5d0*(maxval(s) - minval(s))
+      if (s_scale <= 0.d0) s_scale = 1.d0
+
+      allocate (mat(0:d, 0:d), rhs(0:d), upow(0:2*d))
+      mat = 0.d0
+      rhs = 0.d0
+      do i = 1, n
+         u = (s(i) - s_c)/s_scale
+         upow(0) = 1.d0
+         do k = 1, 2*d
+            upow(k) = upow(k - 1)*u
+         end do
+         do k = 0, d
+            do l = 0, d
+               mat(k, l) = mat(k, l) + upow(k + l)
+            end do
+            rhs(k) = rhs(k) + upow(k)*g(i)
+         end do
+      end do
+      call solve_small(mat, rhs, coef, d + 1)
+      deallocate (mat, rhs, upow)
+   end subroutine polyfit_s
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   subroutine solve_small(a, b, x, n)
+      !> Dense solve a x = b (n small) by Gaussian elimination with partial
+      !> pivoting. a and b are consumed.
+      integer, intent(in) :: n
+      real(dp), intent(inout) :: a(n, n), b(n)
+      real(dp), intent(out) :: x(n)
+
+      integer :: i, j, k, ip
+      real(dp) :: piv, factor, tmp
+
+      do k = 1, n - 1
+         ip = k
+         piv = abs(a(k, k))
+         do i = k + 1, n
+            if (abs(a(i, k)) > piv) then
+               piv = abs(a(i, k))
+               ip = i
+            end if
+         end do
+         if (ip /= k) then
+            do j = k, n
+               tmp = a(k, j); a(k, j) = a(ip, j); a(ip, j) = tmp
+            end do
+            tmp = b(k); b(k) = b(ip); b(ip) = tmp
+         end if
+         do i = k + 1, n
+            factor = a(i, k)/a(k, k)
+            do j = k, n
+               a(i, j) = a(i, j) - factor*a(k, j)
+            end do
+            b(i) = b(i) - factor*b(k)
+         end do
+      end do
+      do i = n, 1, -1
+         x(i) = b(i)
+         do j = i + 1, n
+            x(i) = x(i) - a(i, j)*x(j)
+         end do
+         x(i) = x(i)/a(i, i)
+      end do
+   end subroutine solve_small
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -178,12 +178,12 @@ contains
 
    subroutine perform_axis_healing(almnc_rho, rmnc_rho, zmnc_rho, almns_rho, rmns_rho, zmns_rho)
       use new_vmec_stuff_mod, only: rmnc, zmns, almns, rmns, zmnc, almnc, &
-                                    axm, axn, nstrm, axis_healing_polyfit_degree
+                                    axm, nstrm, axis_healing_polyfit_degree
       use vector_potentail_mod, only: ns
 
       real(dp), dimension(:, :), allocatable, intent(out) :: almnc_rho, rmnc_rho, zmnc_rho
       real(dp), dimension(:, :), allocatable, intent(out) :: almns_rho, rmns_rho, zmns_rho
-      integer :: i, m, nrho, nheal, iunit_hs, i_anchor
+      integer :: i, m, nrho, nheal, i_anchor
       character(len=16) :: mode, boundary
 
       nrho = ns
@@ -222,15 +222,12 @@ contains
          end do
 
       case ('legacy', 'legacy_adaptive')
-         iunit_hs = 1357
-         open (iunit_hs, file='healaxis.dat')
          do i = 1, nstrm
             m = nint(abs(axm(i)))
             if (trim(mode) == 'legacy') then
                nheal = min(m, 4)
             else
                call determine_nheal_for_axis(m, ns, rmnc(i, :), nheal)
-               write (iunit_hs, *) 'm = ', m, ' n = ', nint(abs(axn(i))), ' skipped ', nheal, ' / ', ns
             end if
             call s_to_rho_healaxis(m, ns, nrho, nheal, rmnc(i, :), rmnc_rho(i, :))
             call s_to_rho_healaxis(m, ns, nrho, nheal, zmnc(i, :), zmnc_rho(i, :))
@@ -239,7 +236,6 @@ contains
             call s_to_rho_healaxis(m, ns, nrho, nheal, zmns(i, :), zmns_rho(i, :))
             call s_to_rho_healaxis(m, ns, nrho, nheal, almns(i, :), almns_rho(i, :))
          end do
-         close (iunit_hs)
       end select
    end subroutine perform_axis_healing
 

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -178,22 +178,24 @@ contains
 
    subroutine perform_axis_healing(almnc_rho, rmnc_rho, zmnc_rho, almns_rho, rmns_rho, zmns_rho)
       use new_vmec_stuff_mod, only: rmnc, zmns, almns, rmns, zmnc, almnc, &
-                                    axm, axn, nstrm, old_axis_healing_boundary, &
-                                    axis_healing_power_law, axis_healing_polyfit, &
-                                    axis_healing_polyfit_degree
+                                    axm, axn, nstrm, axis_healing_polyfit_degree
       use vector_potentail_mod, only: ns
 
       real(dp), dimension(:, :), allocatable, intent(out) :: almnc_rho, rmnc_rho, zmnc_rho
       real(dp), dimension(:, :), allocatable, intent(out) :: almns_rho, rmns_rho, zmns_rho
-      integer :: i, m, nrho, nheal, i_anchor
+      integer :: i, m, nrho, nheal, iunit_hs, i_anchor
+      character(len=16) :: mode, boundary
 
       nrho = ns
       allocate (almnc_rho(nstrm, 0:nrho - 1), rmnc_rho(nstrm, 0:nrho - 1), zmnc_rho(nstrm, 0:nrho - 1))
       allocate (almns_rho(nstrm, 0:nrho - 1), rmns_rho(nstrm, 0:nrho - 1), zmns_rho(nstrm, 0:nrho - 1))
 
-      if (axis_healing_polyfit) then
+      call resolve_axis_healing_mode(mode, boundary)
+
+      select case (trim(mode))
+      case ('polyfit')
          i_anchor = axis_anchor_index(ns)
-         print *, 'VMEC axis healing: rho**m * polyfit(s) continuation below s = ', &
+         print *, 'VMEC axis healing: polyfit, rho**m * poly(s) below s = ', &
             dble(i_anchor - 1)/dble(ns - 1), ' degree ', axis_healing_polyfit_degree
          do i = 1, nstrm
             m = nint(abs(axm(i)))
@@ -204,12 +206,10 @@ contains
             call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, zmns(i, :), zmns_rho(i, :))
             call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, almns(i, :), almns_rho(i, :))
          end do
-         return
-      end if
 
-      if (axis_healing_power_law) then
+      case ('powerlaw')
          i_anchor = axis_anchor_index(ns)
-         print *, 'VMEC axis healing: rho**m continuation below s = ', &
+         print *, 'VMEC axis healing: powerlaw, rho**m below s = ', &
             dble(i_anchor - 1)/dble(ns - 1)
          do i = 1, nstrm
             m = nint(abs(axm(i)))
@@ -220,26 +220,105 @@ contains
             call s_to_rho_power_law(m, ns, nrho, i_anchor, zmns(i, :), zmns_rho(i, :))
             call s_to_rho_power_law(m, ns, nrho, i_anchor, almns(i, :), almns_rho(i, :))
          end do
-         return
+
+      case ('legacy')
+         iunit_hs = 1357
+         open (iunit_hs, file='healaxis.dat')
+         do i = 1, nstrm
+            m = nint(abs(axm(i)))
+            if (trim(boundary) == 'fixed') then
+               nheal = min(m, 4)
+            else
+               call determine_nheal_for_axis(m, ns, rmnc(i, :), nheal)
+               write (iunit_hs, *) 'm = ', m, ' n = ', nint(abs(axn(i))), ' skipped ', nheal, ' / ', ns
+            end if
+            call s_to_rho_healaxis(m, ns, nrho, nheal, rmnc(i, :), rmnc_rho(i, :))
+            call s_to_rho_healaxis(m, ns, nrho, nheal, zmnc(i, :), zmnc_rho(i, :))
+            call s_to_rho_healaxis(m, ns, nrho, nheal, almnc(i, :), almnc_rho(i, :))
+            call s_to_rho_healaxis(m, ns, nrho, nheal, rmns(i, :), rmns_rho(i, :))
+            call s_to_rho_healaxis(m, ns, nrho, nheal, zmns(i, :), zmns_rho(i, :))
+            call s_to_rho_healaxis(m, ns, nrho, nheal, almns(i, :), almns_rho(i, :))
+         end do
+         close (iunit_hs)
+      end select
+   end subroutine perform_axis_healing
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   subroutine resolve_axis_healing_mode(mode, boundary)
+      !> Resolves the axis-healing selector. The preferred inputs are the strings
+      !> axis_healing ('legacy'|'powerlaw'|'polyfit') and axis_healing_boundary
+      !> ('fixed'|'adaptive'). When axis_healing is empty the deprecated logical
+      !> switches are mapped to a mode and a one-time deprecation warning is
+      !> emitted, together with a notice that a future release will default to
+      !> 'polyfit'. Unknown values stop the run.
+      use new_vmec_stuff_mod, only: axis_healing, axis_healing_boundary, &
+                                    old_axis_healing_boundary, &
+                                    axis_healing_power_law, axis_healing_polyfit
+
+      character(len=*), intent(out) :: mode, boundary
+      logical :: from_legacy
+
+      from_legacy = (len_trim(axis_healing) == 0)
+      if (from_legacy) then
+         if (axis_healing_polyfit) then
+            mode = 'polyfit'
+         else if (axis_healing_power_law) then
+            mode = 'powerlaw'
+         else
+            mode = 'legacy'
+         end if
+      else
+         mode = to_lower(adjustl(axis_healing))
       end if
 
-      do i = 1, nstrm
-         m = nint(abs(axm(i)))
-
+      if (len_trim(axis_healing_boundary) == 0) then
          if (old_axis_healing_boundary) then
-            nheal = min(m, 4)
+            boundary = 'fixed'
          else
-            call determine_nheal_for_axis(m, ns, rmnc(i, :), nheal)
+            boundary = 'adaptive'
          end if
+      else
+         boundary = to_lower(adjustl(axis_healing_boundary))
+      end if
 
-         call s_to_rho_healaxis(m, ns, nrho, nheal, rmnc(i, :), rmnc_rho(i, :))
-         call s_to_rho_healaxis(m, ns, nrho, nheal, zmnc(i, :), zmnc_rho(i, :))
-         call s_to_rho_healaxis(m, ns, nrho, nheal, almnc(i, :), almnc_rho(i, :))
-         call s_to_rho_healaxis(m, ns, nrho, nheal, rmns(i, :), rmns_rho(i, :))
-         call s_to_rho_healaxis(m, ns, nrho, nheal, zmns(i, :), zmns_rho(i, :))
-         call s_to_rho_healaxis(m, ns, nrho, nheal, almns(i, :), almns_rho(i, :))
+      select case (trim(mode))
+      case ('legacy', 'powerlaw', 'polyfit')
+      case default
+         print *, 'ERROR: unknown axis_healing = ''', trim(axis_healing), ''''
+         error stop 'unknown axis_healing mode (use legacy|powerlaw|polyfit)'
+      end select
+      select case (trim(boundary))
+      case ('fixed', 'adaptive')
+      case default
+         print *, 'ERROR: unknown axis_healing_boundary = ''', trim(axis_healing_boundary), ''''
+         error stop 'unknown axis_healing_boundary (use fixed|adaptive)'
+      end select
+
+      if (from_legacy) then
+         print *, 'WARNING: axis_healing not set; mapped legacy switches to axis_healing=''', &
+            trim(mode), '''. The old_axis_healing*/axis_healing_power_law/axis_healing_polyfit'
+         print *, '         switches are deprecated; set axis_healing (and axis_healing_boundary)'
+         print *, '         explicitly. A future SIMPLE release will default axis_healing to ''polyfit''.'
+      end if
+      if (trim(mode) /= 'polyfit') then
+         print *, 'NOTE: axis_healing=''', trim(mode), '''; ''polyfit'' is recommended and will', &
+            ' become the default. Please test it.'
+      end if
+   end subroutine resolve_axis_healing_mode
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   pure function to_lower(s) result(t)
+      character(len=*), intent(in) :: s
+      character(len=len(s)) :: t
+      integer :: i, c
+      t = s
+      do i = 1, len_trim(s)
+         c = iachar(s(i:i))
+         if (c >= iachar('A') .and. c <= iachar('Z')) t(i:i) = achar(c + 32)
       end do
-   end subroutine perform_axis_healing
+   end function to_lower
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -221,12 +221,12 @@ contains
             call s_to_rho_power_law(m, ns, nrho, i_anchor, almns(i, :), almns_rho(i, :))
          end do
 
-      case ('legacy')
+      case ('legacy', 'legacy_adaptive')
          iunit_hs = 1357
          open (iunit_hs, file='healaxis.dat')
          do i = 1, nstrm
             m = nint(abs(axm(i)))
-            if (trim(boundary) == 'fixed') then
+            if (trim(mode) == 'legacy') then
                nheal = min(m, 4)
             else
                call determine_nheal_for_axis(m, ns, rmnc(i, :), nheal)
@@ -247,13 +247,10 @@ contains
 
    subroutine resolve_axis_healing_mode(mode, boundary)
       !> Resolves the axis-healing selector. The preferred inputs are the strings
-      !> axis_healing ('legacy'|'powerlaw'|'polyfit') and axis_healing_boundary
-      !> ('fixed'|'adaptive'). When axis_healing is empty the deprecated logical
-      !> switches are mapped to a mode and a one-time deprecation warning is
-      !> emitted, together with a notice that a future release will default to
-      !> 'polyfit'. Unknown values stop the run.
-      use new_vmec_stuff_mod, only: axis_healing, axis_healing_boundary, &
-                                    old_axis_healing_boundary, &
+      !> axis_healing ('legacy'|'legacy_adaptive'|'powerlaw'|'polyfit').
+      !> When axis_healing is empty the deprecated logical switches are mapped to
+      !> a mode and a deprecation warning is emitted. Unknown values stop the run.
+      use new_vmec_stuff_mod, only: axis_healing, old_axis_healing_boundary, &
                                     axis_healing_power_law, axis_healing_polyfit
 
       character(len=*), intent(out) :: mode, boundary
@@ -265,45 +262,36 @@ contains
             mode = 'polyfit'
          else if (axis_healing_power_law) then
             mode = 'powerlaw'
-         else
+         else if (old_axis_healing_boundary) then
             mode = 'legacy'
+         else
+            mode = 'legacy_adaptive'
          end if
       else
          mode = to_lower(adjustl(axis_healing))
       end if
 
-      if (len_trim(axis_healing_boundary) == 0) then
-         if (old_axis_healing_boundary) then
-            boundary = 'fixed'
-         else
-            boundary = 'adaptive'
-         end if
-      else
-         boundary = to_lower(adjustl(axis_healing_boundary))
-      end if
-
       select case (trim(mode))
-      case ('legacy', 'powerlaw', 'polyfit')
+      case ('legacy')
+         boundary = 'fixed'
+      case ('legacy_adaptive')
+         boundary = 'adaptive'
+      case ('powerlaw', 'polyfit')
+         boundary = ''
       case default
          print *, 'ERROR: unknown axis_healing = ''', trim(axis_healing), ''''
-         error stop 'unknown axis_healing mode (use legacy|powerlaw|polyfit)'
-      end select
-      select case (trim(boundary))
-      case ('fixed', 'adaptive')
-      case default
-         print *, 'ERROR: unknown axis_healing_boundary = ''', trim(axis_healing_boundary), ''''
-         error stop 'unknown axis_healing_boundary (use fixed|adaptive)'
+         error stop 'unknown axis_healing mode (use legacy|legacy_adaptive|powerlaw|polyfit)'
       end select
 
       if (from_legacy) then
          print *, 'WARNING: axis_healing not set; mapped legacy switches to axis_healing=''', &
             trim(mode), '''. The old_axis_healing*/axis_healing_power_law/axis_healing_polyfit'
-         print *, '         switches are deprecated; set axis_healing (and axis_healing_boundary)'
-         print *, '         explicitly. A future SIMPLE release will default axis_healing to ''polyfit''.'
+         print *, '         switches are deprecated; set axis_healing=''', trim(mode), ''' instead.'
+         print *, '         These switches will become errors in the next SIMPLE release.'
       end if
       if (trim(mode) /= 'polyfit') then
-         print *, 'NOTE: axis_healing=''', trim(mode), '''; ''polyfit'' is recommended and will', &
-            ' become the default. Please test it.'
+         print *, 'NOTE: axis_healing=''', trim(mode), '''; ''polyfit'' is recommended and will'
+         print *, '      become the default. Please test it.'
       end if
    end subroutine resolve_axis_healing_mode
 
@@ -1583,16 +1571,28 @@ contains
 
    function axis_anchor_index(ns) result(i_anchor)
       !> Innermost reliable full-grid surface: the first surface at or
-      !> outside rho_axis_heal. VMEC full-grid harmonics inside this
-      !> radius violate the rho**|m| analyticity condition (the radial
-      !> startup layer), so they are discarded and replaced by the
-      !> power-law continuation.
-      use new_vmec_stuff_mod, only: rho_axis_heal, ns_s
+      !> outside s_axis_heal. VMEC full-grid harmonics inside this
+      !> startup layer can violate the rho**|m| analyticity condition, so
+      !> they are discarded and replaced by the selected continuation.
+      use new_vmec_stuff_mod, only: s_axis_heal, rho_axis_heal, ns_s, &
+                                    rho_axis_heal_warning_printed
 
       integer, intent(in) :: ns
       integer :: i_anchor
+      real(dp) :: s_heal
 
-      i_anchor = 1 + nint(rho_axis_heal**2*dble(ns - 1))
+      if (rho_axis_heal > 0.0d0) then
+         s_heal = rho_axis_heal**2
+         if (.not. rho_axis_heal_warning_printed) then
+            print *, 'WARNING: rho_axis_heal is deprecated; use s_axis_heal = ', s_heal
+            print *, '         This setting will become an error in the next SIMPLE release.'
+            rho_axis_heal_warning_printed = .True.
+         end if
+      else
+         s_heal = s_axis_heal
+      end if
+
+      i_anchor = 1 + nint(s_heal*dble(ns - 1))
       i_anchor = max(2, min(i_anchor, ns - ns_s - 1))
    end function axis_anchor_index
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,13 @@ target_link_libraries(test_axis_power_law_regularization.x
   neo
 )
 
+add_executable(test_axis_polyfit_regularization.x
+  source/test_axis_polyfit_regularization.f90
+)
+target_link_libraries(test_axis_polyfit_regularization.x
+  neo
+)
+
 add_executable(test_flux_pseudocartesian.x
   source/test_flux_pseudocartesian.f90
 )
@@ -223,6 +230,8 @@ target_link_libraries(test_nctools_nc_get3.x
 add_test(NAME test_binsrc COMMAND test_binsrc.x)
 add_test(NAME test_axis_power_law_regularization
   COMMAND test_axis_power_law_regularization.x)
+add_test(NAME test_axis_polyfit_regularization
+  COMMAND test_axis_polyfit_regularization.x)
 add_test(NAME test_flux_pseudocartesian
   COMMAND test_flux_pseudocartesian.x)
 add_test(NAME test_christoffel_symflux

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,6 +103,13 @@ target_link_libraries(test_coordinate_christoffel.x
   neo
 )
 
+add_executable(test_axis_healing_mode.x
+  source/test_axis_healing_mode.f90
+)
+target_link_libraries(test_axis_healing_mode.x
+  neo
+)
+
 add_executable(test_geqdsk_tools.x source/test_geqdsk_tools.f90)
 target_link_libraries(test_geqdsk_tools.x
   ${MAIN_LIB}
@@ -238,6 +245,8 @@ add_test(NAME test_christoffel_symflux
   COMMAND test_christoffel_symflux.x)
 add_test(NAME test_coordinate_christoffel
   COMMAND test_coordinate_christoffel.x)
+add_test(NAME test_axis_healing_mode
+  COMMAND test_axis_healing_mode.x)
 add_test(NAME test_boozer_coordinates_exports
   COMMAND test_boozer_coordinates_exports.x
 )

--- a/test/collisions/test_collision_freqs.f90
+++ b/test/collisions/test_collision_freqs.f90
@@ -1,7 +1,7 @@
 program test_collision_freqs
 
     use libneo_kinds, only : dp
-    use libneo_collisions, only: calc_perp_coll_freq_slow_limit_ee, calc_perp_coll_freq_fast_limit_ee, &
+    use libneo_collisions, only: calc_perp_coll_freq_fast_limit_ee, &
         calc_coulomb_log, calc_perp_coll_freq
     use util_for_test, only: print_test, print_ok, print_fail
 

--- a/test/field/test_field.f90
+++ b/test/field/test_field.f90
@@ -88,7 +88,7 @@ end subroutine test_create_spline_field
 
 
 subroutine test_create_spline_field_from_mesh
-    use neo_field, only: field_t, create_spline_field_from_mesh
+    use neo_field, only: field_t
     use neo_field, only: field_mesh_t
 
     class(field_t), allocatable :: field

--- a/test/poincare/benchmark_poincare.f90
+++ b/test/poincare/benchmark_poincare.f90
@@ -1,6 +1,5 @@
 program benchmark_poincare
     use neo_poincare
-    use neo_field_base, only: field_t
     use neo_example_field, only: example_field_t
     use libneo_kinds, only: dp
     implicit none

--- a/test/source/test_axis_healing_mode.f90
+++ b/test/source/test_axis_healing_mode.f90
@@ -1,0 +1,68 @@
+program test_axis_healing_mode
+    !> resolve_axis_healing_mode maps the axis_healing / axis_healing_boundary
+    !> selectors and the deprecated boolean switches to a (mode, boundary) pair.
+    !> Explicit selectors win and are case-insensitive; when axis_healing is empty
+    !> the legacy booleans are mapped for back-compat.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use new_vmec_stuff_mod, only: axis_healing, axis_healing_boundary, &
+                                  old_axis_healing, old_axis_healing_boundary, &
+                                  axis_healing_power_law, axis_healing_polyfit
+    use spline_vmec_sub, only: resolve_axis_healing_mode
+    implicit none
+
+    character(len=16) :: mode, boundary
+
+    ! Defaults (everything unset) reproduce the legacy/fixed behavior.
+    call reset()
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'legacy', boundary, 'fixed', 'defaults')
+
+    ! Deprecated booleans map to the right mode.
+    call reset(); axis_healing_power_law = .True.
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'powerlaw', boundary, 'fixed', 'legacy bool powerlaw')
+
+    call reset(); axis_healing_polyfit = .True.
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'polyfit', boundary, 'fixed', 'legacy bool polyfit')
+
+    call reset(); old_axis_healing_boundary = .False.
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'legacy', boundary, 'adaptive', 'legacy bool adaptive boundary')
+
+    ! Explicit selector overrides the booleans and is case-insensitive.
+    call reset(); axis_healing = 'polyfit'; axis_healing_power_law = .True.
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'polyfit', boundary, 'fixed', 'explicit overrides bool')
+
+    call reset(); axis_healing = 'POWERLAW'
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'powerlaw', boundary, 'fixed', 'case-insensitive')
+
+    call reset(); axis_healing = 'legacy'; axis_healing_boundary = 'Adaptive'
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'legacy', boundary, 'adaptive', 'explicit boundary')
+
+    print *, 'axis healing mode resolution: all checks passed'
+
+contains
+
+    subroutine reset()
+        axis_healing = ''
+        axis_healing_boundary = ''
+        old_axis_healing = .True.
+        old_axis_healing_boundary = .True.
+        axis_healing_power_law = .False.
+        axis_healing_polyfit = .False.
+    end subroutine reset
+
+    subroutine expect(mode, mode_exp, boundary, boundary_exp, label)
+        character(len=*), intent(in) :: mode, mode_exp, boundary, boundary_exp, label
+        if (trim(mode) /= mode_exp .or. trim(boundary) /= boundary_exp) then
+            print *, 'FAIL [', label, ']: got mode=', trim(mode), ' boundary=', trim(boundary), &
+                ' expected mode=', mode_exp, ' boundary=', boundary_exp
+            error stop 1
+        end if
+    end subroutine expect
+
+end program test_axis_healing_mode

--- a/test/source/test_axis_healing_mode.f90
+++ b/test/source/test_axis_healing_mode.f90
@@ -1,11 +1,10 @@
 program test_axis_healing_mode
-    !> resolve_axis_healing_mode maps the axis_healing / axis_healing_boundary
-    !> selectors and the deprecated boolean switches to a (mode, boundary) pair.
+    !> resolve_axis_healing_mode maps the axis_healing selector and the
+    !> deprecated boolean switches to a (mode, boundary) pair.
     !> Explicit selectors win and are case-insensitive; when axis_healing is empty
     !> the legacy booleans are mapped for back-compat.
-    use, intrinsic :: iso_fortran_env, only: dp => real64
-    use new_vmec_stuff_mod, only: axis_healing, axis_healing_boundary, &
-                                  old_axis_healing, old_axis_healing_boundary, &
+    use new_vmec_stuff_mod, only: axis_healing, old_axis_healing, &
+                                  old_axis_healing_boundary, &
                                   axis_healing_power_law, axis_healing_polyfit
     use spline_vmec_sub, only: resolve_axis_healing_mode
     implicit none
@@ -20,28 +19,28 @@ program test_axis_healing_mode
     ! Deprecated booleans map to the right mode.
     call reset(); axis_healing_power_law = .True.
     call resolve_axis_healing_mode(mode, boundary)
-    call expect(mode, 'powerlaw', boundary, 'fixed', 'legacy bool powerlaw')
+    call expect(mode, 'powerlaw', boundary, '', 'legacy bool powerlaw')
 
     call reset(); axis_healing_polyfit = .True.
     call resolve_axis_healing_mode(mode, boundary)
-    call expect(mode, 'polyfit', boundary, 'fixed', 'legacy bool polyfit')
+    call expect(mode, 'polyfit', boundary, '', 'legacy bool polyfit')
 
     call reset(); old_axis_healing_boundary = .False.
     call resolve_axis_healing_mode(mode, boundary)
-    call expect(mode, 'legacy', boundary, 'adaptive', 'legacy bool adaptive boundary')
+    call expect(mode, 'legacy_adaptive', boundary, 'adaptive', 'legacy bool adaptive boundary')
 
     ! Explicit selector overrides the booleans and is case-insensitive.
     call reset(); axis_healing = 'polyfit'; axis_healing_power_law = .True.
     call resolve_axis_healing_mode(mode, boundary)
-    call expect(mode, 'polyfit', boundary, 'fixed', 'explicit overrides bool')
+    call expect(mode, 'polyfit', boundary, '', 'explicit overrides bool')
 
     call reset(); axis_healing = 'POWERLAW'
     call resolve_axis_healing_mode(mode, boundary)
-    call expect(mode, 'powerlaw', boundary, 'fixed', 'case-insensitive')
+    call expect(mode, 'powerlaw', boundary, '', 'case-insensitive')
 
-    call reset(); axis_healing = 'legacy'; axis_healing_boundary = 'Adaptive'
+    call reset(); axis_healing = 'legacy_adaptive'; axis_healing_power_law = .True.
     call resolve_axis_healing_mode(mode, boundary)
-    call expect(mode, 'legacy', boundary, 'adaptive', 'explicit boundary')
+    call expect(mode, 'legacy_adaptive', boundary, 'adaptive', 'explicit adaptive legacy')
 
     print *, 'axis healing mode resolution: all checks passed'
 
@@ -49,7 +48,6 @@ contains
 
     subroutine reset()
         axis_healing = ''
-        axis_healing_boundary = ''
         old_axis_healing = .True.
         old_axis_healing_boundary = .True.
         axis_healing_power_law = .False.

--- a/test/source/test_axis_polyfit_regularization.f90
+++ b/test/source/test_axis_polyfit_regularization.f90
@@ -5,7 +5,7 @@ program test_axis_polyfit_regularization
     !> the continuation is continuous at the anchor, and unlike the pure power-law
     !> path it does not amplify noise into near-axis oscillations.
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use new_vmec_stuff_mod, only: ns_s, rho_axis_heal
+    use new_vmec_stuff_mod, only: ns_s, s_axis_heal, rho_axis_heal
     use spline_vmec_sub, only: s_to_rho_polyfit, axis_anchor_index
     implicit none
 
@@ -13,7 +13,8 @@ program test_axis_polyfit_regularization
     real(dp), parameter :: amp = 0.75_dp
 
     ns_s = 5
-    rho_axis_heal = 0.1_dp
+    s_axis_heal = 1.0e-2_dp
+    rho_axis_heal = -1.0_dp
 
     call test_axis_vanishing()
     call test_zernike_reproduction()

--- a/test/source/test_axis_polyfit_regularization.f90
+++ b/test/source/test_axis_polyfit_regularization.f90
@@ -1,0 +1,128 @@
+program test_axis_polyfit_regularization
+    !> rho**|m| * polyfit(s) near-axis continuation (s_to_rho_polyfit): a harmonic
+    !> with m>0 vanishes at the axis, an exact Zernike radial input c = rho**m *
+    !> P(s) is reproduced (the reduced amplitude is a low-degree polynomial in s),
+    !> the continuation is continuous at the anchor, and unlike the pure power-law
+    !> path it does not amplify noise into near-axis oscillations.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use new_vmec_stuff_mod, only: ns_s, rho_axis_heal
+    use spline_vmec_sub, only: s_to_rho_polyfit, axis_anchor_index
+    implicit none
+
+    integer, parameter :: ns = 100, nrho = 100, ndeg = 3
+    real(dp), parameter :: amp = 0.75_dp
+
+    ns_s = 5
+    rho_axis_heal = 0.1_dp
+
+    call test_axis_vanishing()
+    call test_zernike_reproduction()
+    call test_anchor_continuity()
+    call test_no_noise_oscillation()
+
+    print *, 'axis polyfit regularization: all checks passed'
+
+contains
+
+    subroutine test_axis_vanishing()
+        integer :: i_anchor
+        real(dp) :: arr_in(ns), arr_out(nrho)
+        i_anchor = axis_anchor_index(ns)
+        call fill_zernike(2, arr_in)
+        call s_to_rho_polyfit(2, ns, nrho, i_anchor, ndeg, arr_in, arr_out)
+        if (abs(arr_out(1)) > 1.0e-13_dp) then
+            print *, 'arr_out at rho=0 =', arr_out(1)
+            error stop 'm>0 harmonic does not vanish at the axis'
+        end if
+    end subroutine test_axis_vanishing
+
+    !> c(rho) = amp*rho**m*(1 + 0.5 s + 0.2 s**2) has reduced amplitude
+    !> c/rho**m = amp*(1 + 0.5 s + 0.2 s**2), a degree-2 polynomial in s, so a
+    !> degree-3 polyfit must reproduce it on the whole rho grid.
+    subroutine test_zernike_reproduction()
+        integer, parameter :: ms(3) = [1, 2, 4]
+        integer :: im, m, i_anchor, irho
+        real(dp) :: arr_in(ns), arr_out(nrho)
+        real(dp) :: rho, s, expected, max_err
+        i_anchor = axis_anchor_index(ns)
+        do im = 1, size(ms)
+            m = ms(im)
+            call fill_zernike(m, arr_in)
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, ndeg, arr_in, arr_out)
+            max_err = 0.0_dp
+            do irho = 1, nrho
+                rho = real(irho - 1, dp)/real(nrho - 1, dp)
+                s = rho*rho
+                expected = amp*rho**m*(1.0_dp + 0.5_dp*s + 0.2_dp*s*s)
+                max_err = max(max_err, abs(arr_out(irho) - expected))
+            end do
+            if (max_err > 1.0e-8_dp) then
+                print *, 'm =', m, ' max |arr_out - zernike| =', max_err
+                error stop 'Zernike radial polynomial not reproduced'
+            end if
+        end do
+    end subroutine test_zernike_reproduction
+
+    subroutine test_anchor_continuity()
+        integer :: i_anchor, irho, irho_below, irho_above
+        real(dp) :: arr_in(ns), arr_out(nrho), rho, rho_anchor, jump
+        i_anchor = axis_anchor_index(ns)
+        rho_anchor = sqrt(real(i_anchor - 1, dp)/real(ns - 1, dp))
+        call fill_zernike(2, arr_in)
+        call s_to_rho_polyfit(2, ns, nrho, i_anchor, ndeg, arr_in, arr_out)
+        irho_below = 0; irho_above = 0
+        do irho = 1, nrho
+            rho = real(irho - 1, dp)/real(nrho - 1, dp)
+            if (rho < rho_anchor) irho_below = irho
+            if (rho >= rho_anchor .and. irho_above == 0) irho_above = irho
+        end do
+        jump = abs(arr_out(irho_above) - arr_out(irho_below))
+        if (jump > 5.0e-3_dp) then
+            print *, 'jump across anchor =', jump
+            error stop 'discontinuity in polyfit continuation at the anchor'
+        end if
+    end subroutine test_anchor_continuity
+
+    !> Reduced-amplitude noise on the reliable surfaces must not blow up into
+    !> a near-axis oscillation: the least-squares fit smooths it. The second
+    !> difference of arr_out below the anchor stays comparable to the input
+    !> perturbation, not orders of magnitude larger (the power-law failure mode).
+    subroutine test_no_noise_oscillation()
+        integer :: i_anchor, irho, n_below
+        real(dp) :: arr_in(ns), arr_out(nrho)
+        real(dp) :: rho, rho_anchor, d2, max_d2
+        i_anchor = axis_anchor_index(ns)
+        rho_anchor = sqrt(real(i_anchor - 1, dp)/real(ns - 1, dp))
+        call fill_zernike(1, arr_in)
+        ! add a small deterministic perturbation to the reliable surfaces
+        do irho = i_anchor, ns
+            arr_in(irho) = arr_in(irho) + 1.0e-3_dp*amp*sin(7.0_dp*real(irho, dp))
+        end do
+        call s_to_rho_polyfit(1, ns, nrho, i_anchor, ndeg, arr_in, arr_out)
+        max_d2 = 0.0_dp
+        n_below = 0
+        do irho = 2, nrho - 1
+            rho = real(irho - 1, dp)/real(nrho - 1, dp)
+            if (rho >= rho_anchor) cycle
+            d2 = abs(arr_out(irho + 1) - 2.0_dp*arr_out(irho) + arr_out(irho - 1))
+            max_d2 = max(max_d2, d2)
+            n_below = n_below + 1
+        end do
+        if (n_below > 0 .and. max_d2 > 1.0e-2_dp) then
+            print *, 'max |second difference| below anchor =', max_d2
+            error stop 'polyfit continuation oscillates near the axis'
+        end if
+    end subroutine test_no_noise_oscillation
+
+    subroutine fill_zernike(m, arr_in)
+        integer, intent(in) :: m
+        real(dp), intent(out) :: arr_in(ns)
+        integer :: is
+        real(dp) :: s
+        do is = 1, ns
+            s = real(is - 1, dp)/real(ns - 1, dp)
+            arr_in(is) = amp*sqrt(s)**m*(1.0_dp + 0.5_dp*s + 0.2_dp*s*s)
+        end do
+    end subroutine fill_zernike
+
+end program test_axis_polyfit_regularization

--- a/test/source/test_axis_power_law_regularization.f90
+++ b/test/source/test_axis_power_law_regularization.f90
@@ -1,6 +1,6 @@
 program test_axis_power_law_regularization
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use new_vmec_stuff_mod, only: ns_s, rho_axis_heal
+    use new_vmec_stuff_mod, only: ns_s, s_axis_heal, rho_axis_heal
     use spline_vmec_sub, only: s_to_rho_power_law, axis_anchor_index
     implicit none
 
@@ -20,17 +20,24 @@ contains
 
     !> The innermost reliable surface index used by the rho**|m| continuation.
     subroutine test_anchor_index()
-        rho_axis_heal = 0.1_dp
+        s_axis_heal = 1.0e-2_dp
+        rho_axis_heal = -1.0_dp
         if (axis_anchor_index(ns) /= 2) then
-            print *, 'i_anchor(rho_heal=0.1) =', axis_anchor_index(ns), 'expected 2'
-            error stop 'axis_anchor_index mismatch for rho_axis_heal=0.1'
+            print *, 'i_anchor(s_axis_heal=0.01) =', axis_anchor_index(ns), 'expected 2'
+            error stop 'axis_anchor_index mismatch for s_axis_heal=0.01'
+        end if
+        s_axis_heal = 9.0e-2_dp
+        if (axis_anchor_index(ns) /= 10) then
+            print *, 'i_anchor(s_axis_heal=0.09) =', axis_anchor_index(ns), 'expected 10'
+            error stop 'axis_anchor_index mismatch for s_axis_heal=0.09'
         end if
         rho_axis_heal = 0.3_dp
         if (axis_anchor_index(ns) /= 10) then
-            print *, 'i_anchor(rho_heal=0.3) =', axis_anchor_index(ns), 'expected 10'
-            error stop 'axis_anchor_index mismatch for rho_axis_heal=0.3'
+            print *, 'i_anchor(rho_axis_heal=0.3) =', axis_anchor_index(ns), 'expected 10'
+            error stop 'deprecated rho_axis_heal conversion mismatch'
         end if
-        rho_axis_heal = 0.1_dp
+        s_axis_heal = 1.0e-2_dp
+        rho_axis_heal = -1.0_dp
     end subroutine test_anchor_index
 
     !> A harmonic with m>0 must vanish at the magnetic axis (rho=0).
@@ -38,7 +45,8 @@ contains
         integer :: i_anchor
         real(dp) :: arr_in(ns), arr_out(nrho)
 
-        rho_axis_heal = 0.1_dp
+        s_axis_heal = 1.0e-2_dp
+        rho_axis_heal = -1.0_dp
         i_anchor = axis_anchor_index(ns)
         call fill_power_law(2, arr_in)
         call s_to_rho_power_law(2, ns, nrho, i_anchor, arr_in, arr_out)
@@ -57,7 +65,8 @@ contains
         real(dp) :: arr_in(ns), arr_out(nrho)
         real(dp) :: rho, expected, err, max_err
 
-        rho_axis_heal = 0.1_dp
+        s_axis_heal = 1.0e-2_dp
+        rho_axis_heal = -1.0_dp
         i_anchor = axis_anchor_index(ns)
         do im = 1, size(ms)
             m = ms(im)
@@ -83,7 +92,8 @@ contains
         real(dp) :: arr_in(ns), arr_out(nrho)
         real(dp) :: rho, rho_anchor, jump
 
-        rho_axis_heal = 0.1_dp
+        s_axis_heal = 1.0e-2_dp
+        rho_axis_heal = -1.0_dp
         i_anchor = axis_anchor_index(ns)
         rho_anchor = sqrt(real(i_anchor - 1, dp)/real(ns - 1, dp))
         call fill_power_law(2, arr_in)

--- a/test/source/test_chartmap_coordinates.f90
+++ b/test/source/test_chartmap_coordinates.f90
@@ -4,7 +4,7 @@ program test_chartmap_coordinates
                                   make_chartmap_coordinate_system, &
                                   chartmap_coordinate_system_t
     use math_constants, only: TWOPI
-    use nctools_module, only: nc_close, nc_get, nc_inq_dim, nc_open
+    use nctools_module, only: nc_close, nc_get, nc_open
     use netcdf
     implicit none
 

--- a/test/source/test_coordinate_systems.f90
+++ b/test/source/test_coordinate_systems.f90
@@ -1,5 +1,4 @@
 program test_coordinate_systems
-    use, intrinsic :: iso_fortran_env, only: dp => real64
     use libneo_coordinates
     implicit none
 

--- a/test/source/test_rng.f90
+++ b/test/source/test_rng.f90
@@ -1,6 +1,4 @@
 program test_rng
-    use, intrinsic :: iso_fortran_env, only: dp => real64
-
     implicit none
 
     logical :: all_passed

--- a/test/source/test_vector_conversion.f90
+++ b/test/source/test_vector_conversion.f90
@@ -3,7 +3,6 @@ program test_vector_conversion
     use libneo_coordinates, only: coordinate_system_t, &
                                   make_chartmap_coordinate_system, &
                                   chartmap_coordinate_system_t
-    use math_constants, only: TWOPI
     implicit none
 
     integer :: nerrors

--- a/test/transport/test_transport.f90
+++ b/test/transport/test_transport.f90
@@ -2,7 +2,7 @@ program test_transport
 
     use libneo_kinds, only: dp
     use libneo_transport, only: init_gauss_laguerre_integration, calc_D_one_over_nu, gauss_laguerre_order
-    use util_for_test, only: print_test, print_ok, print_fail
+    use util_for_test, only: print_ok, print_fail
 
     implicit none
 


### PR DESCRIPTION
## Problem

The near-axis VMEC harmonic continuation needs two separate controls:

- the continuation model (`legacy`, adaptive legacy, `powerlaw`, `polyfit`)
- the flux radius where the regularized model takes over

The previous public surface exposed implementation booleans and a radius-like `rho_axis_heal`, while SIMPLE users otherwise configure and diagnose near-axis orbits in the VMEC flux variable `s`.

## Change

- Add the public selector `axis_healing` with values:

```fortran
axis_healing = 'legacy'
axis_healing = 'legacy_adaptive'
axis_healing = 'powerlaw'
axis_healing = 'polyfit'
```

- Add `s_axis_heal` as the public anchor for `powerlaw` and `polyfit`.
- Keep `rho_axis_heal` as deprecated compatibility. If set, it is converted to `s_axis_heal = rho_axis_heal**2` and warns.
- Keep the old boolean switches as deprecated compatibility. They map to the enum and warn.
- Keep `legacy_adaptive` as a diagnostic control: it uses the old extrapolation with the old adaptive reliability boundary.
- Keep the internal regularity as `rho^|m| * P(s)`: the public boundary is in `s`, but the harmonic parity at the axis is still enforced with `rho = sqrt(s)`.

The PR also contains `s_to_rho_polyfit`, `flux_pseudocartesian`, and the near-axis diagnostic app from the existing investigation branch.

## Verification

### Test fails before downstream tooling fix

SIMPLE's full gate previously scanned generated build/dependency copies:

```text
LIBNEO_BRANCH=feat/near-axis-field-investigation fo check
fo: too many source files, max 2048
Build: OK (469 modules, 0 cached, 469 changed, 469 affected) Tests: pass (2.5s)
```

### Test passes after fix

libneo focused gate:

```text
fo check
Build: OK (41 modules, 0 cached, 41 changed, 41 affected) Tests: pass (.0s)
```

SIMPLE downstream gate with lazy-fortran/fo@502ba14 installed:

```text
LIBNEO_BRANCH=feat/near-axis-field-investigation fo
Static: OK (8 modules, 8 changed, 8 affected)
Build: OK
Tests: skipped, no affected tests
Lint: OK
All stages passed (1.8s)
```

Full `fo` in libneo currently builds and lints, but the formatter reports existing repository-wide formatting changes outside this PR's scope. Those were not applied here.
