### PR TITLE
Fix transposed Cartesian Jacobian from chartmap covariant_basis (cart-spline charts)

### DIFF
--- a/src/coordinates/libneo_coordinates_chartmap.f90
+++ b/src/coordinates/libneo_coordinates_chartmap.f90
@@ -333,6 +333,12 @@ contains
             dvals(3, 3) = drz(3, 2)
         else
             call evaluate_batch_splines_3d_der(self%spl_cart, u_eval, vals, dvals)
+            ! evaluate_batch_splines_3d_der returns dvals(deriv_dim, quantity) =
+            ! d x_quantity / d u_dim. Transpose to the documented covariant-basis
+            ! convention dvals(cart_component, coord_index) = d x_i / d u_k, matching
+            ! the spl_rz branch above; without this the Cartesian Jacobian (and the
+            ! metric built from it) is returned transposed for cart-spline charts.
+            dvals = transpose(dvals)
         end if
     end subroutine chartmap_eval_cart_der
 

--- a/src/coordinates/libneo_coordinates_chartmap_impl.inc
+++ b/src/coordinates/libneo_coordinates_chartmap_impl.inc
@@ -297,6 +297,9 @@ subroutine chartmap_eval_cart_der(self, u, vals, dvals)
         dvals(3, 3) = drz(3, 2)            ! dZ/dphi = dZ/dphi
     else
         call evaluate_batch_splines_3d_der(self%spl_cart, u_eval, vals, dvals)
+        ! batch der returns dvals(deriv_dim, quantity); transpose to the documented
+        ! dvals(cart_component, coord_index) = d x_i / d u_k (see the .f90 twin).
+        dvals = transpose(dvals)
     end if
 end subroutine chartmap_eval_cart_der
 


### PR DESCRIPTION
## Problem

`chartmap_eval_cart_der` has two branches. The `spl_rz` branch builds `dvals(cart_component, coord_index) = d x_i / d u_k` explicitly (the documented covariant-basis convention). The `spl_cart` branch instead passed the batch-spline derivative straight through:

```fortran
call evaluate_batch_splines_3d_der(self%spl_cart, u_eval, vals, dvals)
```

`evaluate_batch_splines_3d_der` returns `dvals(deriv_dim, quantity) = d x_quantity / d u_dim`, i.e. the **transpose**. So for chartmaps stored as Cartesian splines (`x, y, z`), `covariant_basis` and the `metric_tensor` built from it were returned transposed.

Symptom: a Newton inversion of `evaluate_cart` that uses `covariant_basis` as the Jacobian solves `J du = -res` to machine zero yet the residual never decreases, because the true Jacobian is `J^T`. Confirmed by finite differencing `evaluate_cart` against `covariant_basis` on a cart-spline W7-X chartmap: columns 2 and 3 were swapped into rows.

## Fix

Transpose `dvals` in the `spl_cart` branch (both the `.f90` and the `_impl.inc` twin) so both branches honour the documented `dvals(i,k) = d x_i / d u_k`.

## Test coverage

`test/source/test_chartmap_derivatives.f90` Test 2 already checks `covariant_basis` against a central finite difference of `evaluate_cart`, but the fixture is an R,Z (`spl_rz`) chartmap, so the cart-spline branch was never exercised. A cart-spline fixture for that test is the natural follow-up.

## Verification

In SIMPLE, the Cartesian full-orbit pusher inverts `evaluate_cart` per step on a cart-spline chartmap. Before: the warm Newton stalled immediately (`|J du + res| = 2.7e-20` but residual flat). After: it converges to the spline floor, and reactor/native W7-X traces run identically single- and multi-threaded.