### PR TITLE
Use intrinsic complex part accessors for NetCDF I/O in coil_tools

### DIFF
--- a/src/magfie/coil_tools.f90
+++ b/src/magfie/coil_tools.f90
@@ -724,13 +724,13 @@ contains
 
          call nc_check('def_var', nf90_def_var(ncid, name//'_real', NF90_DOUBLE, &
                                                [dimid_tor, dimid_R, dimid_Z, dimid_coil], varid_actual_data))
-         call nc_check('put_var', nf90_put_var(ncid, varid_actual_data, var%Re))
+         call nc_check('put_var', nf90_put_var(ncid, varid_actual_data, real(var, dp)))
          call nc_check('put_att', nf90_put_att(ncid, varid_actual_data, 'comment', &
                                                'real part of toroidal Fourier mode of '//component// &
                                                ' component of vector potential'))
          call nc_check('def_var', nf90_def_var(ncid, name//'_imag', NF90_DOUBLE, &
                                                [dimid_tor, dimid_R, dimid_Z, dimid_coil], varid_actual_data))
-         call nc_check('put_var', nf90_put_var(ncid, varid_actual_data, var%Im))
+         call nc_check('put_var', nf90_put_var(ncid, varid_actual_data, aimag(var)))
          call nc_check('put_att', nf90_put_att(ncid, varid_actual_data, 'comment', &
                                                'imaginary part of toroidal Fourier mode of '//component// &
                                                ' component of vector potential'))
@@ -796,12 +796,16 @@ contains
          complex(dp), dimension(:, :, :, :), allocatable, intent(inout) :: var
          character(len=*), intent(in) :: name
          integer :: varid_actual_data
+         real(dp), dimension(:, :, :, :), allocatable :: re, im
 
          allocate (var(0:nmax, nR, nZ, ncoil))
+         allocate (re(0:nmax, nR, nZ, ncoil), im(0:nmax, nR, nZ, ncoil))
          call nc_check('inq_varid', nf90_inq_varid(ncid, name//'_real', varid_actual_data))
-         call nc_check('get_var', nf90_get_var(ncid, varid_actual_data, var%Re))
+         call nc_check('get_var', nf90_get_var(ncid, varid_actual_data, re))
          call nc_check('inq_varid', nf90_inq_varid(ncid, name//'_imag', varid_actual_data))
-         call nc_check('get_var', nf90_get_var(ncid, varid_actual_data, var%Im))
+         call nc_check('get_var', nf90_get_var(ncid, varid_actual_data, im))
+         var = cmplx(re, im, dp)
+         deallocate (re, im)
       end subroutine read_actual_data
    end subroutine read_Anvac_fourier
 


### PR DESCRIPTION
## Problem

`src/magfie/coil_tools.f90` passes the F2008 complex part-designators `var%Re` / `var%Im` directly into the generic NetCDF `nf90_put_var` / `nf90_get_var` in `write_Anvac_fourier` and `read_Anvac_fourier`. gfortran accepts this; nvfortran (NVHPC 26.3) rejects it. Fixes #323.

## Fix (behavior-preserving)

- Put side: `var%Re` -> `real(var, dp)`, `var%Im` -> `aimag(var)`. Numerically identical input array expressions.
- Get side: `var%Re` / `var%Im` are output args; read into `real(dp)` temporaries `re`/`im` of matching shape, then `var = cmplx(re, im, dp)`.

`real(var, dp)` is exactly `var%Re`; `aimag(var)` is exactly `var%Im`. No numerical change.

## Verification

Built with gfortran 16.1.1 (CMake + Ninja). The Anvac fourier write/read path is exercised by `tilted_coil_fourier_modes` (writes the NetCDF file) and `tilted_coil_field_validation` (reads it back):

```
test_nctools_nc_get3 ...........   Passed
test_biotsavart ................   Passed
test_biotsavart_field ..........   Passed
test_coil_tools_biot_savart ....   Passed
tilted_coil_generate_geometry ..   Passed
tilted_coil_fourier_modes ......   Passed
tilted_coil_field_validation ...   Passed
100% tests passed, 0 tests failed out of 7
```

The remaining failures in the full suite are unrelated chartmap tests failing at setup because the external `map2disc` Python module is not installed in this environment; they do not touch coil_tools.