### PR TITLE
boozer_sub: restore sqrt_g_ss output, gated on use_B_r

### DIFF
--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -27,7 +27,7 @@ module boozer_sub
 
     ! Constants
     real(dp), parameter :: TWOPI = 2.0_dp*3.14159265358979_dp
-    integer, parameter :: MAX_FIELD3D_QUANTITIES = 2
+    integer, parameter :: MAX_FIELD3D_QUANTITIES = 3
 
     ! Field object for the get_boozer_coordinates_with_field entry. The no-arg
     ! get_boozer_coordinates leaves this unallocated so the global-VMEC path
@@ -47,12 +47,13 @@ module boozer_sub
     type(boozer_state_t), save :: boozer_state
     !$acc declare create(boozer_state)
 
-    ! Batch spline data for 3D field quantities (Bmod, optionally B_r)
+    ! Batch spline data for 3D field quantities (Bmod, sqrt_g_ss, optionally B_r)
     type(BatchSplineData3D), save :: field3d_batch_spline
     logical, save :: field3d_batch_spline_ready = .false.
     integer, save :: field3d_num_quantities = 0
     real(dp), allocatable, save :: bmod_grid(:, :, :)
     real(dp), allocatable, save :: br_grid(:, :, :)
+    real(dp), allocatable, save :: sqrt_g_ss_grid(:, :, :)
 
     ! Batch spline for A_phi (vector potential)
     type(BatchSplineData1D), save :: aphi_batch_spline
@@ -198,7 +199,7 @@ contains
                                    B_vartheta_B, dB_vartheta_B, d2B_vartheta_B, &
                                    B_varphi_B, dB_varphi_B, d2B_varphi_B, &
                                    Bmod_B, dBmod_B, d2Bmod_B, &
-                                   B_r, dB_r, d2B_r)
+                                   B_r, dB_r, d2B_r, sqrt_g_ss_B)
 
         use chamb_mod, only: rnegflag
         use diag_mod, only: dodiag, icounter
@@ -213,6 +214,7 @@ contains
         real(dp), intent(out) :: B_vartheta_B, dB_vartheta_B, d2B_vartheta_B
         real(dp), intent(out) :: B_varphi_B, dB_varphi_B, d2B_varphi_B
         real(dp), intent(out) :: Bmod_B, B_r
+        real(dp), intent(out), optional :: sqrt_g_ss_B
         real(dp), intent(out) :: dBmod_B(3), dB_r(3)
         real(dp), intent(out) :: d2Bmod_B(6), d2B_r(6)
 
@@ -321,6 +323,9 @@ contains
             d2Bmod_B(5) = d2qua_dtdp
             d2Bmod_B(6) = d2qua_dp2
 
+            if (present(sqrt_g_ss_B) .and. boozer_state%use_B_r) &
+                sqrt_g_ss_B = y_eval(2)
+
             ! Extract B_r (if present)
             if (boozer_state%use_B_r) then
                 qua = y_eval(i_br)
@@ -367,6 +372,9 @@ contains
             dBmod_B(1) = dy_eval(1, 1)*drhods
             dBmod_B(2) = dy_eval(2, 1)
             dBmod_B(3) = dy_eval(3, 1)
+
+            if (present(sqrt_g_ss_B) .and. boozer_state%use_B_r) &
+                sqrt_g_ss_B = y_eval(2)
 
             d2Bmod_B = 0.0_dp
 
@@ -730,6 +738,7 @@ contains
         real(dp), allocatable :: phi_V(:), phi_B(:), aiota_arr(:), rho_tor(:)
         real(dp), allocatable :: Bcovar_theta_V(:, :), Bcovar_varphi_V(:, :)
         real(dp), allocatable :: bmod_Vg(:, :), alam_2D(:, :)
+        real(dp), allocatable :: sqrt_g_ss(:, :)
         real(dp), allocatable :: deltheta_BV_Vg(:, :), delphi_BV_Vg(:, :)
         real(dp), allocatable :: splcoe_t(:, :)
         real(dp), allocatable :: splcoe_p(:, :), coef(:, :)
@@ -737,7 +746,10 @@ contains
         real(dp), allocatable :: perqua_2D(:, :, :), Gfunc(:, :, :)
         real(dp), allocatable :: Bcovar_symfl(:, :, :, :)
 
+        ! sqrt(g^ss) is perqua quantity 7, built only for use_B_r callers; SIMPLE
+        ! drops it so its one-time field setup carries no unused metric grid.
         nqua = 6
+        if (use_B_r) nqua = 7
         gridcellnum = real((n_theta_B - 1)*(n_phi_B - 1), dp)
 
         npoilag = ns_tp_B + 1
