### PR TITLE
delthe_delphi_BV: return zero V-map when no VMEC<->Boozer map is loaded

### DIFF
--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -459,7 +459,16 @@ contains
 
         if (isw .eq. 0) then
             if (.not. delt_delp_V_batch_spline_ready) then
-                error stop "delthe_delphi_BV: V batch spline not initialized"
+                ! No VMEC<->Boozer angle map loaded -- the field is Boozer-native
+                ! (e.g. loaded from a Boozer chartmap, which stores no VMEC angles).
+                ! The theta_B-theta_V / phi_B-phi_V correction is then identically
+                ! zero, so return it instead of aborting (the chartmap CP/CPP path
+                ! reaches here for near-axis points).
+                deltheta_BV = 0.0_dp
+                delphi_BV = 0.0_dp
+                ddeltheta_BV = 0.0_dp
+                ddelphi_BV = 0.0_dp
+                return
             end if
             call evaluate_batch_splines_3d_der(delt_delp_V_batch_spline, x_eval, &
                                                y_eval, dy_eval)


### PR DESCRIPTION
Cherry-pick of 8626bb4 (was on feature/metric-christoffel) onto main.

When SIMPLE traces in a Boozer chartmap there is no VMEC<->Boozer map loaded, so the V batch spline is uninitialized. delthe_delphi_BV then error-stops (`V batch spline not initialized`), killing every chartmap full-orbit/GC run at the first field evaluation. The theta_B-theta_V / phi_B-phi_V correction is identically zero in that case, so return zero instead of aborting.

This is the only delta between libneo main and feature/metric-christoffel; with it on main, SIMPLE no longer needs to pin a feature branch. Verified: the W7-X high-mirror chartmap config that previously aborted now traces (8/8 markers complete).