### PR TITLE
Add flux_pseudocartesian (X,Y) near-axis chart

### DIFF
--- a/CMakeSources.in
+++ b/CMakeSources.in
@@ -16,6 +16,7 @@ add_library(neo STATIC
     src/nctools_module.f90
     src/new_vmec_allocation_stuff.f90
     src/coordinates/cylindrical_cartesian.f90
+    src/coordinates/flux_pseudocartesian.f90
     src/coordinates/vmec_coordinates.f90
     src/coordinates/geoflux_coordinates.f90
     src/coordinates/libneo_coordinate_conventions.f90

--- a/src/coordinates/flux_pseudocartesian.f90
+++ b/src/coordinates/flux_pseudocartesian.f90
@@ -1,0 +1,82 @@
+module flux_pseudocartesian
+
+    !> Pseudo-Cartesian near-axis chart for a flux radial coordinate s and a
+    !> poloidal angle theta: X = sqrt(s) cos(theta), Y = sqrt(s) sin(theta), with
+    !> the toroidal angle carried through unchanged. Flux coordinates are singular
+    !> at the magnetic axis (s = 0): the poloidal angle is undefined and basis
+    !> vectors diverge, so implicit orbit steps fail to converge through axis
+    !> crossings. In (X, Y) the map back to (s, theta) is smooth (s = X^2 + Y^2,
+    !> ds/dX = 2X, ...), so a solver that works in (X, Y) sees no singularity.
+    !> See e.g. pseudo-Cartesian linearisation near the axis in guiding-centre
+    !> orbit work (Pfefferle et al., arXiv:1412.5464).
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+
+    implicit none
+
+    private
+    public :: flux_to_pseudocart, pseudocart_to_flux
+
+contains
+
+    pure subroutine flux_to_pseudocart(xfrom, xto, dxto_dxfrom)
+        !> (s, theta, phi) -> (X, Y, phi). The radial column of the Jacobian
+        !> carries the 1/(2 sqrt(s)) axis singularity of the forward map; it is
+        !> set to zero at s = 0. Prefer pseudocart_to_flux for near-axis work.
+        real(dp), intent(in) :: xfrom(3)
+        real(dp), intent(out) :: xto(3)
+        real(dp), intent(out), optional :: dxto_dxfrom(3, 3)
+        real(dp) :: s, theta, rho, cth, sth
+
+        s = xfrom(1)
+        theta = xfrom(2)
+        rho = sqrt(max(s, 0.0_dp))
+        cth = cos(theta)
+        sth = sin(theta)
+
+        xto(1) = rho*cth
+        xto(2) = rho*sth
+        xto(3) = xfrom(3)
+
+        if (present(dxto_dxfrom)) then
+            dxto_dxfrom = 0.0_dp
+            if (rho > 0.0_dp) then
+                dxto_dxfrom(1, 1) = 0.5_dp*cth/rho
+                dxto_dxfrom(2, 1) = 0.5_dp*sth/rho
+            end if
+            dxto_dxfrom(1, 2) = -rho*sth
+            dxto_dxfrom(2, 2) = rho*cth
+            dxto_dxfrom(3, 3) = 1.0_dp
+        end if
+    end subroutine flux_to_pseudocart
+
+    pure subroutine pseudocart_to_flux(xfrom, xto, dxto_dxfrom)
+        !> (X, Y, phi) -> (s, theta, phi). The map and its s-derivatives are
+        !> smooth across the axis; only the theta-derivative is singular at the
+        !> axis and is set to zero there.
+        real(dp), intent(in) :: xfrom(3)
+        real(dp), intent(out) :: xto(3)
+        real(dp), intent(out), optional :: dxto_dxfrom(3, 3)
+        real(dp) :: x, y, s
+
+        x = xfrom(1)
+        y = xfrom(2)
+        s = x*x + y*y
+
+        xto(1) = s
+        xto(2) = atan2(y, x)
+        xto(3) = xfrom(3)
+
+        if (present(dxto_dxfrom)) then
+            dxto_dxfrom = 0.0_dp
+            dxto_dxfrom(1, 1) = 2.0_dp*x
+            dxto_dxfrom(1, 2) = 2.0_dp*y
+            if (s > 0.0_dp) then
+                dxto_dxfrom(2, 1) = -y/s
+                dxto_dxfrom(2, 2) = x/s
+            end if
+            dxto_dxfrom(3, 3) = 1.0_dp
+        end if
+    end subroutine pseudocart_to_flux
+
+end module flux_pseudocartesian

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,13 @@ target_link_libraries(test_boozer_coordinates_exports.x
   neo
 )
 
+add_executable(test_flux_pseudocartesian.x
+  source/test_flux_pseudocartesian.f90
+)
+target_link_libraries(test_flux_pseudocartesian.x
+  neo
+)
+
 add_executable(test_geqdsk_tools.x source/test_geqdsk_tools.f90)
 target_link_libraries(test_geqdsk_tools.x
   ${MAIN_LIB}
@@ -190,6 +197,8 @@ target_link_libraries(test_nctools_nc_get3.x
 ## Standard tests according to standard libneo Fortran test convention.
 
 add_test(NAME test_binsrc COMMAND test_binsrc.x)
+add_test(NAME test_flux_pseudocartesian
+  COMMAND test_flux_pseudocartesian.x)
 add_test(NAME test_boozer_coordinates_exports
   COMMAND test_boozer_coordinates_exports.x
 )

--- a/test/source/test_flux_pseudocartesian.f90
+++ b/test/source/test_flux_pseudocartesian.f90
@@ -1,0 +1,97 @@
+program test_flux_pseudocartesian
+    !> Pseudo-Cartesian near-axis chart (X,Y) = (sqrt(s)cos th, sqrt(s)sin th):
+    !> round-trip identity, analytic Jacobians vs finite differences, and the
+    !> defining property that the inverse map (X,Y)->(s,theta) stays smooth at
+    !> the axis where the forward flux chart is singular.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use flux_pseudocartesian, only: flux_to_pseudocart, pseudocart_to_flux
+    implicit none
+
+    call test_round_trip()
+    call test_inverse_jacobian_fd()
+    call test_forward_jacobian_fd()
+    call test_inverse_smooth_at_axis()
+
+    print *, 'flux pseudo-Cartesian chart: all checks passed'
+
+contains
+
+    subroutine test_round_trip()
+        real(dp) :: u(3), xy(3), u2(3)
+        real(dp) :: svals(5)
+        integer :: it
+        svals = [1.0e-8_dp, 1.0e-3_dp, 1.0e-2_dp, 0.1_dp, 0.9_dp]
+        do it = 1, 5
+            u = [svals(it), 0.7_dp, 0.3_dp]
+            call flux_to_pseudocart(u, xy)
+            call pseudocart_to_flux(xy, u2)
+            if (abs(u2(1) - u(1)) + abs(u2(2) - u(2)) + abs(u2(3) - u(3)) > 1.0e-12_dp) then
+                print *, 's =', svals(it), ' round-trip residual too large'
+                error stop 'pseudo-Cartesian round trip failed'
+            end if
+        end do
+    end subroutine test_round_trip
+
+    subroutine test_inverse_jacobian_fd()
+        real(dp) :: xy(3), u(3), J(3, 3), Jfd(3, 3)
+        real(dp) :: xp(3), xm(3), up(3), um(3), h
+        integer :: it, k
+        real(dp) :: xys(2, 4)
+        xys = reshape([0.2_dp, 0.1_dp, 0.4_dp, -0.3_dp, 0.05_dp, 0.0_dp, &
+                       -0.1_dp, 0.25_dp], [2, 4])
+        h = 1.0e-6_dp
+        do it = 1, 4
+            xy = [xys(1, it), xys(2, it), 0.3_dp]
+            call pseudocart_to_flux(xy, u, J)
+            do k = 1, 3
+                xp = xy; xm = xy
+                xp(k) = xy(k) + h; xm(k) = xy(k) - h
+                call pseudocart_to_flux(xp, up)
+                call pseudocart_to_flux(xm, um)
+                Jfd(:, k) = (up - um)/(2.0_dp*h)
+            end do
+            if (maxval(abs(J - Jfd)) > 1.0e-4_dp) then
+                print *, 'inverse Jacobian FD mismatch =', maxval(abs(J - Jfd))
+                error stop 'pseudocart_to_flux Jacobian wrong'
+            end if
+        end do
+    end subroutine test_inverse_jacobian_fd
+
+    subroutine test_forward_jacobian_fd()
+        real(dp) :: u(3), xy(3), J(3, 3), Jfd(3, 3)
+        real(dp) :: up(3), um(3), xp(3), xm(3), h
+        integer :: k
+        ! away from the axis the forward Jacobian is also finite and correct
+        u = [0.25_dp, 0.6_dp, 0.2_dp]
+        h = 1.0e-6_dp
+        call flux_to_pseudocart(u, xy, J)
+        do k = 1, 3
+            up = u; um = u
+            up(k) = u(k) + h; um(k) = u(k) - h
+            call flux_to_pseudocart(up, xp)
+            call flux_to_pseudocart(um, xm)
+            Jfd(:, k) = (xp - xm)/(2.0_dp*h)
+        end do
+        if (maxval(abs(J - Jfd)) > 1.0e-4_dp) then
+            print *, 'forward Jacobian FD mismatch =', maxval(abs(J - Jfd))
+            error stop 'flux_to_pseudocart Jacobian wrong'
+        end if
+    end subroutine test_forward_jacobian_fd
+
+    subroutine test_inverse_smooth_at_axis()
+        real(dp) :: xy(3), u(3), J(3, 3)
+        real(dp) :: rr
+        integer :: i
+        ! ds/dX, ds/dY stay bounded as (X,Y) -> 0; that is the whole point.
+        do i = 1, 6
+            rr = 10.0_dp**(-i)
+            xy = [rr, 0.5_dp*rr, 0.0_dp]
+            call pseudocart_to_flux(xy, u, J)
+            if (abs(J(1, 1)) > 1.0_dp .or. abs(J(1, 2)) > 1.0_dp) then
+                print *, 'radius =', rr, ' ds/dX =', J(1, 1), ' ds/dY =', J(1, 2)
+                error stop 'inverse radial Jacobian not bounded near axis'
+            end if
+        end do
+    end subroutine test_inverse_smooth_at_axis
+
+end program test_flux_pseudocartesian


### PR DESCRIPTION
Standalone `(X,Y)=(sqrt(s)cos th, sqrt(s)sin th)` chart and its inverse with Jacobians. Flux coordinates are singular at the axis (s=0); in (X,Y) the inverse map and its s-derivatives stay smooth, so a near-axis implicit orbit step solved in (X,Y) sees no singularity.

New module with no dependencies; nothing in the tree references it yet, so it cannot affect NEO-2/GORILLA/SIMPLE or any downstream consumer. Intended foundation for a near-axis symplectic solver (cf. itpplasma/SIMPLE#398).

## Verification
`test_flux_pseudocartesian` (round-trip, analytic vs finite-difference Jacobians, bounded inverse Jacobian at the axis):
```
flux pseudo-Cartesian chart: all checks passed
```