@@ -769,6 +781,7 @@ contains
         allocate (Bcovar_varphi_V(n_theta_B, n_phi_B))
         allocate (bmod_Vg(n_theta_B, n_phi_B))
         allocate (alam_2D(n_theta_B, n_phi_B))
+        if (use_B_r) allocate (sqrt_g_ss(n_theta_B, n_phi_B))
         allocate (deltheta_BV_Vg(n_theta_B, n_phi_B))
         allocate (delphi_BV_Vg(n_theta_B, n_phi_B))
         allocate (wint_t(0:ns_tp_B), wint_p(0:ns_tp_B))
@@ -790,6 +803,7 @@ contains
 
         ! Allocate module-level grids
         call ensure_grid_3d(bmod_grid, ns_B, n_theta_B, n_phi_B)
+        if (use_B_r) call ensure_grid_3d(sqrt_g_ss_grid, ns_B, n_theta_B, n_phi_B)
         if (use_B_r) call ensure_grid_3d(br_grid, ns_B, n_theta_B, n_phi_B)
         call ensure_grid_4d(delt_delp_V_grid, ns_B, n_theta_B, n_phi_B, 2)
         if (use_del_tp_B) call ensure_grid_4d(delt_delp_B_grid, ns_B, n_theta_B, &
@@ -857,6 +871,8 @@ contains
                     Bcovar_theta_V(i_theta, i_phi) = Bcovar_vartheta*(1.0_dp + dl_dt)
                     Bcovar_varphi_V(i_theta, i_phi) = &
                         Bcovar_varphi + Bcovar_vartheta*dl_dp
+                    if (use_B_r) sqrt_g_ss(i_theta, i_phi) = &
+                        get_sqrt_g_ss_contravariant(s, theta, varphi)
 
                     perqua_2D(4, i_theta, i_phi) = Bcovar_r
                     perqua_2D(5, i_theta, i_phi) = Bcovar_vartheta
@@ -930,6 +946,7 @@ contains
                 perqua_t(2, 1:n_theta_B) = delphi_BV_Vg(:, i_phi)
                 perqua_t(3, 1:n_theta_B) = bmod_Vg(:, i_phi)
                 perqua_t(4:6, 1:n_theta_B) = perqua_2D(4:6, :, i_phi)
+                if (use_B_r) perqua_t(7, 1:n_theta_B) = sqrt_g_ss(:, i_phi)
                 ! Extend range of theta values
                 perqua_t(:, 2 - n_theta_B:0) = perqua_t(:, 1:n_theta_B - 1)
                 perqua_t(:, n_theta_B + 1:2*n_theta_B - 1) = perqua_t(:, 2:n_theta_B)
@@ -979,6 +996,7 @@ contains
                 delt_delp_B_grid(i_rho, :, :, 2) = perqua_2D(2, :, :)
             end if
             bmod_grid(i_rho, :, :) = perqua_2D(3, :, :)
+            if (use_B_r) sqrt_g_ss_grid(i_rho, :, :) = perqua_2D(7, :, :)
 
 ! End re-interpolate to equidistant grid in $(\vartheta_B,\varphi_B)$
 
@@ -997,6 +1015,7 @@ contains
             deallocate (aiota_arr, Gfunc, Bcovar_symfl)
         end if
 
+        if (use_B_r) deallocate (sqrt_g_ss)
         deallocate (Bcovar_theta_V, Bcovar_varphi_V, bmod_Vg, alam_2D, &
                     deltheta_BV_Vg, delphi_BV_Vg, &
                     wint_t, wint_p, coef, theta_V, theta_B, phi_V, phi_B, &
@@ -1027,6 +1046,35 @@ contains
                         Bctrvr_vartheta, Bctrvr_varphi, &
                         Bcovar_r, Bcovar_vartheta, Bcovar_varphi)
     end subroutine vmec_field_evaluate
+
+    !> Computes sqrt(g^{ss}) which is the same for Boozer (s, theta_B, varphi_B)
+    !> and VMEC (s, theta, varphi) coordinates
+    function get_sqrt_g_ss_contravariant(s, theta, varphi) result(sqrt_g_ss)
+        use spline_vmec_sub, only: splint_vmec_data
+        use spline_vmec_sub, only: metric_tensor_vmec
+        real(dp), intent(in) :: s, theta, varphi
+        real(dp) :: sqrt_g_ss
+
+        real(dp) :: dummy(10)
+        real(dp) :: R, dR_ds, dR_dtheta, dR_dphi
+        real(dp) :: dZ_ds, dZ_dtheta, dZ_dphi
+
+        real(dp) :: g_vmec(3, 3), sqrt_g_vmec
+
+        call splint_vmec_data(s, theta, varphi, &
+                              dummy(1), dummy(2), dummy(3), dummy(4), dummy(5), &
+                              R, &
+                              dummy(6), dummy(7), &
+                              dR_ds, dR_dtheta, dR_dphi, &
+                              dZ_ds, dZ_dtheta, dZ_dphi, &
+                              dummy(8), dummy(9), dummy(10))
+        call metric_tensor_vmec(R, dR_ds, dR_dtheta, dR_dphi, &
+                                dZ_ds, dZ_dtheta, dZ_dphi, g_vmec, sqrt_g_vmec)
+
+        !> contravariant metric component g^{ss} via cofactors of covariant components
+        sqrt_g_ss = sqrt(g_vmec(2, 2)*g_vmec(3, 3) - g_vmec(2, 3)**2.0_dp) &
+                    /abs(sqrt_g_vmec)
+    end function get_sqrt_g_ss_contravariant
 
     !> Compute radial covariant magnetic field B_rho from symmetry flux coordinates
     subroutine compute_br_from_symflux(rho_tor, aiota_arr, Gfunc, Bcovar_symfl)
@@ -1114,6 +1162,7 @@ contains
             field3d_num_quantities = 0
         end if
         if (allocated(bmod_grid)) deallocate (bmod_grid)
+        if (allocated(sqrt_g_ss_grid)) deallocate (sqrt_g_ss_grid)
         if (allocated(br_grid)) deallocate (br_grid)
         if (delt_delp_V_batch_spline_ready) then
             call destroy_batch_splines_3d(delt_delp_V_batch_spline)
@@ -1187,17 +1236,20 @@ contains
     end subroutine build_boozer_bcovar_tp_batch_spline
 
     subroutine build_boozer_field3d_batch_spline
-        ! Combined 3D field batch spline: Bmod, optionally Br
+        ! Combined 3D field batch spline: Bmod, sqrt_g_ss, optionally Br
         use boozer_coordinates_mod, only: ns_s_B, ns_tp_B, ns_B, n_theta_B, n_phi_B, &
                                           hs_B, h_theta_B, h_phi_B, use_B_r
 
         real(dp) :: x_min(3), x_max(3)
         real(dp), allocatable :: y_batch(:, :, :, :)
-        integer :: order(3), nq, i_br
+        integer :: order(3), nq, i_br, i_sqrt_g_ss
         logical :: periodic(3)
 
         if (.not. allocated(bmod_grid)) then
             error stop "build_boozer_field3d_batch_spline: bmod_grid not allocated"
+        end if
+        if (use_B_r .and. .not. allocated(sqrt_g_ss_grid)) then
+            error stop "build_boozer_field3d_batch_spline: sqrt_g_ss_grid not allocated"
         end if
         if (use_B_r .and. .not. allocated(br_grid)) then
             error stop "build_boozer_field3d_batch_spline: br_grid not allocated"
@@ -1221,8 +1273,13 @@ contains
 
         periodic = [.false., .true., .true.]
 
+        ! sqrt_g_ss and B_r are only consumed by use_B_r callers (e.g. RABE's
+        ! nabla_s). SIMPLE leaves use_B_r off and gets the lean single-quantity
+        ! Bmod spline, so its hot field eval stays at the pre-extraction cost.
         nq = 1  ! Bmod
         if (use_B_r) then
+            nq = nq + 1
+            i_sqrt_g_ss = nq
             nq = nq + 1
             i_br = nq
         end if
@@ -1230,6 +1287,7 @@ contains
         allocate (y_batch(ns_B, n_theta_B, n_phi_B, nq))
         y_batch(:, :, :, 1) = bmod_grid(:, :, :)
         if (use_B_r) then
+            y_batch(:, :, :, i_sqrt_g_ss) = sqrt_g_ss_grid(:, :, :)
             y_batch(:, :, :, i_br) = br_grid(:, :, :)
         end if
 
@@ -1387,7 +1445,7 @@ contains
 
         ! Build the 3D field batch spline over (rho_tor, theta_B, phi_B). The
         ! reader appended exact endpoint planes for the periodic spline. The
-        ! chartmap stores Bmod only and never sets B_r, so the field spline
+        ! chartmap stores Bmod only and leaves use_B_r off, so the field spline
         ! carries the single Bmod quantity.
         order_3d = [ns_s_B, ns_tp_B, ns_tp_B]
         periodic_3d = [.false., .true., .true.]
@@ -1437,6 +1495,7 @@ contains
         real(dp) :: A_phi_dum, A_theta_dum, dA_phi_ds, dA_theta_ds, aiota
         real(dp) :: d2A_phi_ds2, d3A_phi_ds3, B_theta_val, B_phi_val
         real(dp) :: dB_theta, d2B_theta, dB_phi, d2B_phi, Bmod_val, B_r_val
+        real(dp) :: sqrt_g_ss_val
         real(dp) :: dBmod(3), d2Bmod(6), dB_r(3), d2B_r(6)
         real(dp) :: dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp
         real(dp) :: dl_ds, dl_dt, dl_dp

--- a/test/source/test_boozer_converter_vs_simple.f90
+++ b/test/source/test_boozer_converter_vs_simple.f90
@@ -20,11 +20,18 @@ program test_boozer_converter_vs_simple
     ! 1e-10 absorbs that cross-platform FP noise without loosening the
     ! relative bound the large quantities meet.
     real(dp), parameter :: reltol = 1.0e-6_dp, abstol = 1.0e-10_dp
+    ! sqrt(g^ss) comes back from the field3d spline (the use_B_r quantity). The
+    ! cross-check evaluates the VMEC metric at the Boozer->VMEC back-mapped angles,
+    ! so the gap carries both the spline and the angle-map interpolation error at
+    ! this coarse grid_refinment=3 grid (~1e-2). 2e-2 confirms it is the right
+    ! quantity without pinning that grid-resolution floor.
+    real(dp), parameter :: reltol_gss = 2.0e-2_dp
     character(len=*), parameter :: wout_file = "wout.nc"
 
     integer, parameter :: n_cases = 5
     real(dp) :: stor(n_cases), theta(n_cases), phi(n_cases)
     real(dp) :: bmod, sqrtg, bder(3), hcovar(3), hctrvr(3), hcurl(3)
+    real(dp) :: sqrt_g_ss_B, sqrt_g_ss_ref
     real(dp) :: bmod_ref(n_cases), sqrtg_ref(n_cases)
     real(dp) :: bder_ref(n_cases, 3), hcovar_ref(n_cases, 3)
     real(dp) :: hctrvr_ref(n_cases, 3), hcurl_ref(n_cases, 3)
@@ -74,13 +81,24 @@ program test_boozer_converter_vs_simple
     test_failed = .false.
     do case = 1, n_cases
         call evaluate_boozer(stor(case), theta(case), phi(case), &
-                             bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+                             bmod, sqrtg, bder, hcovar, hctrvr, hcurl, sqrt_g_ss_B)
         call check("bmod", case, [bmod], [bmod_ref(case)], test_failed)
         call check("sqrtg", case, [sqrtg], [sqrtg_ref(case)], test_failed)
         call check("bder", case, bder, bder_ref(case, :), test_failed)
         call check("hcovar", case, hcovar, hcovar_ref(case, :), test_failed)
         call check("hctrvr", case, hctrvr, hctrvr_ref(case, :), test_failed)
         call check("hcurl", case, hcurl, hcurl_ref(case, :), test_failed)
+
+        ! sqrt(g^ss) is exposed only on the use_B_r path; cross-check it against
+        ! the VMEC metric evaluated at the back-mapped VMEC angles.
+        sqrt_g_ss_ref = metric_nabla_s(stor(case), theta(case), phi(case))
+        if (abs(sqrt_g_ss_B - sqrt_g_ss_ref) > reltol_gss*abs(sqrt_g_ss_ref)) then
+            print *, "---------------------------------------------------"
+            print *, "mismatch in sqrt_g_ss case ", case
+            print *, "spline : ", sqrt_g_ss_B
+            print *, "metric : ", sqrt_g_ss_ref
+            test_failed = .true.
+        end if
     end do
 
     if (test_failed) error stop "boozer converter differs from SIMPLE reference"
@@ -91,9 +109,10 @@ contains
     !> Assemble |B|, sqrt(g) and field components from splint_boozer_coord,
     !> following the SIMPLE/rabe Boozer field convention, in native CGS units.
     subroutine evaluate_boozer(s, vartheta_B, varphi_B, &
-                               bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+                               bmod, sqrtg, bder, hcovar, hctrvr, hcurl, sqrt_g_ss_B)
         real(dp), intent(in) :: s, vartheta_B, varphi_B
         real(dp), intent(out) :: bmod, sqrtg, bder(3), hcovar(3), hctrvr(3), hcurl(3)
+        real(dp), intent(out) :: sqrt_g_ss_B
 
         real(dp) :: A_theta, A_phi, dA_theta_dr, dA_phi_dr, d2A_phi_dr2, d3A_phi_dr3
         real(dp) :: B_vartheta_B, dB_vartheta_B, d2B_vartheta_B
@@ -109,7 +128,7 @@ contains
                                  B_vartheta_B, dB_vartheta_B, d2B_vartheta_B, &
                                  B_varphi_B, dB_varphi_B, d2B_varphi_B, &
                                  Bmod_B, dBmod_B, d2Bmod_B, &
-                                 B_r, dB_r, d2B_r)
+                                 B_r, dB_r, d2B_r, sqrt_g_ss_B)
 
         aiota = -dA_phi_dr/dA_theta_dr
         bmod = Bmod_B
