### PR TITLE
Stop writing healaxis.dat diagnostic file in axis healing

### DIFF
--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -82,16 +82,11 @@ contains
                                       grid_refinment)
         use new_vmec_stuff_mod, only: netcdffile, ns_s, ns_tp, multharm
         use spline_vmec_sub, only: spline_vmec_data
-        use new_vmec_stuff_mod, only: old_axis_healing_boundary
         use field_vmec, only: vmec_field_t, create_vmec_field
 
         character(len=*), intent(in), optional :: vmec_file
         integer, intent(in), optional :: radial_spline_order, angular_spline_order, grid_refinment
 
-        ! diagnostic file written by libneo's perform_axis_healing when splining VMEC data
-        character(len=*), parameter :: healaxis_file = 'healaxis.dat'
-        logical :: healaxis_exists
-        integer :: iunit
         type(vmec_field_t) :: vfield
 
         if (.not. present(vmec_file)) then
@@ -126,12 +121,6 @@ contains
         end if
 
         call spline_vmec_data()
-        ! if old_axis_healing_boundary, healaxis_file is not filled
-        inquire (file=healaxis_file, exist=healaxis_exists)
-        if (healaxis_exists .and. old_axis_healing_boundary) then
-            open (newunit=iunit, file=healaxis_file, status='old')
-            close (iunit, status='delete')
-        end if
 
         ! No-arg entry uses the global VMEC path: current_field stays
         ! unallocated so compute_boozer_data is byte-identical.

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -178,13 +178,13 @@ contains
 
    subroutine perform_axis_healing(almnc_rho, rmnc_rho, zmnc_rho, almns_rho, rmns_rho, zmns_rho)
       use new_vmec_stuff_mod, only: rmnc, zmns, almns, rmns, zmnc, almnc, &
-                                    axm, axn, nstrm, old_axis_healing_boundary, &
+                                    axm, nstrm, old_axis_healing_boundary, &
                                     axis_healing_power_law
       use vector_potentail_mod, only: ns
 
       real(dp), dimension(:, :), allocatable, intent(out) :: almnc_rho, rmnc_rho, zmnc_rho
       real(dp), dimension(:, :), allocatable, intent(out) :: almns_rho, rmns_rho, zmns_rho
-      integer :: i, m, nrho, nheal, iunit_hs, i_anchor
+      integer :: i, m, nrho, nheal, i_anchor
 
       nrho = ns
       allocate (almnc_rho(nstrm, 0:nrho - 1), rmnc_rho(nstrm, 0:nrho - 1), zmnc_rho(nstrm, 0:nrho - 1))
@@ -206,9 +206,6 @@ contains
          return
       end if
 
-      iunit_hs = 1357
-      open (iunit_hs, file='healaxis.dat')
-
       do i = 1, nstrm
          m = nint(abs(axm(i)))
 
@@ -216,7 +213,6 @@ contains
             nheal = min(m, 4)
          else
             call determine_nheal_for_axis(m, ns, rmnc(i, :), nheal)
-            write (iunit_hs, *) 'm = ', m, ' n = ', nint(abs(axn(i))), ' skipped ', nheal, ' / ', ns
          end if
 
          call s_to_rho_healaxis(m, ns, nrho, nheal, rmnc(i, :), rmnc_rho(i, :))
@@ -226,8 +222,6 @@ contains
          call s_to_rho_healaxis(m, ns, nrho, nheal, zmns(i, :), zmns_rho(i, :))
          call s_to_rho_healaxis(m, ns, nrho, nheal, almns(i, :), almns_rho(i, :))
       end do
-
-      close (iunit_hs)
    end subroutine perform_axis_healing
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc


### PR DESCRIPTION
## Summary

`perform_axis_healing` opened `healaxis.dat` on every legacy run and wrote to it only in the adaptive branch. The default boundary case (`old_axis_healing_boundary = .true.`) left a 0-byte file in the working directory. The file is a diagnostic log; the healing output goes back through the `*_rho` arrays. This drops the open/write/close.

`boozer_sub::get_boozer_coordinates` carried a delete-on-exit block to clean up that empty file (Georg's review on #310, https://github.com/itpplasma/libneo/pull/310#discussion_r3458747097). With the write gone the cleanup is dead, so it goes too, along with its now-unused locals and the `old_axis_healing_boundary` import.

The adaptive-mode `m = ... skipped ...` counts were only ever written to this file, so they go with it.

PR #320 reworks axis healing into an enum and still opens an empty `healaxis.dat` in `legacy` mode. Rebase #320 on this, or it reintroduces the write.

## Verification

Before (main, old code): the boozer tests leave a 0-byte file.

```
$ ls -l build/test/healaxis.dat
-rw-r--r-- 1 ert ert 0 22. Jun 15:45 build/test/healaxis.dat
```

After (this branch): no file appears, full suite green.

```
$ ctest --output-on-failure
100% tests passed, 0 tests failed out of 82
$ find build -name healaxis.dat
(nothing)
```

Converter output unchanged, the SIMPLE pin still passes:

```
$ ctest -R test_boozer_converter_vs_simple
5/5 Test #53: test_boozer_converter_vs_simple ... Passed 0.77 sec
```
