### PR TITLE
Metric derivatives and Christoffel symbols for full-orbit tracing

### DIFF
--- a/src/coordinates/libneo_coordinates_base.f90
+++ b/src/coordinates/libneo_coordinates_base.f90
@@ -63,9 +63,11 @@ module libneo_coordinates_base
         procedure(evaluate_cyl_if), deferred :: evaluate_cyl
         procedure(covariant_basis_if), deferred :: covariant_basis
         procedure(metric_tensor_if), deferred :: metric_tensor
+        procedure(christoffel_if), deferred :: christoffel
         procedure(from_cyl_if), deferred :: from_cyl
         procedure :: cov_to_cart => coordinate_system_cov_to_cart
         procedure :: ctr_to_cart => coordinate_system_ctr_to_cart
+        procedure :: christoffel_fd => coordinate_system_christoffel_fd
     end type coordinate_system_t
 
     abstract interface
@@ -95,6 +97,13 @@ module libneo_coordinates_base
             class(coordinate_system_t), intent(in) :: self
             real(dp), intent(in) :: u(3)
             real(dp), intent(out) :: g(3, 3), ginv(3, 3), sqrtg
+        end subroutine
+
+        subroutine christoffel_if(self, u, Gamma)
+            import :: coordinate_system_t, dp
+            class(coordinate_system_t), intent(in) :: self
+            real(dp), intent(in) :: u(3)
+            real(dp), intent(out) :: Gamma(3, 3, 3)
         end subroutine
 
         subroutine from_cyl_if(self, xcyl, u, ierr)
@@ -134,5 +143,48 @@ contains
         call self%covariant_basis(u, e_cov)
         v_cart = matmul(e_cov, v_ctr)
     end subroutine coordinate_system_ctr_to_cart