@@ -126,6 +145,29 @@ contains
         hcurl(2) = (B_varphi_B*bder(1) - B_r*bder(3) + dB_r(3) - dB_varphi_B)/sqrtgbmod
         hcurl(3) = (B_r*bder(2) - B_vartheta_B*bder(1) + dB_vartheta_B - dB_r(2))/sqrtgbmod
     end subroutine evaluate_boozer
+
+    !> Reference |nabla s| = sqrt(g^ss) from the VMEC metric, independent of the
+    !> Boozer field3d spline: back-map the Boozer angles to VMEC and evaluate.
+    function metric_nabla_s(s, vartheta_B, varphi_B) result(sqrt_g_ss)
+        use boozer_sub, only: boozer_to_vmec
+        use spline_vmec_sub, only: splint_vmec_data, metric_tensor_vmec
+        real(dp), intent(in) :: s, vartheta_B, varphi_B
+        real(dp) :: sqrt_g_ss
+
+        real(dp) :: theta_V, varphi_V, dummy(10)
+        real(dp) :: R, dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp
+        real(dp) :: g_vmec(3, 3), sqrt_g_vmec
+
+        call boozer_to_vmec(s, vartheta_B, varphi_B, theta_V, varphi_V)
+        call splint_vmec_data(s, theta_V, varphi_V, &
+                              dummy(1), dummy(2), dummy(3), dummy(4), dummy(5), &
+                              R, dummy(6), dummy(7), &
+                              dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, &
+                              dummy(8), dummy(9), dummy(10))
+        call metric_tensor_vmec(R, dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, &
+                                g_vmec, sqrt_g_vmec)
+        sqrt_g_ss = sqrt(g_vmec(2, 2)*g_vmec(3, 3) - g_vmec(2, 3)**2)/abs(sqrt_g_vmec)
+    end function metric_nabla_s
 
     subroutine check(name, case, val, ref, test_failed)
         character(len=*), intent(in) :: name


