### PR TITLE
magfie: optional allow_sol flag to accept points outside the separatrix

### DIFF
--- a/src/magfie/field_eq_mod.f90
+++ b/src/magfie/field_eq_mod.f90
@@ -9,6 +9,13 @@ module field_eq_mod
    integer :: nrad, nzet, icp, nwindow_r, nwindow_z
    integer :: ierrfield
 
+   ! When .true., magfie accepts guiding-center points outside the separatrix
+   ! (scrape-off layer) instead of flagging ierrfield=1. The equilibrium field
+   ! is splined over the whole EQDSK box and F is frozen to its vacuum value
+   ! there, so it stays valid. Default .false. keeps the historic domain bound
+   ! for all other consumers; edge-orbit tracing (POTATO) sets it .true.
+   logical :: allow_sol = .false.
+
    real(dp) :: psib, btf, rtf, hrad, hzet
    real(dp) :: psi_axis, psi_sep, hfpol                            !<=18.12.18
    real(dp), dimension(:, :), allocatable :: psi, psi0

--- a/src/magfie/magfie_cyl.f90
+++ b/src/magfie/magfie_cyl.f90
@@ -23,7 +23,7 @@ subroutine magfie(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
   !
   !  Called routines:  field
 
-  use field_eq_mod, only : psi_axis,psi_sep,ierrfield
+  use field_eq_mod, only : psi_axis,psi_sep,ierrfield,allow_sol
   use field_sub, only : psif
   use libneo_kinds, only : dp
   use field_sub,    only : field
@@ -40,7 +40,9 @@ subroutine magfie(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
 
   CALL field(x(1),x(2),x(3),br,bf,bz,BRR,BRF,BRZ,BFR,BFF,BFZ,BZR,BZF,BZZ)
 
-  if((psif-psi_axis)/(psi_sep-psi_axis).gt.1d0) then
+  if(allow_sol) then
+    ierrfield=0
+  else if((psif-psi_axis)/(psi_sep-psi_axis).gt.1d0) then
     print *,'magfie: point is outside separatrix, (R,Z) = ',x(1),x(3)
     ierrfield=1
   else


### PR DESCRIPTION
## What

Add `field_eq_mod::allow_sol` (default `.false.`), an opt-in flag that lets the
cylindrical `magfie` return the equilibrium field for guiding-center points
outside the separatrix instead of flagging `ierrfield=1`.

The field is valid there: `psi` is splined over the whole EQDSK box and `F` is
frozen to its vacuum value beyond the LCFS, so `B_phi = F_vac/R` is continuous
across the separatrix. The old unconditional abort was a domain *policy*, not a
field limitation. With the flag default `.false.`, behaviour is byte-identical
for every existing consumer (NEO-2 etc.); only a caller that explicitly sets it
`.true.` (edge orbit tracing) sees the change.

## Why

Guiding-center orbit followers (POTATO) cannot close a trapped banana whose tip
crosses the last closed flux surface, because `magfie` aborts at `psihat>1`.
Edge bananas are exactly where finite-orbit-width NTV matters. This flag is the
minimal enabler.

## Verification

Built through the POTATO subproject, which compiles this `magfie_cyl.f90` via
symlink (links clean).

Before (flag off, historic behaviour) — orbit cannot leave the LCFS:
`magfie: point is outside separatrix, (R,Z) = ...` and the integrator stalls.

After (`allow_sol=.true.`) — POTATO traces a closed trapped banana on the
ASDEX Upgrade #30835 equilibrium whose outboard leg enters the SOL and returns:
`single orbit: taub= 9.600793E+03  delphi= 2.471626E+00  ierr=0`, with
`R_max = 220.8 cm` versus LCFS `213.5 cm`.

Figure: https://box.sloppy.at/67d0f6afd465a297/edge_banana_aug30835.png

@phizenz please review; if it looks fine, go ahead and merge to `main` straight away.