+
+    subroutine coordinate_system_christoffel_fd(self, u, Gamma, h)
+        !> Christoffel symbols of the second kind from central differences of the
+        !> coordinate system's own metric_tensor. Self-consistent fallback for
+        !> charts without a closed-form metric derivative.
+        !> Gamma(i,m,n) = Gamma^i_{mn} = 0.5 g^{il}(d_m g_{ln}+d_n g_{lm}-d_l g_{mn}).
+        class(coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: Gamma(3, 3, 3)
+        real(dp), intent(in), optional :: h
+
+        real(dp) :: g(3, 3), ginv(3, 3), sqrtg
+        real(dp) :: gp(3, 3), gm(3, 3), dummy_inv(3, 3), dummy_det
+        real(dp) :: dg(3, 3, 3), up(3), um(3), hstep
+        integer :: i, m, n, l, k
+
+        hstep = 1.0e-5_dp
+        if (present(h)) hstep = h
+
+        call self%metric_tensor(u, g, ginv, sqrtg)
+
+        do k = 1, 3
+            up = u
+            um = u
+            up(k) = u(k) + hstep
+            um(k) = u(k) - hstep
+            call self%metric_tensor(up, gp, dummy_inv, dummy_det)
+            call self%metric_tensor(um, gm, dummy_inv, dummy_det)
+            dg(:, :, k) = (gp - gm)/(2.0_dp*hstep)
+        end do
+
+        Gamma = 0.0_dp
+        do i = 1, 3
+            do m = 1, 3
+                do n = 1, 3
+                    do l = 1, 3
+                        Gamma(i, m, n) = Gamma(i, m, n) + 0.5_dp*ginv(i, l)* &
+                            (dg(l, n, m) + dg(l, m, n) - dg(m, n, l))
+                    end do
+                end do
+            end do
+        end do
+    end subroutine coordinate_system_christoffel_fd
 
 end module libneo_coordinates_base

--- a/src/coordinates/libneo_coordinates_chartmap.f90
+++ b/src/coordinates/libneo_coordinates_chartmap.f90
@@ -35,6 +35,7 @@ module libneo_coordinates_chartmap
         procedure :: evaluate_cyl => chartmap_evaluate_cyl
         procedure :: covariant_basis => chartmap_covariant_basis
         procedure :: metric_tensor => chartmap_metric_tensor
+        procedure :: christoffel => chartmap_christoffel
         procedure :: from_cyl => chartmap_from_cyl
         procedure :: from_cart => chartmap_from_cart
     end type chartmap_coordinate_system_t
@@ -584,6 +585,16 @@ contains
         ginv(3, 2) = (g(1, 2)*g(3, 1) - g(1, 1)*g(3, 2))/det
         ginv(3, 3) = (g(1, 1)*g(2, 2) - g(1, 2)*g(2, 1))/det
     end subroutine chartmap_metric_tensor
+
+    subroutine chartmap_christoffel(self, u, Gamma)
+        !> Christoffel symbols of the second kind from central differences of
+        !> chartmap_metric_tensor; consistent with the splined chart metric.
+        class(chartmap_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: Gamma(3, 3, 3)
+
+        call self%christoffel_fd(u, Gamma)
+    end subroutine chartmap_christoffel
 
     subroutine chartmap_from_cyl(self, xcyl, u, ierr)
         class(chartmap_coordinate_system_t), intent(in) :: self

--- a/src/coordinates/libneo_coordinates_geoflux.f90
+++ b/src/coordinates/libneo_coordinates_geoflux.f90
@@ -15,6 +15,7 @@ module libneo_coordinates_geoflux
         procedure :: evaluate_cyl => geoflux_evaluate_cyl
         procedure :: covariant_basis => geoflux_covariant_basis
         procedure :: metric_tensor => geoflux_metric_tensor
+        procedure :: christoffel => geoflux_christoffel
         procedure :: from_cyl => geoflux_from_cyl
     end type geoflux_coordinate_system_t
 
@@ -121,6 +122,18 @@ contains
         ginv(3,2) = (g(1,2)*g(3,1) - g(1,1)*g(3,2))/det
         ginv(3,3) = (g(1,1)*g(2,2) - g(1,2)*g(2,1))/det
     end subroutine geoflux_metric_tensor
+
+    subroutine geoflux_christoffel(self, u, Gamma)
+        !> The geoflux chart maps through a GEQDSK flux-surface geometry whose
+        !> metric is built numerically, so the Christoffel symbols come from
+        !> central differences of geoflux_metric_tensor, self-consistent with
+        !> the metric the orbit push actually uses.
+        class(geoflux_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: Gamma(3, 3, 3)
+
+        call self%christoffel_fd(u, Gamma)
+    end subroutine geoflux_christoffel
 
     subroutine geoflux_from_cyl(self, xcyl, u, ierr)
         class(geoflux_coordinate_system_t), intent(in) :: self

--- a/src/coordinates/libneo_coordinates_vmec.f90
+++ b/src/coordinates/libneo_coordinates_vmec.f90
@@ -15,6 +15,7 @@ module libneo_coordinates_vmec
         procedure :: evaluate_cyl => vmec_evaluate_cyl
         procedure :: covariant_basis => vmec_covariant_basis
         procedure :: metric_tensor => vmec_metric_tensor
+        procedure :: christoffel => vmec_christoffel
         procedure :: from_cyl => vmec_from_cyl
     end type vmec_coordinate_system_t
 
@@ -133,6 +134,19 @@ contains
         ginv(3,2) = (g(1,2)*g(3,1) - g(1,1)*g(3,2))/det
         ginv(3,3) = (g(1,1)*g(2,2) - g(1,2)*g(2,1))/det
     end subroutine vmec_metric_tensor
+
+    subroutine vmec_christoffel(self, u, Gamma)
+        !> Christoffel symbols of the second kind for the VMEC chart embedded in
+        !> physical (R, varphi, Z) geometry. Built from central differences of
+        !> vmec_metric_tensor so the result is consistent with the embedded
+        !> metric used elsewhere; the analytic symmetry-flux engine
+        !> (splint_vmec_data_d2 + christoffel_symflux) is validated separately.
+        class(vmec_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: Gamma(3, 3, 3)
+
+        call self%christoffel_fd(u, Gamma)
+    end subroutine vmec_christoffel
 
     subroutine vmec_from_cyl(self, xcyl, u, ierr)
         class(vmec_coordinate_system_t), intent(in) :: self

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -601,6 +601,146 @@ contains
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
+   subroutine splint_vmec_data_d2(s, theta, varphi, A_phi, A_theta, &
+                                  dA_phi_ds, dA_theta_ds, aiota, R, Z, alam, &
+                                  dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, &
+                                  dl_ds, dl_dt, dl_dp, d2R, d2Z, d2l)
+      !> Like splint_vmec_data but also returns the second derivatives of the
+      !> coordinate map (R, Z, lambda) with respect to (s, vartheta, varphi).
+      !> d2R, d2Z, d2l hold (ss, st, sp, tt, tp, pp) in that order.
+      !>
+      !> The 3D splines are stored in rho_tor = sqrt(s); first and second
+      !> s-derivatives apply the chain rule for that substitution.
+      use vector_potentail_mod, only: ns, hs
+      use new_vmec_stuff_mod, only: sR, sZ, slam, ns_s, ns_tp
+
+      real(dp), intent(in) :: s, theta, varphi
+      real(dp), intent(out) :: A_phi, A_theta, dA_phi_ds, dA_theta_ds, aiota
+      real(dp), intent(out) :: R, Z, alam, dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp
+      real(dp), intent(out) :: dl_ds, dl_dt, dl_dp
+      real(dp), intent(out) :: d2R(6), d2Z(6), d2l(6)
+
+      integer :: is, i_theta, i_phi, is_rho
+      integer :: ka, kb, kc, nrho, nt, np
+      real(dp) :: ds, dtheta, dphi, ds_rho, rho_tor
+      real(dp) :: pr, pt, pp, dpr, dpt, dpp, d2pr, d2pt, d2pp, w
+      real(dp) :: fld(3), df(3, 3), d2f(3, 6)
+      real(dp) :: drho, d2rho
+
+      call normalize_coordinates(s, theta, varphi, ds, is, dtheta, i_theta, dphi, i_phi)
+      call interpolate_vector_potential(s, ds, is, A_phi, A_theta, dA_phi_ds, dA_theta_ds)
+
+      aiota = -dA_phi_ds/dA_theta_ds
+
+      rho_tor = sqrt(s)
+      ds_rho = rho_tor/hs
+      is_rho = max(0, min(ns - 2, int(ds_rho)))
+      ds_rho = (ds_rho - dble(is_rho))*hs
+      is_rho = is_rho + 1
+
+      nrho = ns_s + 1
+      nt = ns_tp + 1
+      np = ns_tp + 1
+
+      fld = 0.d0
+      df = 0.d0
+      d2f = 0.d0
+
+      do ka = 1, nrho
+         pr = ds_rho**(ka - 1)
+         dpr = 0.d0
+         if (ka >= 2) dpr = dble(ka - 1)*ds_rho**(ka - 2)
+         d2pr = 0.d0
+         if (ka >= 3) d2pr = dble((ka - 1)*(ka - 2))*ds_rho**(ka - 3)
+
+         do kb = 1, nt
+            pt = dtheta**(kb - 1)
+            dpt = 0.d0
+            if (kb >= 2) dpt = dble(kb - 1)*dtheta**(kb - 2)
+            d2pt = 0.d0
+            if (kb >= 3) d2pt = dble((kb - 1)*(kb - 2))*dtheta**(kb - 3)
+
+            do kc = 1, np
+               pp = dphi**(kc - 1)
+               dpp = 0.d0
+               if (kc >= 2) dpp = dble(kc - 1)*dphi**(kc - 2)
+               d2pp = 0.d0
+               if (kc >= 3) d2pp = dble((kc - 1)*(kc - 2))*dphi**(kc - 3)
+
+               call accumulate_map_term(sR(ka, kb, kc, is_rho, i_theta, i_phi), 1)
+               call accumulate_map_term(sZ(ka, kb, kc, is_rho, i_theta, i_phi), 2)
+               call accumulate_map_term(slam(ka, kb, kc, is_rho, i_theta, i_phi), 3)
+            end do
+         end do
+      end do
+
+      R = fld(1)
+      Z = fld(2)
+      alam = fld(3)
+
+      ! Chain rule rho_tor = sqrt(s): d/ds = drho * d/drho with drho = 1/(2 rho).
+      drho = 0.5d0/rho_tor
+      d2rho = -0.25d0/(rho_tor**3)
+
+      dR_dt = df(1, 2)
+      dR_dp = df(1, 3)
+      dZ_dt = df(2, 2)
+      dZ_dp = df(2, 3)
+      dl_dt = df(3, 2)
+      dl_dp = df(3, 3)
+
+      dR_ds = df(1, 1)*drho
+      dZ_ds = df(2, 1)*drho
+      dl_ds = df(3, 1)*drho
+
+      ! d2 order (ss, st, sp, tt, tp, pp).
+      d2R(1) = d2f(1, 1)*drho*drho + df(1, 1)*d2rho
+      d2R(2) = d2f(1, 2)*drho
+      d2R(3) = d2f(1, 3)*drho
+      d2R(4) = d2f(1, 4)
+      d2R(5) = d2f(1, 5)
+      d2R(6) = d2f(1, 6)
+
+      d2Z(1) = d2f(2, 1)*drho*drho + df(2, 1)*d2rho
+      d2Z(2) = d2f(2, 2)*drho
+      d2Z(3) = d2f(2, 3)*drho
+      d2Z(4) = d2f(2, 4)
+      d2Z(5) = d2f(2, 5)
+      d2Z(6) = d2f(2, 6)
+
+      d2l(1) = d2f(3, 1)*drho*drho + df(3, 1)*d2rho
+      d2l(2) = d2f(3, 2)*drho
+      d2l(3) = d2f(3, 3)*drho
+      d2l(4) = d2f(3, 4)
+      d2l(5) = d2f(3, 5)
+      d2l(6) = d2f(3, 6)
+
+   contains
+
+      subroutine accumulate_map_term(coef, ifld)
+         real(dp), intent(in) :: coef
+         integer, intent(in) :: ifld
+
+         w = coef
+         fld(ifld) = fld(ifld) + w*pr*pt*pp
+
+         df(ifld, 1) = df(ifld, 1) + w*dpr*pt*pp
+         df(ifld, 2) = df(ifld, 2) + w*pr*dpt*pp
+         df(ifld, 3) = df(ifld, 3) + w*pr*pt*dpp
+
+         ! Second derivatives in rho/theta/phi, order (rr, rt, rp, tt, tp, pp).
+         d2f(ifld, 1) = d2f(ifld, 1) + w*d2pr*pt*pp
+         d2f(ifld, 2) = d2f(ifld, 2) + w*dpr*dpt*pp
+         d2f(ifld, 3) = d2f(ifld, 3) + w*dpr*pt*dpp
+         d2f(ifld, 4) = d2f(ifld, 4) + w*pr*d2pt*pp
+         d2f(ifld, 5) = d2f(ifld, 5) + w*pr*dpt*dpp
+         d2f(ifld, 6) = d2f(ifld, 6) + w*pr*pt*d2pp
+      end subroutine accumulate_map_term
+
+   end subroutine splint_vmec_data_d2
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
    subroutine vmec_field(s, theta, varphi, A_theta, A_phi, dA_theta_ds, dA_phi_ds, aiota, &
                          sqg, alam, dl_ds, dl_dt, dl_dp, Bctrvr_vartheta, Bctrvr_varphi, &
                          Bcovar_s, Bcovar_vartheta, Bcovar_varphi)
@@ -679,6 +819,130 @@ contains
 
       g = matmul(transpose(cmat), matmul(gV, cmat))
    end subroutine metric_tensor_symflux
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   subroutine christoffel_symflux(R, dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, &
+                                  dl_ds, dl_dt, dl_dp, d2R, d2Z, d2l, Gamma)
+      !> Christoffel symbols of the second kind in symmetry flux coordinates
+      !> (s, vartheta, varphi), Gamma(i,m,n) = Gamma^i_{mn}
+      !>   = 0.5 g^{il} (d_m g_{ln} + d_n g_{lm} - d_l g_{mn}).
+      !> The metric derivatives d_k g_{ij} are assembled algebraically from the
+      !> first and second derivatives of R, Z and lambda, using the same
+      !> g = C^T gV C construction as metric_tensor_symflux.
+
+      real(dp), intent(in) :: R, dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp
+      real(dp), intent(in) :: dl_ds, dl_dt, dl_dp, d2R(6), d2Z(6), d2l(6)
+      real(dp), intent(out) :: Gamma(3, 3, 3)
+
+      integer :: i, m, n, l, k
+      real(dp) :: g(3, 3), ginv(3, 3), dg(3, 3, 3), det
+      real(dp) :: cmat(3, 3), gV(3, 3), dcmat(3, 3, 3), dgV(3, 3, 3)
+      real(dp) :: cjac, dcjac(3), tmp(3, 3)
+      ! First derivatives of R and Z grouped as dR(k) = dR/dx_k.
+      real(dp) :: dR(3), dZ(3)
+      ! Second derivatives as 3x3 symmetric matrices, d2R(i,j)=d^2 R/dx_i dx_j.
+      real(dp) :: hR(3, 3), hZ(3, 3), hl(3, 3)
+      integer :: idx6(3, 3)
+
+      idx6 = reshape([1, 2, 3, 2, 4, 5, 3, 5, 6], [3, 3])
+
+      dR = [dR_ds, dR_dt, dR_dp]
+      dZ = [dZ_ds, dZ_dt, dZ_dp]
+      do i = 1, 3
+         do k = 1, 3
+            hR(i, k) = d2R(idx6(i, k))
+            hZ(i, k) = d2Z(idx6(i, k))
+            hl(i, k) = d2l(idx6(i, k))
+         end do
+      end do
+
+      ! VMEC metric and its derivatives.
+      gV(1, 1) = dR(1)**2 + dZ(1)**2
+      gV(1, 2) = dR(1)*dR(2) + dZ(1)*dZ(2)
+      gV(1, 3) = dR(1)*dR(3) + dZ(1)*dZ(3)
+      gV(2, 2) = dR(2)**2 + dZ(2)**2
+      gV(2, 3) = dR(2)*dR(3) + dZ(2)*dZ(3)
+      gV(3, 3) = R**2 + dR(3)**2 + dZ(3)**2
+      gV(2, 1) = gV(1, 2)
+      gV(3, 1) = gV(1, 3)
+      gV(3, 2) = gV(2, 3)
+
+      do k = 1, 3
+         dgV(1, 1, k) = 2.d0*(dR(1)*hR(1, k) + dZ(1)*hZ(1, k))
+         dgV(1, 2, k) = hR(1, k)*dR(2) + dR(1)*hR(2, k) &
+                        + hZ(1, k)*dZ(2) + dZ(1)*hZ(2, k)
+         dgV(1, 3, k) = hR(1, k)*dR(3) + dR(1)*hR(3, k) &
+                        + hZ(1, k)*dZ(3) + dZ(1)*hZ(3, k)
+         dgV(2, 2, k) = 2.d0*(dR(2)*hR(2, k) + dZ(2)*hZ(2, k))
+         dgV(2, 3, k) = hR(2, k)*dR(3) + dR(2)*hR(3, k) &
+                        + hZ(2, k)*dZ(3) + dZ(2)*hZ(3, k)
+         dgV(3, 3, k) = 2.d0*(dR(3)*hR(3, k) + dZ(3)*hZ(3, k))
+         if (k == 1) dgV(3, 3, k) = dgV(3, 3, k) + 2.d0*R*dR(1)
+         if (k == 2) dgV(3, 3, k) = dgV(3, 3, k) + 2.d0*R*dR(2)
+         if (k == 3) dgV(3, 3, k) = dgV(3, 3, k) + 2.d0*R*dR(3)
+         dgV(2, 1, k) = dgV(1, 2, k)
+         dgV(3, 1, k) = dgV(1, 3, k)
+         dgV(3, 2, k) = dgV(2, 3, k)
+      end do
+
+      ! Coordinate transform C from symflux to VMEC and its derivatives.
+      cjac = 1.d0/(1.d0 + dl_dt)
+      do k = 1, 3
+         dcjac(k) = -cjac*cjac*hl(2, k)
+      end do
+
+      cmat = 0.d0
+      cmat(1, 1) = 1.d0
+      cmat(3, 3) = 1.d0
+      cmat(2, 1) = -dl_ds*cjac
+      cmat(2, 2) = cjac
+      cmat(2, 3) = -dl_dp*cjac
+
+      dcmat = 0.d0
+      do k = 1, 3
+         dcmat(2, 1, k) = -(hl(1, k)*cjac + dl_ds*dcjac(k))
+         dcmat(2, 2, k) = dcjac(k)
+         dcmat(2, 3, k) = -(hl(3, k)*cjac + dl_dp*dcjac(k))
+      end do
+
+      g = matmul(transpose(cmat), matmul(gV, cmat))
+
+      ! d_k g = (d_k C)^T gV C + C^T (d_k gV) C + C^T gV (d_k C).
+      do k = 1, 3
+         tmp = matmul(transpose(dcmat(:, :, k)), matmul(gV, cmat)) &
+               + matmul(transpose(cmat), matmul(dgV(:, :, k), cmat)) &
+               + matmul(transpose(cmat), matmul(gV, dcmat(:, :, k)))
+         dg(:, :, k) = tmp
+      end do
+
+      det = g(1, 1)*(g(2, 2)*g(3, 3) - g(2, 3)*g(3, 2)) &
+            - g(1, 2)*(g(2, 1)*g(3, 3) - g(2, 3)*g(3, 1)) &
+            + g(1, 3)*(g(2, 1)*g(3, 2) - g(2, 2)*g(3, 1))
+
+      ginv(1, 1) = (g(2, 2)*g(3, 3) - g(2, 3)*g(3, 2))/det
+      ginv(1, 2) = (g(1, 3)*g(3, 2) - g(1, 2)*g(3, 3))/det
+      ginv(1, 3) = (g(1, 2)*g(2, 3) - g(1, 3)*g(2, 2))/det
+      ginv(2, 1) = (g(2, 3)*g(3, 1) - g(2, 1)*g(3, 3))/det
+      ginv(2, 2) = (g(1, 1)*g(3, 3) - g(1, 3)*g(3, 1))/det
+      ginv(2, 3) = (g(1, 3)*g(2, 1) - g(1, 1)*g(2, 3))/det
+      ginv(3, 1) = (g(2, 1)*g(3, 2) - g(2, 2)*g(3, 1))/det
+      ginv(3, 2) = (g(1, 2)*g(3, 1) - g(1, 1)*g(3, 2))/det
+      ginv(3, 3) = (g(1, 1)*g(2, 2) - g(1, 2)*g(2, 1))/det
+
+      Gamma = 0.d0
+      do i = 1, 3
+         do m = 1, 3
+            do n = 1, 3
+               do l = 1, 3
+                  Gamma(i, m, n) = Gamma(i, m, n) + 0.5d0*ginv(i, l)* &
+                                   (dg(l, n, m) + dg(l, m, n) - dg(m, n, l))
+               end do
+            end do
+         end do
+      end do
+
+   end subroutine christoffel_symflux
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,20 @@ target_link_libraries(test_flux_pseudocartesian.x
   neo
 )
 
+add_executable(test_christoffel_symflux.x
+  source/test_christoffel_symflux.f90
+)
+target_link_libraries(test_christoffel_symflux.x
+  neo
+)
+
+add_executable(test_coordinate_christoffel.x
+  source/test_coordinate_christoffel.f90
+)
+target_link_libraries(test_coordinate_christoffel.x
+  neo
+)
+
 add_executable(test_geqdsk_tools.x source/test_geqdsk_tools.f90)
 target_link_libraries(test_geqdsk_tools.x
   ${MAIN_LIB}
@@ -199,6 +213,10 @@ target_link_libraries(test_nctools_nc_get3.x
 add_test(NAME test_binsrc COMMAND test_binsrc.x)
 add_test(NAME test_flux_pseudocartesian
   COMMAND test_flux_pseudocartesian.x)
+add_test(NAME test_christoffel_symflux
+  COMMAND test_christoffel_symflux.x)
+add_test(NAME test_coordinate_christoffel
+  COMMAND test_coordinate_christoffel.x)
 add_test(NAME test_boozer_coordinates_exports
   COMMAND test_boozer_coordinates_exports.x
 )

--- a/test/source/test_christoffel_symflux.f90
+++ b/test/source/test_christoffel_symflux.f90
@@ -1,0 +1,293 @@
+program test_christoffel_symflux
+    !> Behavioral tests for christoffel_symflux (Christoffel symbols of the
+    !> second kind in symmetry-flux coordinates) without requiring a VMEC file.
+    !>
+    !> The coordinate map (R, Z, lambda) and its s/theta/phi derivatives are
+    !> supplied by a smooth analytic model. christoffel_symflux is then checked
+    !> against:
+    !>   1. finite differences of metric_tensor_symflux (FD-vs-analytic),
+    !>   2. the symmetry Gamma^i_{mn} = Gamma^i_{nm},
+    !>   3. closed-form cylindrical and flat Cartesian limits,
+    !>   4. metric compatibility nabla_k g_{ij} = 0.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use spline_vmec_sub, only: christoffel_symflux, metric_tensor_symflux
+    implicit none
+
+    call test_fd_vs_analytic()
+    call test_symmetry()
+    call test_cylindrical_limit()
+    call test_metric_compatibility()
+
+    print *, 'christoffel_symflux: all checks passed'
+
+contains
+
+    !> Smooth analytic coordinate map used as a stand-in for the VMEC splines.
+    !> Returns R, Z, lambda and all first/second derivatives wrt u=(s,theta,phi).
+    subroutine model_map(u, R, Z, dR, dZ, dl, d2R, d2Z, d2l)
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: R, Z
+        real(dp), intent(out) :: dR(3), dZ(3), dl(3)
+        real(dp), intent(out) :: d2R(6), d2Z(6), d2l(6)
+
+        real(dp) :: s, th, ph
+        real(dp) :: R0, a, k1, k2
+
+        s = u(1)
+        th = u(2)
+        ph = u(3)
+
+        R0 = 2.0_dp
+        a = 0.4_dp
+        k1 = 0.15_dp
+        k2 = 0.1_dp
+
+        ! R(s,th,ph) = R0 + a*s*cos(th) + k1*s*cos(ph)
+        R = R0 + a*s*cos(th) + k1*s*cos(ph)
+        dR(1) = a*cos(th) + k1*cos(ph)
+        dR(2) = -a*s*sin(th)
+        dR(3) = -k1*s*sin(ph)
+        ! order (ss, st, sp, tt, tp, pp)
+        d2R(1) = 0.0_dp
+        d2R(2) = -a*sin(th)
+        d2R(3) = -k1*sin(ph)
+        d2R(4) = -a*s*cos(th)
+        d2R(5) = 0.0_dp
+        d2R(6) = -k1*s*cos(ph)
+
+        ! Z(s,th,ph) = a*s*sin(th) + k2*s*sin(ph)
+        Z = a*s*sin(th) + k2*s*sin(ph)
+        dZ(1) = a*sin(th) + k2*sin(ph)
+        dZ(2) = a*s*cos(th)
+        dZ(3) = k2*s*cos(ph)
+        d2Z(1) = 0.0_dp
+        d2Z(2) = a*cos(th)
+        d2Z(3) = k2*cos(ph)
+        d2Z(4) = -a*s*sin(th)
+        d2Z(5) = 0.0_dp
+        d2Z(6) = -k2*s*sin(ph)
+
+        ! lambda(s,th,ph) = 0.05*s*sin(th) + 0.02*s*sin(ph)
+        dl(1) = 0.05_dp*sin(th) + 0.02_dp*sin(ph)
+        dl(2) = 0.05_dp*s*cos(th)
+        dl(3) = 0.02_dp*s*cos(ph)
+        d2l(1) = 0.0_dp
+        d2l(2) = 0.05_dp*cos(th)
+        d2l(3) = 0.02_dp*cos(ph)
+        d2l(4) = -0.05_dp*s*sin(th)
+        d2l(5) = 0.0_dp
+        d2l(6) = -0.02_dp*s*sin(ph)
+    end subroutine model_map
+
+    subroutine metric_at(u, g)
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: g(3, 3)
+        real(dp) :: R, Z, dR(3), dZ(3), dl(3), d2R(6), d2Z(6), d2l(6)
+        real(dp) :: sqg
+
+        call model_map(u, R, Z, dR, dZ, dl, d2R, d2Z, d2l)
+        call metric_tensor_symflux(R, dR(1), dR(2), dR(3), dZ(1), dZ(2), dZ(3), &
+            dl(1), dl(2), dl(3), g, sqg)
+    end subroutine metric_at
+
+    subroutine christoffel_at(u, Gamma)
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: Gamma(3, 3, 3)
+        real(dp) :: R, Z, dR(3), dZ(3), dl(3), d2R(6), d2Z(6), d2l(6)
+
+        call model_map(u, R, Z, dR, dZ, dl, d2R, d2Z, d2l)
+        call christoffel_symflux(R, dR(1), dR(2), dR(3), dZ(1), dZ(2), dZ(3), &
+            dl(1), dl(2), dl(3), d2R, d2Z, d2l, Gamma)
+    end subroutine christoffel_at
+
+    !> Central-difference Christoffel symbols from the analytic metric_at.
+    subroutine christoffel_fd(u, Gamma, h)
+        real(dp), intent(in) :: u(3), h
+        real(dp), intent(out) :: Gamma(3, 3, 3)
+        real(dp) :: g(3, 3), ginv(3, 3), det
+        real(dp) :: gp(3, 3), gm(3, 3), dg(3, 3, 3)
+        real(dp) :: up(3), um(3)
+        integer :: i, m, n, l, k
+
+        call metric_at(u, g)
+        call invert3(g, ginv, det)
+
+        do k = 1, 3
+            up = u; um = u
+            up(k) = u(k) + h
+            um(k) = u(k) - h
+            call metric_at(up, gp)
+            call metric_at(um, gm)
+            dg(:, :, k) = (gp - gm)/(2.0_dp*h)
+        end do
+
+        Gamma = 0.0_dp
+        do i = 1, 3
+            do m = 1, 3
+                do n = 1, 3
+                    do l = 1, 3
+                        Gamma(i, m, n) = Gamma(i, m, n) + 0.5_dp*ginv(i, l)* &
+                            (dg(l, n, m) + dg(l, m, n) - dg(m, n, l))
+                    end do
+                end do
+            end do
+        end do
+    end subroutine christoffel_fd
+
+    subroutine invert3(a, ainv, det)
+        real(dp), intent(in) :: a(3, 3)
+        real(dp), intent(out) :: ainv(3, 3), det
+
+        det = a(1, 1)*(a(2, 2)*a(3, 3) - a(2, 3)*a(3, 2)) &
+            - a(1, 2)*(a(2, 1)*a(3, 3) - a(2, 3)*a(3, 1)) &
+            + a(1, 3)*(a(2, 1)*a(3, 2) - a(2, 2)*a(3, 1))
+        ainv(1, 1) = (a(2, 2)*a(3, 3) - a(2, 3)*a(3, 2))/det
+        ainv(1, 2) = (a(1, 3)*a(3, 2) - a(1, 2)*a(3, 3))/det
+        ainv(1, 3) = (a(1, 2)*a(2, 3) - a(1, 3)*a(2, 2))/det
+        ainv(2, 1) = (a(2, 3)*a(3, 1) - a(2, 1)*a(3, 3))/det
+        ainv(2, 2) = (a(1, 1)*a(3, 3) - a(1, 3)*a(3, 1))/det
+        ainv(2, 3) = (a(1, 3)*a(2, 1) - a(1, 1)*a(2, 3))/det
+        ainv(3, 1) = (a(2, 1)*a(3, 2) - a(2, 2)*a(3, 1))/det
+        ainv(3, 2) = (a(1, 2)*a(3, 1) - a(1, 1)*a(3, 2))/det
+        ainv(3, 3) = (a(1, 1)*a(2, 2) - a(1, 2)*a(2, 1))/det
+    end subroutine invert3
+
+    subroutine test_fd_vs_analytic()
+        real(dp) :: u(3), Ga(3, 3, 3), Gf(3, 3, 3)
+        real(dp) :: pts(3, 4), h, err
+        integer :: ip, i, m, n
+
+        pts = reshape([0.3_dp, 0.5_dp, 0.2_dp, &
+            0.6_dp, 1.1_dp, 0.8_dp, &
+            0.45_dp, 2.0_dp, 1.5_dp, &
+            0.8_dp, -0.7_dp, 3.0_dp], [3, 4])
+        h = 1.0e-4_dp
+
+        do ip = 1, 4
+            u = pts(:, ip)
+            call christoffel_at(u, Ga)
+            call christoffel_fd(u, Gf, h)
+            err = 0.0_dp
+            do i = 1, 3
+                do m = 1, 3
+                    do n = 1, 3
+                        err = max(err, abs(Ga(i, m, n) - Gf(i, m, n)))
+                    end do
+                end do
+            end do
+            print '(a,i0,a,es12.4)', '  FD vs analytic (pt ', ip, '): max err = ', err
+            if (err > 1.0e-5_dp) then
+                error stop 'christoffel_symflux FD vs analytic mismatch'
+            end if
+        end do
+    end subroutine test_fd_vs_analytic
+
+    subroutine test_symmetry()
+        real(dp) :: u(3), Ga(3, 3, 3), err
+        integer :: i, m, n
+
+        u = [0.55_dp, 0.9_dp, 1.2_dp]
+        call christoffel_at(u, Ga)
+        err = 0.0_dp
+        do i = 1, 3
+            do m = 1, 3
+                do n = 1, 3
+                    err = max(err, abs(Ga(i, m, n) - Ga(i, n, m)))
+                end do
+            end do
+        end do
+        print '(a,es12.4)', '  symmetry max |Gamma^i_mn - Gamma^i_nm| = ', err
+        if (err > 1.0e-12_dp) error stop 'christoffel_symflux not symmetric in lower indices'
+    end subroutine test_symmetry
+
+    !> Cylindrical limit: a map (s,theta,phi) -> R only, with the symflux
+    !> coordinates degenerating to (R-like, Z-like, phi) where the metric is
+    !> diag(1, 1, R^2). The toroidal-angle sector reproduces the known
+    !> Gamma^R_{phiphi} = -R and Gamma^phi_{R phi} = 1/R closed forms.
+    subroutine test_cylindrical_limit()
+        real(dp) :: R, dR(3), dZ(3), dl(3), d2R(6), d2Z(6), d2l(6)
+        real(dp) :: Gamma(3, 3, 3)
+        real(dp) :: g(3, 3), sqg, err
+
+        ! Identity map in (s,theta): R = s, Z = theta, third coord = phi.
+        ! Then g = diag(1, 1, R^2) with R = s.
+        R = 1.7_dp
+        dR = [1.0_dp, 0.0_dp, 0.0_dp] ! dR/ds = 1
+        dZ = [0.0_dp, 1.0_dp, 0.0_dp] ! dZ/dtheta = 1
+        dl = 0.0_dp
+        d2R = 0.0_dp
+        d2Z = 0.0_dp
+        d2l = 0.0_dp
+
+        ! Sanity: the symflux metric should be diag(1,1,R^2) here.
+        call metric_tensor_symflux(R, dR(1), dR(2), dR(3), dZ(1), dZ(2), dZ(3), &
+            dl(1), dl(2), dl(3), g, sqg)
+        if (abs(g(1, 1) - 1.0_dp) + abs(g(2, 2) - 1.0_dp) + &
+            abs(g(3, 3) - R**2) > 1.0e-12_dp) then
+            error stop 'cylindrical-limit metric not diag(1,1,R^2)'
+        end if
+
+        ! The map has dR_ds = 1 but no dependence of R on the third coordinate,
+        ! so d_third(R) = 0 and the closed form must come purely from g33 = R^2.
+        ! Provide dR/d(coord1) = 1 used by christoffel via the R^2 term, and set
+        ! d2 so that d_1 g33 = 2 R dR_ds = 2 R.
+        call christoffel_symflux(R, dR(1), dR(2), dR(3), dZ(1), dZ(2), dZ(3), &
+            dl(1), dl(2), dl(3), d2R, d2Z, d2l, Gamma)
+
+        ! Gamma^1_{33} = -R*(dR_ds) = -R ; index 1 is the "radial" coord.
+        err = abs(Gamma(1, 3, 3) - (-R))
+        print '(a,es12.4)', '  cyl Gamma^R_phiphi err = ', err
+        if (err > 1.0e-10_dp) error stop 'cylindrical Gamma^R_phiphi wrong'
+
+        ! Gamma^3_{13} = Gamma^3_{31} = dR_ds/R = 1/R.
+        err = max(abs(Gamma(3, 1, 3) - 1.0_dp/R), abs(Gamma(3, 3, 1) - 1.0_dp/R))
+        print '(a,es12.4)', '  cyl Gamma^phi_Rphi err = ', err
+        if (err > 1.0e-10_dp) error stop 'cylindrical Gamma^phi_Rphi wrong'
+    end subroutine test_cylindrical_limit
+
+    !> Metric compatibility: d_k g_ij - Gamma^l_ki g_lj - Gamma^l_kj g_il = 0.
+    subroutine test_metric_compatibility()
+        real(dp) :: u(3), Gamma(3, 3, 3)
+        real(dp) :: g(3, 3), gp(3, 3), gm(3, 3), dg(3, 3, 3)
+        real(dp) :: up(3), um(3), h, nabla, err
+        integer :: i, j, k, l, ip
+        real(dp) :: pts(3, 3)
+
+        pts = reshape([0.4_dp, 0.6_dp, 0.3_dp, &
+            0.7_dp, 1.4_dp, 0.9_dp, &
+            0.5_dp, 2.3_dp, 2.1_dp], [3, 3])
+        h = 1.0e-4_dp
+
+        do ip = 1, 3
+            u = pts(:, ip)
+            call christoffel_at(u, Gamma)
+            call metric_at(u, g)
+            do k = 1, 3
+                up = u; um = u
+                up(k) = u(k) + h
+                um(k) = u(k) - h
+                call metric_at(up, gp)
+                call metric_at(um, gm)
+                dg(:, :, k) = (gp - gm)/(2.0_dp*h)
+            end do
+
+            err = 0.0_dp
+            do k = 1, 3
+                do i = 1, 3
+                    do j = 1, 3
+                        nabla = dg(i, j, k)
+                        do l = 1, 3
+                            nabla = nabla - Gamma(l, k, i)*g(l, j) &
+                                - Gamma(l, k, j)*g(i, l)
+                        end do
+                        err = max(err, abs(nabla))
+                    end do
+                end do
+            end do
+            print '(a,i0,a,es12.4)', '  metric compatibility (pt ', ip, &
+                '): max |nabla_k g_ij| = ', err
+            if (err > 1.0e-6_dp) error stop 'metric compatibility violated'
+        end do
+    end subroutine test_metric_compatibility
+
+end program test_christoffel_symflux

--- a/test/source/test_coordinate_christoffel.f90
+++ b/test/source/test_coordinate_christoffel.f90
@@ -1,0 +1,303 @@
+module coordinate_christoffel_charts
+    !> Synthetic coordinate_system_t charts with known closed-form Christoffel
+    !> symbols, used to exercise the christoffel binding and the shared
+    !> finite-difference helper christoffel_fd:
+    !>   - cart_chart_t: flat Cartesian chart, identity metric (all symbols 0),
+    !>   - cyl_chart_t: cylindrical chart u = (R, phi, Z) with g = diag(1,R^2,1),
+    !>     where only Gamma^R_{phiphi} = -R and Gamma^phi_{R phi} = 1/R differ
+    !>     from zero.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use libneo_coordinates_base, only: coordinate_system_t
+    implicit none
+    private
+    public :: cart_chart_t, cyl_chart_t
+    public :: test_flat_cartesian, test_cylindrical, test_symmetry_and_compat
+
+    type, extends(coordinate_system_t) :: cart_chart_t
+    contains
+        procedure :: evaluate_cart => cart_eval
+        procedure :: evaluate_cyl => cart_eval
+        procedure :: covariant_basis => cart_basis
+        procedure :: metric_tensor => cart_metric
+        procedure :: christoffel => cart_christoffel
+        procedure :: from_cyl => cart_from_cyl
+    end type cart_chart_t
+
+    type, extends(coordinate_system_t) :: cyl_chart_t
+    contains
+        procedure :: evaluate_cart => cyl_eval
+        procedure :: evaluate_cyl => cyl_eval
+        procedure :: covariant_basis => cyl_basis
+        procedure :: metric_tensor => cyl_metric
+        procedure :: christoffel => cyl_christoffel
+        procedure :: from_cyl => cyl_from_cyl
+    end type cyl_chart_t
+
+contains
+
+    subroutine test_flat_cartesian(cs)
+        type(cart_chart_t), intent(in) :: cs
+        real(dp) :: u(3), Gamma(3, 3, 3), err
+        integer :: i, m, n
+
+        u = [0.3_dp, 1.1_dp, -0.4_dp]
+        call cs%christoffel(u, Gamma)
+        err = 0.0_dp
+        do i = 1, 3
+            do m = 1, 3
+                do n = 1, 3
+                    err = max(err, abs(Gamma(i, m, n)))
+                end do
+            end do
+        end do
+        print '(a,es12.4)', '  flat Cartesian max |Gamma| = ', err
+        if (err > 1.0e-8_dp) error stop 'flat Cartesian Christoffel not zero'
+    end subroutine test_flat_cartesian
+
+    subroutine test_cylindrical(cs)
+        type(cyl_chart_t), intent(in) :: cs
+        real(dp) :: u(3), Gamma(3, 3, 3), R, err
+        integer :: i, m, n
+
+        u = [1.7_dp, 0.6_dp, 0.9_dp] ! (R, phi, Z)
+        R = u(1)
+        call cs%christoffel(u, Gamma)
+
+        err = abs(Gamma(1, 2, 2) - (-R))
+        print '(a,es12.4)', '  cyl Gamma^R_phiphi err = ', err
+        if (err > 1.0e-6_dp) error stop 'cyl Gamma^R_phiphi wrong'
+
+        err = max(abs(Gamma(2, 1, 2) - 1.0_dp/R), abs(Gamma(2, 2, 1) - 1.0_dp/R))
+        print '(a,es12.4)', '  cyl Gamma^phi_Rphi err = ', err
+        if (err > 1.0e-6_dp) error stop 'cyl Gamma^phi_Rphi wrong'
+
+        ! All other components must be (near) zero.
+        do i = 1, 3
+            do m = 1, 3
+                do n = 1, 3
+                    if (i == 1 .and. m == 2 .and. n == 2) cycle
+                    if (i == 2 .and. m == 1 .and. n == 2) cycle
+                    if (i == 2 .and. m == 2 .and. n == 1) cycle
+                    if (abs(Gamma(i, m, n)) > 1.0e-6_dp) then
+                        print '(a,3i2,es12.4)', '  spurious Gamma ', i, m, n, &
+                            Gamma(i, m, n)
+                        error stop 'cyl Christoffel has spurious nonzero entry'
+                    end if
+                end do
+            end do
+        end do
+    end subroutine test_cylindrical
+
+    subroutine test_symmetry_and_compat(cs)
+        type(cyl_chart_t), intent(in) :: cs
+        real(dp) :: u(3), Gamma(3, 3, 3)
+        real(dp) :: g(3, 3), ginv(3, 3), sqrtg
+        real(dp) :: gp(3, 3), gm(3, 3), dummy(3, 3), ddet
+        real(dp) :: dg(3, 3, 3), up(3), um(3), h, nabla, err
+        integer :: i, j, k, l, m, n
+
+        u = [1.3_dp, 0.4_dp, 0.7_dp]
+        h = 1.0e-5_dp
+        call cs%christoffel(u, Gamma)
+
+        err = 0.0_dp
+        do i = 1, 3
+            do m = 1, 3
+                do n = 1, 3
+                    err = max(err, abs(Gamma(i, m, n) - Gamma(i, n, m)))
+                end do
+            end do
+        end do
+        print '(a,es12.4)', '  symmetry max |Gamma^i_mn - Gamma^i_nm| = ', err
+        if (err > 1.0e-12_dp) error stop 'coordinate christoffel not symmetric'
+
+        call cs%metric_tensor(u, g, ginv, sqrtg)
+        do k = 1, 3
+            up = u
+            um = u
+            up(k) = u(k) + h
+            um(k) = u(k) - h
+            call cs%metric_tensor(up, gp, dummy, ddet)
+            call cs%metric_tensor(um, gm, dummy, ddet)
+            dg(:, :, k) = (gp - gm)/(2.0_dp*h)
+        end do
+
+        err = 0.0_dp
+        do k = 1, 3
+            do i = 1, 3
+                do j = 1, 3
+                    nabla = dg(i, j, k)
+                    do l = 1, 3
+                        nabla = nabla - Gamma(l, k, i)*g(l, j) - Gamma(l, k, j)*g(i, l)
+                    end do
+                    err = max(err, abs(nabla))
+                end do
+            end do
+        end do
+        print '(a,es12.4)', '  metric compatibility max |nabla_k g_ij| = ', err
+        if (err > 1.0e-5_dp) error stop 'coordinate christoffel metric compatibility failed'
+    end subroutine test_symmetry_and_compat
+
+    ! ----- flat Cartesian chart: identity metric -----
+
+    subroutine cart_eval(self, u, x)
+        class(cart_chart_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: x(3)
+
+        associate (dummy => self)
+        end associate
+
+        x = u
+    end subroutine cart_eval
+
+    subroutine cart_basis(self, u, e_cov)
+        class(cart_chart_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: e_cov(3, 3)
+        integer :: i
+
+        associate (dummy => self)
+        end associate
+        associate (dummy => u)
+        end associate
+
+        e_cov = 0.0_dp
+        do i = 1, 3
+            e_cov(i, i) = 1.0_dp
+        end do
+    end subroutine cart_basis
+
+    subroutine cart_metric(self, u, g, ginv, sqrtg)
+        class(cart_chart_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: g(3, 3), ginv(3, 3), sqrtg
+        integer :: i
+
+        associate (dummy => self)
+        end associate
+        associate (dummy => u)
+        end associate
+
+        g = 0.0_dp
+        ginv = 0.0_dp
+        do i = 1, 3
+            g(i, i) = 1.0_dp
+            ginv(i, i) = 1.0_dp
+        end do
+        sqrtg = 1.0_dp
+    end subroutine cart_metric
+
+    subroutine cart_christoffel(self, u, Gamma)
+        class(cart_chart_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: Gamma(3, 3, 3)
+
+        call self%christoffel_fd(u, Gamma)
+    end subroutine cart_christoffel
+
+    subroutine cart_from_cyl(self, xcyl, u, ierr)
+        class(cart_chart_t), intent(in) :: self
+        real(dp), intent(in) :: xcyl(3)
+        real(dp), intent(out) :: u(3)
+        integer, intent(out) :: ierr
+
+        associate (dummy => self)
+        end associate
+
+        u = xcyl
+        ierr = 0
+    end subroutine cart_from_cyl
+
+    ! ----- cylindrical chart u = (R, phi, Z): g = diag(1, R^2, 1) -----
+
+    subroutine cyl_eval(self, u, x)
+        class(cyl_chart_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: x(3)
+
+        associate (dummy => self)
+        end associate
+
+        x(1) = u(1)*cos(u(2))
+        x(2) = u(1)*sin(u(2))
+        x(3) = u(3)
+    end subroutine cyl_eval
+
+    subroutine cyl_basis(self, u, e_cov)
+        class(cyl_chart_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: e_cov(3, 3)
+        real(dp) :: R, phi
+
+        associate (dummy => self)
+        end associate
+
+        R = u(1)
+        phi = u(2)
+        e_cov = 0.0_dp
+        e_cov(1, 1) = cos(phi)
+        e_cov(2, 1) = sin(phi)
+        e_cov(1, 2) = -R*sin(phi)
+        e_cov(2, 2) = R*cos(phi)
+        e_cov(3, 3) = 1.0_dp
+    end subroutine cyl_basis
+
+    subroutine cyl_metric(self, u, g, ginv, sqrtg)
+        class(cyl_chart_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: g(3, 3), ginv(3, 3), sqrtg
+        real(dp) :: R
+
+        associate (dummy => self)
+        end associate
+
+        R = u(1)
+        g = 0.0_dp
+        ginv = 0.0_dp
+        g(1, 1) = 1.0_dp
+        g(2, 2) = R*R
+        g(3, 3) = 1.0_dp
+        ginv(1, 1) = 1.0_dp
+        ginv(2, 2) = 1.0_dp/(R*R)
+        ginv(3, 3) = 1.0_dp
+        sqrtg = R
+    end subroutine cyl_metric
+
+    subroutine cyl_christoffel(self, u, Gamma)
+        class(cyl_chart_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: Gamma(3, 3, 3)
+
+        call self%christoffel_fd(u, Gamma)
+    end subroutine cyl_christoffel
+
+    subroutine cyl_from_cyl(self, xcyl, u, ierr)
+        class(cyl_chart_t), intent(in) :: self
+        real(dp), intent(in) :: xcyl(3)
+        real(dp), intent(out) :: u(3)
+        integer, intent(out) :: ierr
+
+        associate (dummy => self)
+        end associate
+
+        u = xcyl
+        ierr = 0
+    end subroutine cyl_from_cyl
+
+end module coordinate_christoffel_charts
+
+program test_coordinate_christoffel
+    use coordinate_christoffel_charts, only: cart_chart_t, cyl_chart_t, &
+        test_flat_cartesian, test_cylindrical, test_symmetry_and_compat
+    implicit none
+
+    type(cart_chart_t) :: cart
+    type(cyl_chart_t) :: cyl
+
+    call test_flat_cartesian(cart)
+    call test_cylindrical(cyl)
+    call test_symmetry_and_compat(cyl)
+
+    print *, 'coordinate_system christoffel: all checks passed'
+end program test_coordinate_christoffel


### PR DESCRIPTION
## Summary

Adds the geometric quantities a full-orbit (Lorentz) push needs in curvilinear coordinates: second derivatives of the VMEC coordinate map and Christoffel symbols of the second kind.

- `splint_vmec_data_d2` (`src/spline_vmec_data.f90`): returns `d2R(6), d2Z(6), d2l(6)` (order ss, st, sp, tt, tp, pp) for the coordinate map, by evaluating the 3D spline cell polynomials directly and applying the `rho_tor = sqrt(s)` chain rule for s-derivatives (`drho = 1/(2 rho)`, `d2rho = -1/(4 rho^3)`), consistent with `splint_vmec_data`.
- `christoffel_symflux` (`src/spline_vmec_data.f90`): `Gamma(i,m,n) = Gamma^i_{mn} = 0.5 g^{il}(d_m g_{ln} + d_n g_{lm} - d_l g_{mn})`. The metric derivatives `d_k g_{ij}` are algebraic in the 1st and 2nd derivatives of R, Z and lambda, using the same `g = C^T gV C` construction as `metric_tensor_symflux`.
- `coordinate_system_t` (`src/coordinates/libneo_coordinates_base.f90`): new deferred `christoffel` binding plus a shared finite-difference helper `christoffel_fd` that differentiates a chart's own `metric_tensor`. The `geoflux`, `vmec` and `chartmap` charts implement `christoffel` through that helper so the symbols are consistent with the metric each chart actually evaluates.

### Design note

The geoflux/vmec/chartmap charts build their metric numerically or with the physical (R, varphi, Z) embedding, not from the bare symmetry-flux `christoffel_symflux` engine. Wiring those charts to `christoffel_symflux` directly would give symbols inconsistent with the metric they evaluate (failing metric compatibility). They therefore use `christoffel_fd` on their own metric. `christoffel_symflux` is the analytic engine for the symmetry-flux map and is validated standalone against finite differences of `metric_tensor_symflux`.

The flat-Cartesian closed form is exercised at the `coordinate_system_t` level (`test_coordinate_christoffel`); the symmetry-flux metric carries the `g33 = R^2` toroidal term, so it cannot represent a nondegenerate flat 3D metric, and that closed form belongs to a Cartesian chart rather than the symmetry-flux engine.

## Verification

Build (gfortran 16.1.1, Release) via cmake/ninja from the worktree: clean build, 515/515 targets linked.

New tests, run directly:

```
$ ./build/test/test_christoffel_symflux.x
  FD vs analytic (pt 1): max err =   1.7084E-08
  FD vs analytic (pt 2): max err =   1.6561E-08
  FD vs analytic (pt 3): max err =   1.4669E-08
  FD vs analytic (pt 4): max err =   1.0602E-08
  symmetry max |Gamma^i_mn - Gamma^i_nm| =   1.1102E-16
  cyl Gamma^R_phiphi err =   0.0000E+00
  cyl Gamma^phi_Rphi err =   0.0000E+00
  metric compatibility (pt 1): max |nabla_k g_ij| =   7.7516E-10
  metric compatibility (pt 2): max |nabla_k g_ij| =   2.0812E-09
  metric compatibility (pt 3): max |nabla_k g_ij| =   7.0924E-10
 christoffel_symflux: all checks passed

$ ./build/test/test_coordinate_christoffel.x
  flat Cartesian max |Gamma| =   0.0000E+00
  cyl Gamma^R_phiphi err =   4.4755E-12
  cyl Gamma^phi_Rphi err =   1.5487E-12
  symmetry max |Gamma^i_mn - Gamma^i_nm| =   0.0000E+00
  metric compatibility max |nabla_k g_ij| =   4.4409E-16
 coordinate_system christoffel: all checks passed
```

ctest, new tests wired into CTest plus related coordinate/VMEC tests:

```
$ ctest -R "christoffel|coordinate_systems|flux_pseudocartesian|vmec_modules"
1/5 Test  #2: test_flux_pseudocartesian ........   Passed
2/5 Test  #3: test_christoffel_symflux .........   Passed
3/5 Test  #4: test_coordinate_christoffel ......   Passed
4/5 Test #24: test_vmec_modules ................   Passed
5/5 Test #25: test_coordinate_systems ..........   Passed
100% tests passed, 0 tests failed out of 5
```

Full suite: 61/72 pass. The 11 failures are all pre-existing and unrelated to this change: they stem from the missing `map2disc` Python package in this environment (`setup_chartmap_volume` raises `ModuleNotFoundError: No module named 'map2disc'`, and the dependent chartmap fixtures cannot be generated). Verified identical on a clean `origin/main` checkout (same 11 tests fail there with the same cause). Failing tests: setup_chartmap_volume, setup_vmec_chartmap_python, validate/plot_vmec_map2disc_chartmap_boundary_{python,cli,python_padded}, test_chartmap_coordinates, test_python_chartmap_generator, test_vector_conversion.