### PR DESCRIPTION
## What

`sqrt_g_ss` (= |∇s|, the contravariant metric factor) was removed from `boozer_sub` in 4a8e985 as "unused". It is used: RABE's Boozer field reads it through `splint_boozer_coord` for `nabla_s` in the bootstrap fieldline integrals. After the removal, RABE's golden record drifts by a uniform ~1.5e-6 (all outputs share the `dr_dAtheta ∝ 1/nabla_s` prefactor).

This restores `sqrt_g_ss`, but **gated on `use_B_r`** so the perf fix from 4a8e985 still holds:

- `use_B_r` callers (RABE) get the 3-quantity `field3d` spline `(Bmod, sqrt_g_ss, B_r)` and the optional `sqrt_g_ss_B` output of `splint_boozer_coord` — identical to pre-removal behaviour.
- SIMPLE leaves `use_B_r` off and keeps the lean single-quantity `Bmod` spline. The metric grid is neither built nor splined, so neither the hot field eval nor the one-time setup regress.

## Verification

Built the curated `neo` subset and ran the boozer tests:

```
test_boozer_converter_vs_simple   exit 0   (use_B_r=.true.; new sqrt_g_ss_B cross-check vs VMEC metric passes, SIMPLE refs unchanged)
test_boozer_with_field            exit 0   (use_B_r=.false.; reproduces global VMEC path, 0 error)
test_boozer_chartmap_roundtrip    exit 0   (chartmap path, |B| roundtrip 4.3e-7)
```

RABE built against this branch: 32/32 quick+slow pass (incl. `TestAgainstNEO_QA`, the `nabla_s` vs NEO-2 check). RABE golden fidelity on the pinned toolchain is verified by the companion RABE PR.

`test_boozer_converter_vs_simple` gains an assertion comparing `sqrt_g_ss_B` to the VMEC metric `|∇s|` at the Boozer→VMEC back-mapped angles (tolerance 2e-2 absorbs the `grid_refinment=3` spline + angle-map floor).