### PR TITLE
Near-axis healing and exact-analytic Boozer chartmap axis (s=0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,11 @@ add_executable(vmec_to_chartmap.x
 )
 target_link_libraries(vmec_to_chartmap.x neo)
 
+add_executable(near_axis_field_diag.x
+    app/near_axis_field_diag.f90
+)
+target_link_libraries(near_axis_field_diag.x neo)
+
 
 if(LIBNEO_BUILD_TESTING)
     add_subdirectory(test)

--- a/app/near_axis_field_diag.f90
+++ b/app/near_axis_field_diag.f90
@@ -1,0 +1,85 @@
+program near_axis_field_diag
+    !> Near-axis VMEC field diagnostic. Splines the field with a chosen axis
+    !> healing variant and dumps a radial cut at fixed (theta, varphi) so the
+    !> continuity and rho^|m| behaviour can be inspected. One row per rho point:
+    !>   rho s theta A_theta A_phi dA_theta_ds dA_phi_ds Bmod Bcov_theta Bcov_phi
+    !> Radial derivatives are taken in post from the fine rho grid.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use new_vmec_stuff_mod, only: netcdffile, ns_s, ns_tp, multharm, &
+                                  old_axis_healing, old_axis_healing_boundary, &
+                                  axis_healing_power_law, rho_axis_heal
+    use spline_vmec_sub, only: spline_vmec_data, vmec_field
+    implicit none
+
+    character(len=1024) :: wout_file, variant, outfile, arg
+    integer :: nrho, irho, itheta
+    real(dp) :: rho, s, theta, varphi, rho_min, rho_max
+    real(dp) :: A_theta, A_phi, dA_theta_ds, dA_phi_ds, aiota
+    real(dp) :: sqg, alam, dl_ds, dl_dt, dl_dp
+    real(dp) :: Bctr_th, Bctr_ph, Bcov_s, Bcov_th, Bcov_ph, Bmod2, Bmod
+    real(dp), parameter :: pi = 3.14159265358979d0
+    real(dp) :: thetas(3)
+
+    call get_command_argument(1, wout_file)
+    call get_command_argument(2, variant)
+    call get_command_argument(3, outfile)
+    if (len_trim(wout_file) == 0 .or. len_trim(variant) == 0 .or. len_trim(outfile) == 0) then
+        print *, "Usage: near_axis_field_diag.x <wout.nc> <power|oldheal|oldbnd> <out.dat> [rho_axis_heal]"
+        error stop 1
+    end if
+
+    ! Geometry/resolution matching the benchmark runs (mh5 ns3).
+    ns_s = 3
+    ns_tp = 3
+    multharm = 5
+    rho_axis_heal = 0.1d0
+    call get_command_argument(4, arg)
+    if (len_trim(arg) > 0) read (arg, *) rho_axis_heal
+
+    select case (trim(variant))
+    case ('power')
+        axis_healing_power_law = .True.
+        old_axis_healing = .True.
+        old_axis_healing_boundary = .True.
+    case ('oldheal')
+        axis_healing_power_law = .False.
+        old_axis_healing = .True.
+        old_axis_healing_boundary = .False.
+    case ('oldbnd')
+        axis_healing_power_law = .False.
+        old_axis_healing = .True.
+        old_axis_healing_boundary = .True.
+    case default
+        print *, "unknown variant: ", trim(variant)
+        error stop 2
+    end select
+
+    netcdffile = trim(wout_file)
+    call spline_vmec_data
+
+    thetas = [0.0d0, 0.5d0*pi, pi]
+    varphi = 0.0d0
+    nrho = 4000
+    rho_min = 1.0d-4
+    rho_max = 0.40d0
+
+    open (unit=21, file=trim(outfile), status='replace', action='write')
+    write (21, '(A)') '# rho s theta A_theta A_phi dA_theta_ds dA_phi_ds Bmod Bcov_theta Bcov_phi'
+    do itheta = 1, 3
+        theta = thetas(itheta)
+        do irho = 0, nrho
+            rho = rho_min + (rho_max - rho_min)*dble(irho)/dble(nrho)
+            s = rho*rho
+            call vmec_field(s, theta, varphi, A_theta, A_phi, dA_theta_ds, dA_phi_ds, &
+                            aiota, sqg, alam, dl_ds, dl_dt, dl_dp, Bctr_th, Bctr_ph, &
+                            Bcov_s, Bcov_th, Bcov_ph)
+            Bmod2 = Bctr_th*Bcov_th + Bctr_ph*Bcov_ph
+            Bmod = sqrt(max(Bmod2, 0.0d0))
+            write (21, '(10ES20.11)') rho, s, theta, A_theta, A_phi, dA_theta_ds, &
+                dA_phi_ds, Bmod, Bcov_th, Bcov_ph
+        end do
+        write (21, '(A)') ''
+    end do
+    close (21)
+    print *, 'wrote ', trim(outfile), ' variant=', trim(variant), ' rho_axis_heal=', rho_axis_heal
+end program near_axis_field_diag

--- a/app/near_axis_field_diag.f90
+++ b/app/near_axis_field_diag.f90
@@ -6,9 +6,8 @@ program near_axis_field_diag
     !> Radial derivatives are taken in post from the fine rho grid.
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use new_vmec_stuff_mod, only: netcdffile, ns_s, ns_tp, multharm, &
-                                  old_axis_healing, old_axis_healing_boundary, &
-                                  axis_healing_power_law, rho_axis_heal, &
-                                  axis_healing_polyfit, axis_healing_polyfit_degree
+                                  axis_healing, s_axis_heal, rho_axis_heal, &
+                                  axis_healing_polyfit_degree
     use spline_vmec_sub, only: spline_vmec_data, vmec_field
     implicit none
 
@@ -25,7 +24,7 @@ program near_axis_field_diag
     call get_command_argument(2, variant)
     call get_command_argument(3, outfile)
     if (len_trim(wout_file) == 0 .or. len_trim(variant) == 0 .or. len_trim(outfile) == 0) then
-        print *, "Usage: near_axis_field_diag.x <wout.nc> <power|oldheal|oldbnd> <out.dat> [rho_axis_heal]"
+        print *, "Usage: near_axis_field_diag.x <wout.nc> <polyfit|powerlaw|legacy|legacy_adaptive> <out.dat> [s_axis_heal]"
         error stop 1
     end if
 
@@ -33,27 +32,21 @@ program near_axis_field_diag
     ns_s = 3
     ns_tp = 3
     multharm = 5
-    rho_axis_heal = 0.1d0
+    s_axis_heal = 1.0d-2
+    rho_axis_heal = -1.0d0
     call get_command_argument(4, arg)
-    if (len_trim(arg) > 0) read (arg, *) rho_axis_heal
+    if (len_trim(arg) > 0) read (arg, *) s_axis_heal
 
     select case (trim(variant))
     case ('polyfit')
-        axis_healing_polyfit = .True.
+        axis_healing = 'polyfit'
         axis_healing_polyfit_degree = 3
-        axis_healing_power_law = .False.
-    case ('power')
-        axis_healing_power_law = .True.
-        old_axis_healing = .True.
-        old_axis_healing_boundary = .True.
-    case ('oldheal')
-        axis_healing_power_law = .False.
-        old_axis_healing = .True.
-        old_axis_healing_boundary = .False.
-    case ('oldbnd')
-        axis_healing_power_law = .False.
-        old_axis_healing = .True.
-        old_axis_healing_boundary = .True.
+    case ('power', 'powerlaw')
+        axis_healing = 'powerlaw'
+    case ('oldbnd', 'legacy')
+        axis_healing = 'legacy'
+    case ('oldheal', 'legacy_adaptive')
+        axis_healing = 'legacy_adaptive'
     case default
         print *, "unknown variant: ", trim(variant)
         error stop 2
@@ -86,5 +79,5 @@ program near_axis_field_diag
         write (21, '(A)') ''
     end do
     close (21)
-    print *, 'wrote ', trim(outfile), ' variant=', trim(variant), ' rho_axis_heal=', rho_axis_heal
+    print *, 'wrote ', trim(outfile), ' variant=', trim(variant), ' s_axis_heal=', s_axis_heal
 end program near_axis_field_diag

--- a/app/near_axis_field_diag.f90
+++ b/app/near_axis_field_diag.f90
@@ -7,7 +7,8 @@ program near_axis_field_diag
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use new_vmec_stuff_mod, only: netcdffile, ns_s, ns_tp, multharm, &
                                   old_axis_healing, old_axis_healing_boundary, &
-                                  axis_healing_power_law, rho_axis_heal
+                                  axis_healing_power_law, rho_axis_heal, &
+                                  axis_healing_polyfit, axis_healing_polyfit_degree
     use spline_vmec_sub, only: spline_vmec_data, vmec_field
     implicit none
 
@@ -37,6 +38,10 @@ program near_axis_field_diag
     if (len_trim(arg) > 0) read (arg, *) rho_axis_heal
 
     select case (trim(variant))
+    case ('polyfit')
+        axis_healing_polyfit = .True.
+        axis_healing_polyfit_degree = 3
+        axis_healing_power_law = .False.
     case ('power')
         axis_healing_power_law = .True.
         old_axis_healing = .True.

--- a/bench/spline_many/src/util_bench_args.f90
+++ b/bench/spline_many/src/util_bench_args.f90
@@ -25,4 +25,3 @@ contains
     end function get_env_int
 
 end module util_bench_args
-

--- a/doc/near_axis_chartmap_limit.out
+++ b/doc/near_axis_chartmap_limit.out
@@ -1,0 +1,26 @@
+=== Position x = (R Cos phi, R Sin phi, Z), near-axis expansion ===
+x  = SeriesData[rho, 0, {Cos[p0[ze]]*r0[ze], Cos[p0[ze]]*(Cos[th]*r1c[ze] + r1s[ze]*Sin[th]) - r0[ze]*(Cos[th]*p1c[ze] + p1s[ze]*Sin[th])*Sin[p0[ze]]}, 0, 2, 1]
+
+=== Covariant basis at the axis (rho=0) ===
+dx/drho |0   = {Cos[p0[ze]]*(Cos[th]*r1c[ze] + r1s[ze]*Sin[th]) - r0[ze]*(Cos[th]*p1c[ze] + p1s[ze]*Sin[th])*Sin[p0[ze]], Cos[p0[ze]]*r0[ze]*(Cos[th]*p1c[ze] + p1s[ze]*Sin[th]) + (Cos[th]*r1c[ze] + r1s[ze]*Sin[th])*Sin[p0[ze]], Cos[th]*z1c[ze] + Sin[th]*z1s[ze]}   (m=1 ellipse vectors; NONZERO)
+dx/dtheta|0  = {0, 0, 0}   (vanishes ~rho: degenerate)
+dx/dzeta |0  = {-(r0[ze]*Sin[p0[ze]]*Derivative[1][p0][ze]) + Cos[p0[ze]]*Derivative[1][r0][ze], Cos[p0[ze]]*r0[ze]*Derivative[1][p0][ze] + Sin[p0[ze]]*Derivative[1][r0][ze], Derivative[1][z0][ze]}   (axis tangent)
+
+=== Metric / Jacobian leading order in rho ===
+g_rho_rho(0) = (Cos[p0[ze]]*(Cos[th]*r1c[ze] + r1s[ze]*Sin[th]) - r0[ze]*(Cos[th]*p1c[ze] + p1s[ze]*Sin[th])*Sin[p0[ze]])^2 + (Cos[p0[ze]]*r0[ze]*(Cos[th]*p1c[ze] + p1s[ze]*Sin[th]) + (Cos[th]*r1c[ze] + r1s[ze]*Sin[th])*Sin[p0[ze]])^2 + (Cos[th]*z1c[ze] + Sin[th]*z1s[ze])^2   (finite)
+g_theta_theta = rho^2*((Cos[th]*Cos[p0[ze]]*r1s[ze] - Cos[p0[ze]]*r1c[ze]*Sin[th] + r0[ze]*(-(Cos[th]*p1s[ze]) + p1c[ze]*Sin[th])*Sin[p0[ze]])^2 + (Cos[p0[ze]]*r0[ze]*(Cos[th]*p1s[ze] - p1c[ze]*Sin[th]) + (Cos[th]*r1s[ze] - r1c[ze]*Sin[th])*Sin[p0[ze]])^2 + (Sin[th]*z1c[ze] - Cos[th]*z1s[ze])^2)   (O(rho^2) -> 0)
+det[J_polar]  = rho*r0[ze]*((-(p1s[ze]*z1c[ze]) + p1c[ze]*z1s[ze])*Derivative[1][r0][ze] + r1s[ze]*(z1c[ze]*Derivative[1][p0][ze] - p1c[ze]*Derivative[1][z0][ze]) + r1c[ze]*(-(z1s[ze]*Derivative[1][p0][ze]) + p1s[ze]*Derivative[1][z0][ze]))   (O(rho): sqrt(g) ~ rho, vanishes at axis)
+
+=== Pseudo-Cartesian (X,Y) basis at axis (regular) ===
+dx/dX|0 = {Cos[p0[ze]]*r1c[ze] - p1c[ze]*r0[ze]*Sin[p0[ze]], Cos[p0[ze]]*p1c[ze]*r0[ze] + r1c[ze]*Sin[p0[ze]], z1c[ze]}
+dx/dY|0 = {Cos[p0[ze]]*r1s[ze] - p1s[ze]*r0[ze]*Sin[p0[ze]], Cos[p0[ze]]*p1s[ze]*r0[ze] + r1s[ze]*Sin[p0[ze]], z1s[ze]}
+det[J_(X,Y,ze)]|0 = r0[ze]*((-(p1s[ze]*z1c[ze]) + p1c[ze]*z1s[ze])*Derivative[1][r0][ze] + r1s[ze]*(z1c[ze]*Derivative[1][p0][ze] - p1c[ze]*Derivative[1][z0][ze]) + r1c[ze]*(-(z1s[ze]*Derivative[1][p0][ze]) + p1s[ze]*Derivative[1][z0][ze]))   (finite, nonzero -> chart regular through the axis)
+
+=== Identification with VMEC data ===
+axis (m=0): R0(ze)=p? no -> r0 = Sum_n raxis_cc(n) Cos[n nfp ze],
+            Z0(ze) = Sum_n zaxis_cs(n) Sin[n nfp ze]  (exact, from wout).
+x_axis = (r0 Cos[p0], r0 Sin[p0], z0),  p0 = cyl toroidal angle limit.
+ellipse (dx/drho|0): r1c,r1s,z1c,z1s = the m=1 harmonics' rho-slope.
+A_phi(0)=0 (no enclosed flux); |B|,B_theta,B_phi from healed m=0 at rho=0.
+
+DONE

--- a/doc/near_axis_chartmap_limit.wl
+++ b/doc/near_axis_chartmap_limit.wl
@@ -9,7 +9,25 @@
    Stellarator-symmetric VMEC map with near-axis (VMEC / Garren-Boozer)
    regularity R_m(rho) ~ rho^|m|: only m=0 survives at the axis (the axis curve),
    m=1 gives the limiting ellipse. Position in cylindrical (R, phi, Z), then
-   Cartesian x = R Cos[phi], y = R Sin[phi], z = Z. *)
+   Cartesian x = R Cos[phi], y = R Sin[phi], z = Z.
+
+   References (near-axis expansion, NAE):
+   - Garren & Boozer, Phys. Fluids B 3, 2822 (1991): existence/expansion.
+   - Landreman & Sengupta, JPP 84, 905840616 (2018), arXiv:1809.10233:
+     cylindrical-coordinate NAE, R=R0(phi)+r R1(theta,phi)+..., r ~ Sqrt[Phi_tor]
+     ~ Sqrt[s] = rho; axis from raxis_cc/zaxis_cs; m!=0 coeffs vanish at the axis.
+   - Rodriguez/Landreman et al., arXiv:1911.02659: arbitrary-order NAE.
+   - Generalized (signed) Frenet "G-frame", arXiv:2410.17595, Eq.(14):
+       x = X0(zeta) + q1 N(zeta) + q2 B(zeta),
+     axis X0 plus periodic cross-section coords (q1,q2) in a frame that stays
+     smooth where curvature vanishes (rotation Gamma(zeta) removes the Frenet
+     sign flip). This is the GVEC hmap_axisNB. The chartmap co-rotating frame
+     (libneo PR #332) is the special case X0=0 with uniform rotation; the exact
+     axis slice below is q1=q2=0 -> x=X0(zeta), the same axis curve.
+
+   Smooth VMEC match: store the rho=0 slice as X0(zeta) (theta-INDEPENDENT, the
+   m=0 regularity), let the rho>0 slices carry the m=1 ellipse = dx/drho|0; the
+   spline through rho=0 then reproduces the VMEC harmonics to leading orders. *)
 
 ClearAll["Global`*"];
 

--- a/doc/near_axis_chartmap_limit.wl
+++ b/doc/near_axis_chartmap_limit.wl
@@ -1,0 +1,79 @@
+(* ::Package:: *)
+
+(* Analytic near-axis limit of the Boozer chartmap (rho = Sqrt[s]).
+   Derives the position, covariant basis (chartmap metric), Jacobian and the
+   pseudo-Cartesian regularization of the flux->Cartesian map as rho->0, to
+   implement the exact s=0 slice of the chartmap export without evaluating VMEC
+   surface harmonics at the axis (no surface exists there).
+
+   Stellarator-symmetric VMEC map with near-axis (VMEC / Garren-Boozer)
+   regularity R_m(rho) ~ rho^|m|: only m=0 survives at the axis (the axis curve),
+   m=1 gives the limiting ellipse. Position in cylindrical (R, phi, Z), then
+   Cartesian x = R Cos[phi], y = R Sin[phi], z = Z. *)
+
+ClearAll["Global`*"];
+
+(* Near-axis scalar expansions to O(rho^2). Coefficients are functions of zeta
+   ze (the toroidal coordinate). phi is the cylindrical toroidal angle, regular
+   at the axis (phi -> p0[ze]); only the poloidal structure carries rho^|m|. *)
+Rr = r0[ze] + rho (r1c[ze] Cos[th] + r1s[ze] Sin[th])
+   + rho^2 (r20[ze] + r2c[ze] Cos[2 th] + r2s[ze] Sin[2 th]);
+Zz = z0[ze] + rho (z1c[ze] Cos[th] + z1s[ze] Sin[th])
+   + rho^2 (z20[ze] + z2c[ze] Cos[2 th] + z2s[ze] Sin[2 th]);
+ph = p0[ze] + rho (p1c[ze] Cos[th] + p1s[ze] Sin[th]);
+
+xvec = {Rr Cos[ph], Rr Sin[ph], Zz};
+
+Print["=== Position x = (R Cos phi, R Sin phi, Z), near-axis expansion ==="];
+Print["x  = ", Series[xvec[[1]], {rho, 0, 1}]];
+
+(* Covariant basis columns dx/d(rho,theta,zeta) *)
+eRho = D[xvec, rho];
+eThe = D[xvec, th];
+eZet = D[xvec, ze];
+
+aRho = Simplify[eRho /. rho -> 0];
+aThe = Simplify[eThe /. rho -> 0];
+aZet = Simplify[eZet /. rho -> 0];
+Print["\n=== Covariant basis at the axis (rho=0) ==="];
+Print["dx/drho |0   = ", aRho, "   (m=1 ellipse vectors; NONZERO)"];
+Print["dx/dtheta|0  = ", aThe, "   (vanishes ~rho: degenerate)"];
+Print["dx/dzeta |0  = ", aZet, "   (axis tangent)"];
+
+(* Metric and Jacobian leading behaviour *)
+gTT = Simplify[eThe . eThe];
+gRR = Simplify[eRho . eRho];
+Jpolar = Det[Transpose[{eRho, eThe, eZet}]];
+Print["\n=== Metric / Jacobian leading order in rho ==="];
+Print["g_rho_rho(0) = ", Simplify[gRR /. rho -> 0], "   (finite)"];
+Print["g_theta_theta = ", Normal[Series[gTT, {rho, 0, 2}]], "   (O(rho^2) -> 0)"];
+Print["det[J_polar]  = ", Simplify[Normal[Series[Jpolar, {rho, 0, 1}]]],
+   "   (O(rho): sqrt(g) ~ rho, vanishes at axis)"];
+
+(* Pseudo-Cartesian chart X = rho Cos[th], Y = rho Sin[th] : regular at axis.
+   Rewrite the O(rho^2) position with rho Cos[th]=Xv, rho Sin[th]=Yv,
+   rho^2 = Xv^2+Yv^2, rho^2 Cos[2th] = Xv^2-Yv^2, rho^2 Sin[2th] = 2 Xv Yv. *)
+sub = {rho Cos[th] -> Xv, rho Sin[th] -> Yv, rho^2 -> Xv^2 + Yv^2,
+   rho^2 Cos[2 th] -> Xv^2 - Yv^2, rho^2 Sin[2 th] -> 2 Xv Yv};
+RrC = r0[ze] + (r1c[ze] Xv + r1s[ze] Yv)
+   + r20[ze] (Xv^2 + Yv^2) + r2c[ze] (Xv^2 - Yv^2) + r2s[ze] (2 Xv Yv);
+ZzC = z0[ze] + (z1c[ze] Xv + z1s[ze] Yv)
+   + z20[ze] (Xv^2 + Yv^2) + z2c[ze] (Xv^2 - Yv^2) + z2s[ze] (2 Xv Yv);
+phC = p0[ze] + (p1c[ze] Xv + p1s[ze] Yv);
+xC = {RrC Cos[phC], RrC Sin[phC], ZzC};
+eX = D[xC, Xv] /. {Xv -> 0, Yv -> 0};
+eY = D[xC, Yv] /. {Xv -> 0, Yv -> 0};
+eZc = D[xC, ze] /. {Xv -> 0, Yv -> 0};
+Print["\n=== Pseudo-Cartesian (X,Y) basis at axis (regular) ==="];
+Print["dx/dX|0 = ", Simplify[eX]];
+Print["dx/dY|0 = ", Simplify[eY]];
+Print["det[J_(X,Y,ze)]|0 = ", Simplify[Det[Transpose[{eX, eY, eZc}]]],
+   "   (finite, nonzero -> chart regular through the axis)"];
+
+Print["\n=== Identification with VMEC data ==="];
+Print["axis (m=0): R0(ze)=p? no -> r0 = Sum_n raxis_cc(n) Cos[n nfp ze],"];
+Print["            Z0(ze) = Sum_n zaxis_cs(n) Sin[n nfp ze]  (exact, from wout)."];
+Print["x_axis = (r0 Cos[p0], r0 Sin[p0], z0),  p0 = cyl toroidal angle limit."];
+Print["ellipse (dx/drho|0): r1c,r1s,z1c,z1s = the m=1 harmonics' rho-slope."];
+Print["A_phi(0)=0 (no enclosed flux); |B|,B_theta,B_phi from healed m=0 at rho=0."];
+Print["\nDONE"];

--- a/src/boozer_chartmap.f90
+++ b/src/boozer_chartmap.f90
@@ -34,7 +34,7 @@ contains
         !> get_boozer_coordinates() and while VMEC splines are still active
         !> (needed for X, Y, Z geometry evaluation).
         use vector_potentail_mod, only: torflux
-        use new_vmec_stuff_mod, only: nper
+        use new_vmec_stuff_mod, only: nper, raxis_cc, zaxis_cs, ntor_axis
         use boozer_coordinates_mod, only: ns_B, n_theta_B, n_phi_B, &
                                           h_theta_B, h_phi_B
         use spline_vmec_sub, only: splint_vmec_data
@@ -49,16 +49,23 @@ contains
         integer :: var_aphi, var_btheta, var_bphi, var_bmod, var_nfp
         integer :: i_rho, i_theta, i_phi
         integer :: n_theta_out, n_phi_out
-        real(dp) :: rho_tor, s, theta_B, phi_B, theta_V, phi_V
+        real(dp) :: s, theta_B, phi_B, theta_V, phi_V
         real(dp) :: R, Zval, alam
         real(dp) :: A_phi_dum, A_theta_dum, dA_phi_ds, dA_theta_ds, aiota
         real(dp) :: d2A_phi_ds2, d3A_phi_ds3, B_theta_val, B_phi_val
         real(dp) :: dB_theta, d2B_theta, dB_phi, d2B_phi, Bmod_val, B_r_val
-        real(dp) :: sqrt_g_ss_val
         real(dp) :: dBmod(3), d2Bmod(6), dB_r(3), d2B_r(6)
         real(dp) :: dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp
         real(dp) :: dl_ds, dl_dt, dl_dp
-        real(dp), parameter :: rho_min = sqrt(1.0e-6_dp)
+        real(dp) :: R_axis, Z_axis, phi_V0, axis_geom_err, bmod_axis
+        ! Chartmap now reaches the exact magnetic axis (rho=0, s=0). The axis is
+        ! the m=0 limit: theta-independent geometry from the exact VMEC axis
+        ! curve raxis_cc/zaxis_cs (no flux surface exists at s=0). boozer_to_vmec
+        ! and splint_boozer_coord are singular at s=0, so the toroidal angle and
+        ! the field profiles are taken at the regular limit s_axis_eval (the
+        ! Boozer-data spline floor), while the axis position is exact.
+        real(dp), parameter :: rho_min = 0.0_dp
+        real(dp), parameter :: s_axis_eval = 1.0e-6_dp
         real(dp), allocatable :: rho_arr(:), s_arr(:), theta_arr(:), zeta_arr(:)
         real(dp), allocatable :: A_phi_arr(:), B_theta_arr(:), B_phi_arr(:)
         real(dp), allocatable :: x_arr(:, :, :), y_arr(:, :, :), z_arr(:, :, :)
@@ -95,15 +102,14 @@ contains
 
         ! A_phi is a flux profile on s. B_theta/B_phi stay on rho for now.
         do i_rho = 1, ns_B
-            call splint_boozer_coord(s_arr(i_rho), 0.0_dp, 0.0_dp, 0, &
+            call splint_boozer_coord(max(s_arr(i_rho), s_axis_eval), 0.0_dp, 0.0_dp, 0, &
                                      A_theta_dum, A_phi_arr(i_rho), dA_theta_ds, &
                                      dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
                                      B_theta_val, dB_theta, d2B_theta, &
                                      B_phi_val, dB_phi, d2B_phi, &
                                      Bmod_val, dBmod, d2Bmod, &
                                      B_r_val, dB_r, d2B_r)
-
-            s = rho_arr(i_rho)**2
+            s = max(rho_arr(i_rho)**2, s_axis_eval)
             call splint_boozer_coord(s, 0.0_dp, 0.0_dp, 0, &
                                      A_theta_dum, A_phi_dum, dA_theta_ds, &
                                      dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
@@ -113,37 +119,83 @@ contains
                                      B_r_val, dB_r, d2B_r)
         end do
 
-        ! Compute X, Y, Z geometry on the Boozer grid (endpoint-excluded)
+        ! Axis slice (rho=0): the exact magnetic axis is m=0, theta-independent.
+        ! boozer_to_vmec degenerates poloidally at s=0, so take the regular
+        ! toroidal limit phi_V0(phi_B) at s_axis_eval and average over theta to
+        ! cancel the O(rho) poloidal contamination (the m=1 mean is zero on the
+        ! full-period grid), leaving phi_V0 to O(rho**2). The axis position is
+        ! the exact VMEC axis curve, identical for every theta -> regular at rho=0.
+        axis_geom_err = 0.0_dp
+        do i_phi = 1, n_phi_out
+            phi_B = zeta_arr(i_phi)
+            phi_V0 = 0.0_dp
+            do i_theta = 1, n_theta_out
+                call boozer_to_vmec(s_axis_eval, theta_arr(i_theta), phi_B, theta_V, phi_V)
+                phi_V0 = phi_V0 + phi_V
+            end do
+            phi_V0 = phi_V0/real(n_theta_out, dp)
+            call eval_vmec_axis(phi_V0, R_axis, Z_axis)
+            x_arr(1, :, i_phi) = R_axis*cos(phi_V0)
+            y_arr(1, :, i_phi) = R_axis*sin(phi_V0)
+            z_arr(1, :, i_phi) = Z_axis
+
+            ! Convention + smoothness gate: at s=0 splint_vmec_data returns the
+            ! m=0 (theta-independent) limit; with the m=0 healing anchored to
+            ! the exact axis it must equal the exact axis.
+            call splint_vmec_data(0.0_dp, 0.0_dp, phi_V0, &
+                                  A_phi_dum, A_theta_dum, dA_phi_ds, &
+                                  dA_theta_ds, aiota, &
+                                  R, Zval, alam, dR_ds, dR_dt, dR_dp, &
+                                  dZ_ds, dZ_dt, dZ_dp, dl_ds, dl_dt, dl_dp)
+            axis_geom_err = max(axis_geom_err, abs(R - R_axis) + abs(Zval - Z_axis))
+        end do
+
+        ! Interior (rho>0): Boozer angles -> VMEC angles -> VMEC geometry.
         do i_phi = 1, n_phi_out
             do i_theta = 1, n_theta_out
-                do i_rho = 1, ns_B
-                    rho_tor = rho_arr(i_rho)
-                    s = rho_tor**2
+                do i_rho = 2, ns_B
+                    s = rho_arr(i_rho)**2
                     theta_B = theta_arr(i_theta)
                     phi_B = zeta_arr(i_phi)
-
-                    ! Convert Boozer angles to VMEC angles
                     call boozer_to_vmec(s, theta_B, phi_B, theta_V, phi_V)
-
-                    ! Evaluate VMEC geometry at (s, theta_V, phi_V)
                     call splint_vmec_data(s, theta_V, phi_V, &
                                           A_phi_dum, A_theta_dum, dA_phi_ds, &
                                           dA_theta_ds, aiota, &
                                           R, Zval, alam, dR_ds, dR_dt, dR_dp, &
                                           dZ_ds, dZ_dt, dZ_dp, dl_ds, dl_dt, dl_dp)
-
                     x_arr(i_rho, i_theta, i_phi) = R*cos(phi_V)
                     y_arr(i_rho, i_theta, i_phi) = R*sin(phi_V)
                     z_arr(i_rho, i_theta, i_phi) = Zval
                 end do
             end do
         end do
+        print *, 'export_boozer_chartmap: axis vs VMEC m=0 limit max|dR|+|dZ| =', &
+            axis_geom_err
 
+        ! Bmod axis slice (rho=0): theta-independent m=0 axis field strength,
+        ! the theta-average at s_axis_eval (the m=1 mean is zero on the grid).
+        do i_phi = 1, n_phi_out
+            phi_B = zeta_arr(i_phi)
+            bmod_axis = 0.0_dp
+            do i_theta = 1, n_theta_out
+                call splint_boozer_coord(s_axis_eval, theta_arr(i_theta), phi_B, 0, &
+                                         A_theta_dum, A_phi_dum, dA_theta_ds, &
+                                         dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
+                                         B_theta_val, dB_theta, d2B_theta, &
+                                         B_phi_val, dB_phi, d2B_phi, &
+                                         Bmod_val, dBmod, d2Bmod, &
+                                         B_r_val, dB_r, d2B_r)
+                bmod_axis = bmod_axis + Bmod_val
+            end do
+            bmod_arr(1, :, i_phi) = bmod_axis/real(n_theta_out, dp)
+        end do
+
+        ! Bmod interior (rho>0)
         do i_phi = 1, n_phi_out
             phi_B = real(i_phi - 1, dp)*h_phi_B
             do i_theta = 1, n_theta_out
                 theta_B = real(i_theta - 1, dp)*h_theta_B
-                do i_rho = 1, ns_B
+                do i_rho = 2, ns_B
                     s = rho_arr(i_rho)**2
                     call splint_boozer_coord(s, theta_B, phi_B, 0, &
                                              A_theta_dum, A_phi_dum, dA_theta_ds, &
@@ -256,6 +308,26 @@ contains
                 error stop
             end if
         end subroutine nc_assert
+
+        !> Exact VMEC magnetic axis (m=0) at the VMEC toroidal angle phi_V.
+        !> Stellarator-symmetric: R = sum_n raxis_cc(n) cos(n nfp phi_V),
+        !> Z = sum_n zaxis_cs(n) sin(n nfp phi_V). Sign convention is checked
+        !> against the s=0 limit of splint_vmec_data (axis_geom_err).
+        subroutine eval_vmec_axis(phi_V, R_axis_out, Z_axis_out)
+            real(dp), intent(in) :: phi_V
+            real(dp), intent(out) :: R_axis_out, Z_axis_out
+            integer :: nm
+            real(dp) :: ang
+            R_axis_out = 0.0_dp
+            Z_axis_out = 0.0_dp
+            ! VMEC convention R = sum rmnc cos(m u - n v), Z = sum zmns sin(m u - n v).
+            ! At m=0: cos(-n v) = cos(n v), sin(-n v) = -sin(n v), hence the Z sign.
+            do nm = 0, ntor_axis
+                ang = real(nm, dp)*real(nper, dp)*phi_V
+                R_axis_out = R_axis_out + raxis_cc(nm)*cos(ang)
+                Z_axis_out = Z_axis_out - zaxis_cs(nm)*sin(ang)
+            end do
+        end subroutine eval_vmec_axis
 
     end subroutine export_boozer_chartmap
 

--- a/src/boozer_chartmap.f90
+++ b/src/boozer_chartmap.f90
@@ -57,7 +57,7 @@ contains
         real(dp) :: dBmod(3), d2Bmod(6), dB_r(3), d2B_r(6)
         real(dp) :: dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp
         real(dp) :: dl_ds, dl_dt, dl_dp
-        real(dp) :: R_axis, Z_axis, phi_V0, axis_geom_err, bmod_axis
+        real(dp) :: R_axis, Z_axis, phi_V0, axis_geom_err, bmod_axis, axis_pos_scale
         ! Chartmap now reaches the exact magnetic axis (rho=0, s=0). The axis is
         ! the m=0 limit: theta-independent geometry from the exact VMEC axis
         ! curve raxis_cc/zaxis_cs (no flux surface exists at s=0). boozer_to_vmec
@@ -126,6 +126,7 @@ contains
         ! full-period grid), leaving phi_V0 to O(rho**2). The axis position is
         ! the exact VMEC axis curve, identical for every theta -> regular at rho=0.
         axis_geom_err = 0.0_dp
+        axis_pos_scale = 0.0_dp
         do i_phi = 1, n_phi_out
             phi_B = zeta_arr(i_phi)
             phi_V0 = 0.0_dp
@@ -148,6 +149,7 @@ contains
                                   R, Zval, alam, dR_ds, dR_dt, dR_dp, &
                                   dZ_ds, dZ_dt, dZ_dp, dl_ds, dl_dt, dl_dp)
             axis_geom_err = max(axis_geom_err, abs(R - R_axis) + abs(Zval - Z_axis))
+            axis_pos_scale = max(axis_pos_scale, abs(R_axis) + abs(Z_axis))
         end do
 
         ! Interior (rho>0): Boozer angles -> VMEC angles -> VMEC geometry.
@@ -171,6 +173,18 @@ contains
         end do
         print *, 'export_boozer_chartmap: axis vs VMEC m=0 limit max|dR|+|dZ| =', &
             axis_geom_err
+        ! Gross-mismatch gate: a wrong axis sign/convention (a flipped Z gives an
+        ! error of order the axis magnitude itself, ratio ~0.5-1) writes a chartmap
+        ! whose innermost surface does not meet the interior. Abort on that. The
+        ! residual of a legitimate healing stays orders of magnitude below 1% of the
+        ! axis scale (anchored ~1e-7 cm, legacy ~1e-1 cm on a ~1e2 cm axis = ~1e-3),
+        ! so 1% catches a convention regression without rejecting any valid mode.
+        if (axis_geom_err > 1.0e-2_dp*max(axis_pos_scale, 1.0e-30_dp)) then
+            print *, 'export_boozer_chartmap: s=0 axis disagrees with the VMEC m=0 ', &
+                'limit by', axis_geom_err, 'vs position scale', axis_pos_scale, &
+                '-- wrong axis convention or healing mode'
+            error stop 'export_boozer_chartmap: axis geometry gate failed'
+        end if
 
         ! Bmod axis slice (rho=0): theta-independent m=0 axis field strength,
         ! the theta-average at s_axis_eval (the m=1 mean is zero on the grid).
@@ -318,6 +332,8 @@ contains
             real(dp), intent(out) :: R_axis_out, Z_axis_out
             integer :: nm
             real(dp) :: ang
+            if (ntor_axis >= 0 .and. .not. allocated(raxis_cc)) &
+                error stop 'eval_vmec_axis: raxis_cc not allocated for ntor_axis >= 0'
             R_axis_out = 0.0_dp
             Z_axis_out = 0.0_dp
             ! VMEC convention R = sum rmnc cos(m u - n v), Z = sum zmns sin(m u - n v).

--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -1026,7 +1026,7 @@ contains
                                 dZ_ds, dZ_dtheta, dZ_dphi, g_vmec, sqrt_g_vmec)
 
         !> contravariant metric component g^{ss} via cofactors of covariant components
-        sqrt_g_ss = sqrt(g_vmec(2, 2)*g_vmec(3, 3) - g_vmec(2, 3)**2.0_dp) &
+        sqrt_g_ss = sqrt(g_vmec(2, 2)*g_vmec(3, 3) - g_vmec(2, 3)**2) &
                     /abs(sqrt_g_vmec)
     end function get_sqrt_g_ss_contravariant
 

--- a/src/canonical_coordinates_mod.f90
+++ b/src/canonical_coordinates_mod.f90
@@ -33,6 +33,15 @@
     ! legacy healing so existing chartmap/field consumers are unchanged.
     logical :: axis_healing_power_law = .False.
     double precision :: rho_axis_heal = 0.1d0
+    ! rho**|m| * (least-squares polynomial in s) axis continuation below
+    ! rho_axis_heal. Same analytic regularity as the power-law path, but the
+    ! rescaled amplitude c_m/rho**|m| is extrapolated to the axis by a smooth
+    ! degree-axis_healing_polyfit_degree fit to the reliable surfaces and then
+    ! splined over the full grid, avoiding the noise amplification and anchor
+    ! roughness of the pure power-law continuation. Overrides the flags above
+    ! when .true.
+    logical :: axis_healing_polyfit = .False.
+    integer :: axis_healing_polyfit_degree = 3
   end module new_vmec_stuff_mod
 !
   module vector_potentail_mod

--- a/src/canonical_coordinates_mod.f90
+++ b/src/canonical_coordinates_mod.f90
@@ -24,24 +24,32 @@
 !
     double precision, dimension(:,:,:,:,:,:), allocatable :: sR,sZ,slam
 
+    ! Near-axis healing of the VMEC harmonics. Preferred selector:
+    !   axis_healing = 'legacy'   - skip the innermost unreliable surfaces and
+    !                               extrapolate the rescaled amplitude (old default).
+    !                  'powerlaw' - rho**|m| continuation below rho_axis_heal
+    !                               (analytic regularity, but amplifies near-axis
+    !                               noise; superseded by 'polyfit').
+    !                  'polyfit'  - rho**|m| * least-squares poly(s) continuation
+    !                               below rho_axis_heal: same regularity, smooth,
+    !                               no anchor noise. Recommended.
+    ! axis_healing_boundary selects the legacy reliability boundary (where the
+    ! VMEC data is no longer trusted near the axis):
+    !   'fixed'    - discard the innermost min(|m|,4) surfaces.
+    !   'adaptive' - detect the noisy surface via determine_nheal_for_axis.
+    ! Empty strings mean "unset": the deprecated logical switches below are
+    ! mapped to a mode with a one-time warning (see resolve_axis_healing_mode).
+    character(len=16) :: axis_healing = ''
+    character(len=16) :: axis_healing_boundary = ''
+    double precision :: rho_axis_heal = 0.1d0      ! anchor radius for powerlaw/polyfit
+    integer :: axis_healing_polyfit_degree = 3     ! polyfit polynomial degree in s
+    ! DEPRECATED boolean switches (use axis_healing / axis_healing_boundary). Kept
+    ! for back-compat and mapped to a mode with a deprecation warning; the next
+    ! SIMPLE release will remove them and default axis_healing to 'polyfit'.
     logical :: old_axis_healing = .True.
     logical :: old_axis_healing_boundary = .True.
-    ! rho**m power-law axis continuation below rho_axis_heal; enforces the
-    ! analytic regularity c_m(rho) ~ rho**|m| at the axis and overrides the two
-    ! legacy flags above when .true. Opt-in: consumers that need it (SIMPLE
-    ! near-axis symplectic tracing) enable it via namelist. Default keeps the
-    ! legacy healing so existing chartmap/field consumers are unchanged.
     logical :: axis_healing_power_law = .False.
-    double precision :: rho_axis_heal = 0.1d0
-    ! rho**|m| * (least-squares polynomial in s) axis continuation below
-    ! rho_axis_heal. Same analytic regularity as the power-law path, but the
-    ! rescaled amplitude c_m/rho**|m| is extrapolated to the axis by a smooth
-    ! degree-axis_healing_polyfit_degree fit to the reliable surfaces and then
-    ! splined over the full grid, avoiding the noise amplification and anchor
-    ! roughness of the pure power-law continuation. Overrides the flags above
-    ! when .true.
     logical :: axis_healing_polyfit = .False.
-    integer :: axis_healing_polyfit_degree = 3
   end module new_vmec_stuff_mod
 !
   module vector_potentail_mod

--- a/src/canonical_coordinates_mod.f90
+++ b/src/canonical_coordinates_mod.f90
@@ -25,27 +25,24 @@
     double precision, dimension(:,:,:,:,:,:), allocatable :: sR,sZ,slam
 
     ! Near-axis healing of the VMEC harmonics. Preferred selector:
-    !   axis_healing = 'legacy'   - skip the innermost unreliable surfaces and
-    !                               extrapolate the rescaled amplitude (old default).
-    !                  'powerlaw' - rho**|m| continuation below rho_axis_heal
-    !                               (analytic regularity, but amplifies near-axis
-    !                               noise; superseded by 'polyfit').
-    !                  'polyfit'  - rho**|m| * least-squares poly(s) continuation
-    !                               below rho_axis_heal: same regularity, smooth,
-    !                               no anchor noise. Recommended.
-    ! axis_healing_boundary selects the legacy reliability boundary (where the
-    ! VMEC data is no longer trusted near the axis):
-    !   'fixed'    - discard the innermost min(|m|,4) surfaces.
-    !   'adaptive' - detect the noisy surface via determine_nheal_for_axis.
-    ! Empty strings mean "unset": the deprecated logical switches below are
-    ! mapped to a mode with a one-time warning (see resolve_axis_healing_mode).
+    !   axis_healing = 'legacy'          - old default: discard min(|m|,4)
+    !                                      surfaces and extrapolate.
+    !                  'legacy_adaptive' - old adaptive boundary from
+    !                                      determine_nheal_for_axis.
+    !                  'powerlaw'        - rho**|m| continuation below
+    !                                      s_axis_heal.
+    !                  'polyfit'         - rho**|m| * least-squares poly(s)
+    !                                      below s_axis_heal. Recommended.
+    ! The empty string means "unset": deprecated logical switches below are
+    ! mapped to a mode with a warning (see resolve_axis_healing_mode).
     character(len=16) :: axis_healing = ''
-    character(len=16) :: axis_healing_boundary = ''
-    double precision :: rho_axis_heal = 0.1d0      ! anchor radius for powerlaw/polyfit
+    double precision :: s_axis_heal = 1.0d-2       ! anchor flux for powerlaw/polyfit
+    double precision :: rho_axis_heal = -1.0d0     ! deprecated; use s_axis_heal
     integer :: axis_healing_polyfit_degree = 3     ! polyfit polynomial degree in s
-    ! DEPRECATED boolean switches (use axis_healing / axis_healing_boundary). Kept
-    ! for back-compat and mapped to a mode with a deprecation warning; the next
-    ! SIMPLE release will remove them and default axis_healing to 'polyfit'.
+    logical :: rho_axis_heal_warning_printed = .False.
+    ! DEPRECATED boolean switches (use axis_healing). Kept for back-compat and
+    ! mapped to a mode with a deprecation warning; the next SIMPLE release will
+    ! remove them and default axis_healing to 'polyfit'.
     logical :: old_axis_healing = .True.
     logical :: old_axis_healing_boundary = .True.
     logical :: axis_healing_power_law = .False.

--- a/src/canonical_coordinates_mod.f90
+++ b/src/canonical_coordinates_mod.f90
@@ -21,6 +21,14 @@
     double precision, dimension(:),     allocatable :: aiota,s,sps,phi
     double precision, dimension(:,:),   allocatable :: almnc,rmnc,zmnc
     double precision, dimension(:,:),   allocatable :: almns,rmns,zmns
+    ! Exact magnetic axis (VMEC wout raxis_cc/zaxis_cs), indexed n=0..ntor:
+    !   R_axis(phi) = sum_n raxis_cc(n) cos(n*nfp*phi) + raxis_cs(n) sin(...)
+    !   Z_axis(phi) = sum_n zaxis_cc(n) cos(n*nfp*phi) + zaxis_cs(n) sin(...)
+    ! The exact axis curve (no flux surface at s=0), used for the analytic
+    ! near-axis chartmap limit. raxis_cs/zaxis_cc are zero unless lasym.
+    integer :: ntor_axis = -1
+    double precision, dimension(:), allocatable :: raxis_cc, zaxis_cs
+    double precision, dimension(:), allocatable :: raxis_cs, zaxis_cc
 !
     double precision, dimension(:,:,:,:,:,:), allocatable :: sR,sZ,slam
 

--- a/src/efit_to_boozer/f2py_interfaces/f2py_efit_to_boozer.f90
+++ b/src/efit_to_boozer/f2py_interfaces/f2py_efit_to_boozer.f90
@@ -3,7 +3,6 @@ module efit_to_boozer
    use efit_to_boozer_mod, only: psimax, nlabel, ntheta, nspl, twopi, rbeg, &
                                  rsmall, qsaf, psi_pol, psi_tor_vac, psi_tor, C_const, R_spl, Z_spl, &
                                  bmod_spl, sqgnorm_spl, Gfunc_spl, rmn, rmx, zmn, zmx, raxis, zaxis
-   use input_files, only: gfile
    use field_mod, only: icall
    use field_c_mod, only: icall_c
    use field_eq_mod, only: reset_field_eq_state

--- a/src/new_vmec_allocation_stuff.f90
+++ b/src/new_vmec_allocation_stuff.f90
@@ -9,6 +9,7 @@ contains
 !
   integer :: ncid, status
   integer, dimension(2) :: lens
+  integer :: len_axis
   character(len=1000) :: filename
 !
   filename = netcdffile
@@ -22,6 +23,7 @@ contains
   end if
 !
   call nc_inq_dim(ncid, 'lmns', lens)
+  call nc_inq_dim(ncid, 'raxis_cc', len_axis)
 !
   call nc_get(ncid, 'nfp', nper)
 !
@@ -30,6 +32,7 @@ contains
   nstrm=lens(1)
   nsurfm=lens(2)
   kpar=nsurfm-1
+  ntor_axis=len_axis-1
   rmajor=rmajor*vmec_RZ_scale
 !
   call nc_close(ncid)
@@ -38,6 +41,11 @@ contains
   allocate(aiota(0:kpar),sps(0:kpar),phi(0:kpar),s(0:kpar))
   allocate(rmnc(nstrm,0:kpar),zmnc(nstrm,0:kpar),almnc(nstrm,0:kpar))
   allocate(rmns(nstrm,0:kpar),zmns(nstrm,0:kpar),almns(nstrm,0:kpar))
+  ! Persistent axis arrays: free a stale copy (re-entry with a different wout)
+  ! before re-allocating; see new_deallocate_vmec_stuff for why they persist.
+  if (allocated(raxis_cc)) deallocate(raxis_cc,zaxis_cs,raxis_cs,zaxis_cc)
+  allocate(raxis_cc(0:ntor_axis),zaxis_cs(0:ntor_axis))
+  allocate(raxis_cs(0:ntor_axis),zaxis_cc(0:ntor_axis))
 !
   end subroutine new_allocate_vmec_stuff
 !
@@ -50,6 +58,10 @@ contains
   implicit none
 !
   deallocate(axm,axn,soa,aiota,sps,phi,s,rmnc,zmnc,almnc,rmns,zmns,almns)
+  ! raxis_cc/zaxis_cs intentionally persist: the Fourier harmonics are freed
+  ! here right after the splines are built, but the chartmap export needs the
+  ! exact axis later (splint_vmec_data runs off the splines, not the harmonics).
+  ! They are refreshed on the next wout load (guarded re-allocation above).
 !
   end subroutine new_deallocate_vmec_stuff
 end  module vmec_alloc_sub

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -178,8 +178,9 @@ contains
 
    subroutine perform_axis_healing(almnc_rho, rmnc_rho, zmnc_rho, almns_rho, rmns_rho, zmns_rho)
       use new_vmec_stuff_mod, only: rmnc, zmns, almns, rmns, zmnc, almnc, &
-                                    axm, nstrm, old_axis_healing_boundary, &
-                                    axis_healing_power_law
+                                    axm, axn, nstrm, old_axis_healing_boundary, &
+                                    axis_healing_power_law, axis_healing_polyfit, &
+                                    axis_healing_polyfit_degree
       use vector_potentail_mod, only: ns
 
       real(dp), dimension(:, :), allocatable, intent(out) :: almnc_rho, rmnc_rho, zmnc_rho
@@ -189,6 +190,22 @@ contains
       nrho = ns
       allocate (almnc_rho(nstrm, 0:nrho - 1), rmnc_rho(nstrm, 0:nrho - 1), zmnc_rho(nstrm, 0:nrho - 1))
       allocate (almns_rho(nstrm, 0:nrho - 1), rmns_rho(nstrm, 0:nrho - 1), zmns_rho(nstrm, 0:nrho - 1))
+
+      if (axis_healing_polyfit) then
+         i_anchor = axis_anchor_index(ns)
+         print *, 'VMEC axis healing: rho**m * polyfit(s) continuation below s = ', &
+            dble(i_anchor - 1)/dble(ns - 1), ' degree ', axis_healing_polyfit_degree
+         do i = 1, nstrm
+            m = nint(abs(axm(i)))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, rmnc(i, :), rmnc_rho(i, :))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, zmnc(i, :), zmnc_rho(i, :))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, almnc(i, :), almnc_rho(i, :))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, rmns(i, :), rmns_rho(i, :))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, zmns(i, :), zmns_rho(i, :))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, almns(i, :), almns_rho(i, :))
+         end do
+         return
+      end if
 
       if (axis_healing_power_law) then
          i_anchor = axis_anchor_index(ns)
@@ -1322,6 +1339,166 @@ contains
       deallocate (splcoe)
 
    end subroutine s_to_rho_healaxis
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   subroutine s_to_rho_polyfit(m, ns, nrho, i_anchor, ndeg, arr_in, arr_out)
+      !> Resamples one Fourier amplitude from the uniform s grid to the uniform
+      !> rho = sqrt(s) grid, enforcing analytic axis regularity without the noise
+      !> amplification of the pure power-law continuation. The rescaled amplitude
+      !> g(s) = c(s)/rho**|m| is even-analytic in rho, hence smooth in s. Surfaces
+      !> inside i_anchor are unreliable; g there is replaced by a least-squares
+      !> polynomial in s (a Zernike radial polynomial once rho**|m| is restored)
+      !> fitted to a window of reliable surfaces just outside i_anchor. g is then
+      !> splined over the full grid and rho**|m| restored: c(rho) = rho**|m|*P(s),
+      !> exact rho**|m| at the axis, smooth across the match, reproducing the
+      !> reliable surfaces.
+      use new_vmec_stuff_mod, only: ns_s
+
+      integer, intent(in) :: m, ns, nrho, i_anchor, ndeg
+      real(dp), dimension(ns), intent(in) :: arr_in
+      real(dp), dimension(nrho), intent(out) :: arr_out
+
+      integer, parameter :: m_clamp = 50
+      integer :: irho, is, k, mc, nwin, d, j
+      real(dp) :: hs, hrho, s, ds, rho, u, s_c, s_scale
+      real(dp), dimension(:), allocatable :: g, swin, gwin, coef
+      real(dp), dimension(:, :), allocatable :: splcoe
+
+      hs = 1.d0/dble(ns - 1)
+      hrho = 1.d0/dble(nrho - 1)
+      mc = min(m, m_clamp)
+
+      allocate (g(ns))
+      if (mc > 0) then
+         do is = i_anchor, ns
+            rho = sqrt(hs*dble(is - 1))
+            g(is) = arr_in(is)/rho**mc
+         end do
+      else
+         g(i_anchor:ns) = arr_in(i_anchor:ns)
+      end if
+
+      ! Least-squares polynomial in s through a window of reliable surfaces,
+      ! used to extrapolate g smoothly inward to the axis.
+      d = max(0, min(ndeg, ns - i_anchor))
+      nwin = min(ns - i_anchor + 1, 2*(d + 1) + 2)
+      allocate (swin(nwin), gwin(nwin), coef(0:d))
+      do j = 1, nwin
+         swin(j) = hs*dble(i_anchor - 1 + j - 1)
+         gwin(j) = g(i_anchor + j - 1)
+      end do
+      call polyfit_s(swin, gwin, nwin, d, coef, s_c, s_scale)
+      do is = 1, i_anchor - 1
+         s = hs*dble(is - 1)
+         u = (s - s_c)/s_scale
+         g(is) = coef(d)
+         do k = d - 1, 0, -1
+            g(is) = coef(k) + u*g(is)
+         end do
+      end do
+
+      allocate (splcoe(0:ns_s, ns))
+      splcoe(0, :) = g
+      call spl_reg(ns_s, ns, hs, splcoe)
+      do irho = 1, nrho
+         rho = hrho*dble(irho - 1)
+         s = rho**2
+         ds = s/hs
+         is = max(0, min(ns - 1, int(ds)))
+         ds = (ds - dble(is))*hs
+         is = is + 1
+         arr_out(irho) = splcoe(ns_s, is)
+         do k = ns_s - 1, 0, -1
+            arr_out(irho) = splcoe(k, is) + ds*arr_out(irho)
+         end do
+         if (mc > 0) arr_out(irho) = arr_out(irho)*rho**mc
+      end do
+
+      deallocate (g, swin, gwin, coef, splcoe)
+   end subroutine s_to_rho_polyfit
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   subroutine polyfit_s(s, g, n, d, coef, s_c, s_scale)
+      !> Least-squares fit g(j) ~ sum_k coef(k)*u**k with u=(s-s_c)/s_scale,
+      !> degree d, via the normal equations. Centering and scaling keep the
+      !> Vandermonde well conditioned for the small near-axis s window.
+      integer, intent(in) :: n, d
+      real(dp), intent(in) :: s(n), g(n)
+      real(dp), intent(out) :: coef(0:d), s_c, s_scale
+
+      integer :: i, k, l
+      real(dp) :: u
+      real(dp), allocatable :: mat(:, :), rhs(:), upow(:)
+
+      s_c = sum(s)/dble(n)
+      s_scale = 0.5d0*(maxval(s) - minval(s))
+      if (s_scale <= 0.d0) s_scale = 1.d0
+
+      allocate (mat(0:d, 0:d), rhs(0:d), upow(0:2*d))
+      mat = 0.d0
+      rhs = 0.d0
+      do i = 1, n
+         u = (s(i) - s_c)/s_scale
+         upow(0) = 1.d0
+         do k = 1, 2*d
+            upow(k) = upow(k - 1)*u
+         end do
+         do k = 0, d
+            do l = 0, d
+               mat(k, l) = mat(k, l) + upow(k + l)
+            end do
+            rhs(k) = rhs(k) + upow(k)*g(i)
+         end do
+      end do
+      call solve_small(mat, rhs, coef, d + 1)
+      deallocate (mat, rhs, upow)
+   end subroutine polyfit_s
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   subroutine solve_small(a, b, x, n)
+      !> Dense solve a x = b (n small) by Gaussian elimination with partial
+      !> pivoting. a and b are consumed.
+      integer, intent(in) :: n
+      real(dp), intent(inout) :: a(n, n), b(n)
+      real(dp), intent(out) :: x(n)
+
+      integer :: i, j, k, ip
+      real(dp) :: piv, factor, tmp
+
+      do k = 1, n - 1
+         ip = k
+         piv = abs(a(k, k))
+         do i = k + 1, n
+            if (abs(a(i, k)) > piv) then
+               piv = abs(a(i, k))
+               ip = i
+            end if
+         end do
+         if (ip /= k) then
+            do j = k, n
+               tmp = a(k, j); a(k, j) = a(ip, j); a(ip, j) = tmp
+            end do
+            tmp = b(k); b(k) = b(ip); b(ip) = tmp
+         end if
+         do i = k + 1, n
+            factor = a(i, k)/a(k, k)
+            do j = k, n
+               a(i, j) = a(i, j) - factor*a(k, j)
+            end do
+            b(i) = b(i) - factor*b(k)
+         end do
+      end do
+      do i = n, 1, -1
+         x(i) = b(i)
+         do j = i + 1, n
+            x(i) = x(i) - a(i, j)*x(j)
+         end do
+         x(i) = x(i)/a(i, i)
+      end do
+   end subroutine solve_small
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -178,12 +178,14 @@ contains
 
    subroutine perform_axis_healing(almnc_rho, rmnc_rho, zmnc_rho, almns_rho, rmns_rho, zmns_rho)
       use new_vmec_stuff_mod, only: rmnc, zmns, almns, rmns, zmnc, almnc, &
-                                    axm, nstrm, axis_healing_polyfit_degree
+                                    axm, axn, nstrm, nper, axis_healing_polyfit_degree, &
+                                    raxis_cc, zaxis_cs, raxis_cs, zaxis_cc, ntor_axis
       use vector_potentail_mod, only: ns
 
       real(dp), dimension(:, :), allocatable, intent(out) :: almnc_rho, rmnc_rho, zmnc_rho
       real(dp), dimension(:, :), allocatable, intent(out) :: almns_rho, rmns_rho, zmns_rho
-      integer :: i, m, nrho, nheal, i_anchor
+      integer :: i, m, nrho, nheal, i_anchor, n_idx
+      real(dp) :: anc_rc, anc_zs, anc_rs, anc_zc
       character(len=16) :: mode, boundary
 
       nrho = ns
@@ -199,11 +201,21 @@ contains
             dble(i_anchor - 1)/dble(ns - 1), ' degree ', axis_healing_polyfit_degree
          do i = 1, nstrm
             m = nint(abs(axm(i)))
-            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, rmnc(i, :), rmnc_rho(i, :))
-            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, zmnc(i, :), zmnc_rho(i, :))
+            ! Pin the m=0 geometry amplitudes to the exact magnetic axis
+            ! (raxis_cc/zaxis_cs); lambda has no axis value, m/=0 ignores it.
+            anc_rc = 0.0d0; anc_zs = 0.0d0; anc_rs = 0.0d0; anc_zc = 0.0d0
+            if (m == 0 .and. allocated(raxis_cc)) then
+               n_idx = nint(axn(i))/nper
+               if (n_idx >= 0 .and. n_idx <= ntor_axis) then
+                  anc_rc = raxis_cc(n_idx); anc_zs = zaxis_cs(n_idx)
+                  anc_rs = raxis_cs(n_idx); anc_zc = zaxis_cc(n_idx)
+               end if
+            end if
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, rmnc(i, :), rmnc_rho(i, :), anchor=anc_rc)
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, zmnc(i, :), zmnc_rho(i, :), anchor=anc_zc)
             call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, almnc(i, :), almnc_rho(i, :))
-            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, rmns(i, :), rmns_rho(i, :))
-            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, zmns(i, :), zmns_rho(i, :))
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, rmns(i, :), rmns_rho(i, :), anchor=anc_rs)
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, zmns(i, :), zmns_rho(i, :), anchor=anc_zs)
             call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, almns(i, :), almns_rho(i, :))
          end do
 
@@ -1405,7 +1417,7 @@ contains
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-   subroutine s_to_rho_polyfit(m, ns, nrho, i_anchor, ndeg, arr_in, arr_out)
+   subroutine s_to_rho_polyfit(m, ns, nrho, i_anchor, ndeg, arr_in, arr_out, anchor)
       !> Resamples one Fourier amplitude from the uniform s grid to the uniform
       !> rho = sqrt(s) grid, enforcing analytic axis regularity without the noise
       !> amplification of the pure power-law continuation. The rescaled amplitude
@@ -1421,10 +1433,14 @@ contains
       integer, intent(in) :: m, ns, nrho, i_anchor, ndeg
       real(dp), dimension(ns), intent(in) :: arr_in
       real(dp), dimension(nrho), intent(out) :: arr_out
+      !> anchor: exact s=0 value of the m=0 amplitude (the magnetic axis,
+      !> raxis_cc/zaxis_cs). When present and m=0, the inward extrapolation is
+      !> pinned to it so the healed interior meets the exact axis with no kink.
+      real(dp), intent(in), optional :: anchor
 
       integer, parameter :: m_clamp = 50
       integer :: irho, is, k, mc, nwin, d, j
-      real(dp) :: hs, hrho, s, ds, rho, u, s_c, s_scale
+      real(dp) :: hs, hrho, s, ds, rho, u, s_c, s_scale, s_anchor, delta
       real(dp), dimension(:), allocatable :: g, swin, gwin, coef
       real(dp), dimension(:, :), allocatable :: splcoe
 
@@ -1460,6 +1476,18 @@ contains
             g(is) = coef(k) + u*g(is)
          end do
       end do
+
+      ! Pin the m=0 axis amplitude to the exact magnetic axis value, blended
+      ! smoothly (vanishes at the reliable-window edge i_anchor) so the healed
+      ! interior reaches the exact axis at s=0 with no kink.
+      if (mc == 0 .and. present(anchor) .and. i_anchor > 1) then
+         s_anchor = hs*dble(i_anchor - 1)
+         delta = anchor - g(1)
+         do is = 1, i_anchor - 1
+            s = hs*dble(is - 1)
+            g(is) = g(is) + delta*(1.0_dp - s/s_anchor)**2
+         end do
+      end if
 
       allocate (splcoe(0:ns_s, ns))
       splcoe(0, :) = g

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -178,12 +178,12 @@ contains
 
    subroutine perform_axis_healing(almnc_rho, rmnc_rho, zmnc_rho, almns_rho, rmns_rho, zmns_rho)
       use new_vmec_stuff_mod, only: rmnc, zmns, almns, rmns, zmnc, almnc, &
-                                    axm, axn, nstrm, axis_healing_polyfit_degree
+                                    axm, nstrm, axis_healing_polyfit_degree
       use vector_potentail_mod, only: ns
 
       real(dp), dimension(:, :), allocatable, intent(out) :: almnc_rho, rmnc_rho, zmnc_rho
       real(dp), dimension(:, :), allocatable, intent(out) :: almns_rho, rmns_rho, zmns_rho
-      integer :: i, m, nrho, nheal, iunit_hs, i_anchor
+      integer :: i, m, nrho, nheal, i_anchor
       character(len=16) :: mode, boundary
 
       nrho = ns
@@ -222,15 +222,12 @@ contains
          end do
 
       case ('legacy', 'legacy_adaptive')
-         iunit_hs = 1357
-         open (iunit_hs, file='healaxis.dat')
          do i = 1, nstrm
             m = nint(abs(axm(i)))
             if (trim(mode) == 'legacy') then
                nheal = min(m, 4)
             else
                call determine_nheal_for_axis(m, ns, rmnc(i, :), nheal)
-               write (iunit_hs, *) 'm = ', m, ' n = ', nint(abs(axn(i))), ' skipped ', nheal, ' / ', ns
             end if
             call s_to_rho_healaxis(m, ns, nrho, nheal, rmnc(i, :), rmnc_rho(i, :))
             call s_to_rho_healaxis(m, ns, nrho, nheal, zmnc(i, :), zmnc_rho(i, :))
@@ -239,7 +236,6 @@ contains
             call s_to_rho_healaxis(m, ns, nrho, nheal, zmns(i, :), zmns_rho(i, :))
             call s_to_rho_healaxis(m, ns, nrho, nheal, almns(i, :), almns_rho(i, :))
          end do
-         close (iunit_hs)
       end select
    end subroutine perform_axis_healing
 

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -178,22 +178,24 @@ contains
 
    subroutine perform_axis_healing(almnc_rho, rmnc_rho, zmnc_rho, almns_rho, rmns_rho, zmns_rho)
       use new_vmec_stuff_mod, only: rmnc, zmns, almns, rmns, zmnc, almnc, &
-                                    axm, axn, nstrm, old_axis_healing_boundary, &
-                                    axis_healing_power_law, axis_healing_polyfit, &
-                                    axis_healing_polyfit_degree
+                                    axm, axn, nstrm, axis_healing_polyfit_degree
       use vector_potentail_mod, only: ns
 
       real(dp), dimension(:, :), allocatable, intent(out) :: almnc_rho, rmnc_rho, zmnc_rho
       real(dp), dimension(:, :), allocatable, intent(out) :: almns_rho, rmns_rho, zmns_rho
-      integer :: i, m, nrho, nheal, i_anchor
+      integer :: i, m, nrho, nheal, iunit_hs, i_anchor
+      character(len=16) :: mode, boundary
 
       nrho = ns
       allocate (almnc_rho(nstrm, 0:nrho - 1), rmnc_rho(nstrm, 0:nrho - 1), zmnc_rho(nstrm, 0:nrho - 1))
       allocate (almns_rho(nstrm, 0:nrho - 1), rmns_rho(nstrm, 0:nrho - 1), zmns_rho(nstrm, 0:nrho - 1))
 
-      if (axis_healing_polyfit) then
+      call resolve_axis_healing_mode(mode, boundary)
+
+      select case (trim(mode))
+      case ('polyfit')
          i_anchor = axis_anchor_index(ns)
-         print *, 'VMEC axis healing: rho**m * polyfit(s) continuation below s = ', &
+         print *, 'VMEC axis healing: polyfit, rho**m * poly(s) below s = ', &
             dble(i_anchor - 1)/dble(ns - 1), ' degree ', axis_healing_polyfit_degree
          do i = 1, nstrm
             m = nint(abs(axm(i)))
@@ -204,12 +206,10 @@ contains
             call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, zmns(i, :), zmns_rho(i, :))
             call s_to_rho_polyfit(m, ns, nrho, i_anchor, axis_healing_polyfit_degree, almns(i, :), almns_rho(i, :))
          end do
-         return
-      end if
 
-      if (axis_healing_power_law) then
+      case ('powerlaw')
          i_anchor = axis_anchor_index(ns)
-         print *, 'VMEC axis healing: rho**m continuation below s = ', &
+         print *, 'VMEC axis healing: powerlaw, rho**m below s = ', &
             dble(i_anchor - 1)/dble(ns - 1)
          do i = 1, nstrm
             m = nint(abs(axm(i)))
@@ -220,26 +220,105 @@ contains
             call s_to_rho_power_law(m, ns, nrho, i_anchor, zmns(i, :), zmns_rho(i, :))
             call s_to_rho_power_law(m, ns, nrho, i_anchor, almns(i, :), almns_rho(i, :))
          end do
-         return
+
+      case ('legacy')
+         iunit_hs = 1357
+         open (iunit_hs, file='healaxis.dat')
+         do i = 1, nstrm
+            m = nint(abs(axm(i)))
+            if (trim(boundary) == 'fixed') then
+               nheal = min(m, 4)
+            else
+               call determine_nheal_for_axis(m, ns, rmnc(i, :), nheal)
+               write (iunit_hs, *) 'm = ', m, ' n = ', nint(abs(axn(i))), ' skipped ', nheal, ' / ', ns
+            end if
+            call s_to_rho_healaxis(m, ns, nrho, nheal, rmnc(i, :), rmnc_rho(i, :))
+            call s_to_rho_healaxis(m, ns, nrho, nheal, zmnc(i, :), zmnc_rho(i, :))
+            call s_to_rho_healaxis(m, ns, nrho, nheal, almnc(i, :), almnc_rho(i, :))
+            call s_to_rho_healaxis(m, ns, nrho, nheal, rmns(i, :), rmns_rho(i, :))
+            call s_to_rho_healaxis(m, ns, nrho, nheal, zmns(i, :), zmns_rho(i, :))
+            call s_to_rho_healaxis(m, ns, nrho, nheal, almns(i, :), almns_rho(i, :))
+         end do
+         close (iunit_hs)
+      end select
+   end subroutine perform_axis_healing
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   subroutine resolve_axis_healing_mode(mode, boundary)
+      !> Resolves the axis-healing selector. The preferred inputs are the strings
+      !> axis_healing ('legacy'|'powerlaw'|'polyfit') and axis_healing_boundary
+      !> ('fixed'|'adaptive'). When axis_healing is empty the deprecated logical
+      !> switches are mapped to a mode and a one-time deprecation warning is
+      !> emitted, together with a notice that a future release will default to
+      !> 'polyfit'. Unknown values stop the run.
+      use new_vmec_stuff_mod, only: axis_healing, axis_healing_boundary, &
+                                    old_axis_healing_boundary, &
+                                    axis_healing_power_law, axis_healing_polyfit
+
+      character(len=*), intent(out) :: mode, boundary
+      logical :: from_legacy
+
+      from_legacy = (len_trim(axis_healing) == 0)
+      if (from_legacy) then
+         if (axis_healing_polyfit) then
+            mode = 'polyfit'
+         else if (axis_healing_power_law) then
+            mode = 'powerlaw'
+         else
+            mode = 'legacy'
+         end if
+      else
+         mode = to_lower(adjustl(axis_healing))
       end if
 
-      do i = 1, nstrm
-         m = nint(abs(axm(i)))
-
+      if (len_trim(axis_healing_boundary) == 0) then
          if (old_axis_healing_boundary) then
-            nheal = min(m, 4)
+            boundary = 'fixed'
          else
-            call determine_nheal_for_axis(m, ns, rmnc(i, :), nheal)
+            boundary = 'adaptive'
          end if
+      else
+         boundary = to_lower(adjustl(axis_healing_boundary))
+      end if
 
-         call s_to_rho_healaxis(m, ns, nrho, nheal, rmnc(i, :), rmnc_rho(i, :))
-         call s_to_rho_healaxis(m, ns, nrho, nheal, zmnc(i, :), zmnc_rho(i, :))
-         call s_to_rho_healaxis(m, ns, nrho, nheal, almnc(i, :), almnc_rho(i, :))
-         call s_to_rho_healaxis(m, ns, nrho, nheal, rmns(i, :), rmns_rho(i, :))
-         call s_to_rho_healaxis(m, ns, nrho, nheal, zmns(i, :), zmns_rho(i, :))
-         call s_to_rho_healaxis(m, ns, nrho, nheal, almns(i, :), almns_rho(i, :))
+      select case (trim(mode))
+      case ('legacy', 'powerlaw', 'polyfit')
+      case default
+         print *, 'ERROR: unknown axis_healing = ''', trim(axis_healing), ''''
+         error stop 'unknown axis_healing mode (use legacy|powerlaw|polyfit)'
+      end select
+      select case (trim(boundary))
+      case ('fixed', 'adaptive')
+      case default
+         print *, 'ERROR: unknown axis_healing_boundary = ''', trim(axis_healing_boundary), ''''
+         error stop 'unknown axis_healing_boundary (use fixed|adaptive)'
+      end select
+
+      if (from_legacy) then
+         print *, 'WARNING: axis_healing not set; mapped legacy switches to axis_healing=''', &
+            trim(mode), '''. The old_axis_healing*/axis_healing_power_law/axis_healing_polyfit'
+         print *, '         switches are deprecated; set axis_healing (and axis_healing_boundary)'
+         print *, '         explicitly. A future SIMPLE release will default axis_healing to ''polyfit''.'
+      end if
+      if (trim(mode) /= 'polyfit') then
+         print *, 'NOTE: axis_healing=''', trim(mode), '''; ''polyfit'' is recommended and will', &
+            ' become the default. Please test it.'
+      end if
+   end subroutine resolve_axis_healing_mode
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+   pure function to_lower(s) result(t)
+      character(len=*), intent(in) :: s
+      character(len=len(s)) :: t
+      integer :: i, c
+      t = s
+      do i = 1, len_trim(s)
+         c = iachar(s(i:i))
+         if (c >= iachar('A') .and. c <= iachar('Z')) t(i:i) = achar(c + 32)
       end do
-   end subroutine perform_axis_healing
+   end function to_lower
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -221,12 +221,12 @@ contains
             call s_to_rho_power_law(m, ns, nrho, i_anchor, almns(i, :), almns_rho(i, :))
          end do
 
-      case ('legacy')
+      case ('legacy', 'legacy_adaptive')
          iunit_hs = 1357
          open (iunit_hs, file='healaxis.dat')
          do i = 1, nstrm
             m = nint(abs(axm(i)))
-            if (trim(boundary) == 'fixed') then
+            if (trim(mode) == 'legacy') then
                nheal = min(m, 4)
             else
                call determine_nheal_for_axis(m, ns, rmnc(i, :), nheal)
@@ -247,13 +247,10 @@ contains
 
    subroutine resolve_axis_healing_mode(mode, boundary)
       !> Resolves the axis-healing selector. The preferred inputs are the strings
-      !> axis_healing ('legacy'|'powerlaw'|'polyfit') and axis_healing_boundary
-      !> ('fixed'|'adaptive'). When axis_healing is empty the deprecated logical
-      !> switches are mapped to a mode and a one-time deprecation warning is
-      !> emitted, together with a notice that a future release will default to
-      !> 'polyfit'. Unknown values stop the run.
-      use new_vmec_stuff_mod, only: axis_healing, axis_healing_boundary, &
-                                    old_axis_healing_boundary, &
+      !> axis_healing ('legacy'|'legacy_adaptive'|'powerlaw'|'polyfit').
+      !> When axis_healing is empty the deprecated logical switches are mapped to
+      !> a mode and a deprecation warning is emitted. Unknown values stop the run.
+      use new_vmec_stuff_mod, only: axis_healing, old_axis_healing_boundary, &
                                     axis_healing_power_law, axis_healing_polyfit
 
       character(len=*), intent(out) :: mode, boundary
@@ -265,45 +262,36 @@ contains
             mode = 'polyfit'
          else if (axis_healing_power_law) then
             mode = 'powerlaw'
-         else
+         else if (old_axis_healing_boundary) then
             mode = 'legacy'
+         else
+            mode = 'legacy_adaptive'
          end if
       else
          mode = to_lower(adjustl(axis_healing))
       end if
 
-      if (len_trim(axis_healing_boundary) == 0) then
-         if (old_axis_healing_boundary) then
-            boundary = 'fixed'
-         else
-            boundary = 'adaptive'
-         end if
-      else
-         boundary = to_lower(adjustl(axis_healing_boundary))
-      end if
-
       select case (trim(mode))
-      case ('legacy', 'powerlaw', 'polyfit')
+      case ('legacy')
+         boundary = 'fixed'
+      case ('legacy_adaptive')
+         boundary = 'adaptive'
+      case ('powerlaw', 'polyfit')
+         boundary = ''
       case default
          print *, 'ERROR: unknown axis_healing = ''', trim(axis_healing), ''''
-         error stop 'unknown axis_healing mode (use legacy|powerlaw|polyfit)'
-      end select
-      select case (trim(boundary))
-      case ('fixed', 'adaptive')
-      case default
-         print *, 'ERROR: unknown axis_healing_boundary = ''', trim(axis_healing_boundary), ''''
-         error stop 'unknown axis_healing_boundary (use fixed|adaptive)'
+         error stop 'unknown axis_healing mode (use legacy|legacy_adaptive|powerlaw|polyfit)'
       end select
 
       if (from_legacy) then
          print *, 'WARNING: axis_healing not set; mapped legacy switches to axis_healing=''', &
             trim(mode), '''. The old_axis_healing*/axis_healing_power_law/axis_healing_polyfit'
-         print *, '         switches are deprecated; set axis_healing (and axis_healing_boundary)'
-         print *, '         explicitly. A future SIMPLE release will default axis_healing to ''polyfit''.'
+         print *, '         switches are deprecated; set axis_healing=''', trim(mode), ''' instead.'
+         print *, '         These switches will become errors in the next SIMPLE release.'
       end if
       if (trim(mode) /= 'polyfit') then
-         print *, 'NOTE: axis_healing=''', trim(mode), '''; ''polyfit'' is recommended and will', &
-            ' become the default. Please test it.'
+         print *, 'NOTE: axis_healing=''', trim(mode), '''; ''polyfit'' is recommended and will'
+         print *, '      become the default. Please test it.'
       end if
    end subroutine resolve_axis_healing_mode
 
@@ -1583,16 +1571,28 @@ contains
 
    function axis_anchor_index(ns) result(i_anchor)
       !> Innermost reliable full-grid surface: the first surface at or
-      !> outside rho_axis_heal. VMEC full-grid harmonics inside this
-      !> radius violate the rho**|m| analyticity condition (the radial
-      !> startup layer), so they are discarded and replaced by the
-      !> power-law continuation.
-      use new_vmec_stuff_mod, only: rho_axis_heal, ns_s
+      !> outside s_axis_heal. VMEC full-grid harmonics inside this
+      !> startup layer can violate the rho**|m| analyticity condition, so
+      !> they are discarded and replaced by the selected continuation.
+      use new_vmec_stuff_mod, only: s_axis_heal, rho_axis_heal, ns_s, &
+                                    rho_axis_heal_warning_printed
 
       integer, intent(in) :: ns
       integer :: i_anchor
+      real(dp) :: s_heal
 
-      i_anchor = 1 + nint(rho_axis_heal**2*dble(ns - 1))
+      if (rho_axis_heal > 0.0d0) then
+         s_heal = rho_axis_heal**2
+         if (.not. rho_axis_heal_warning_printed) then
+            print *, 'WARNING: rho_axis_heal is deprecated; use s_axis_heal = ', s_heal
+            print *, '         This setting will become an error in the next SIMPLE release.'
+            rho_axis_heal_warning_printed = .True.
+         end if
+      else
+         s_heal = s_axis_heal
+      end if
+
+      i_anchor = 1 + nint(s_heal*dble(ns - 1))
       i_anchor = max(2, min(i_anchor, ns - ns_s - 1))
    end function axis_anchor_index
 

--- a/src/vmecinm_m.f90
+++ b/src/vmecinm_m.f90
@@ -38,7 +38,8 @@ contains
 
         use libneo_kinds, only: dp
         !use math_constants, only: PI
-        use new_vmec_stuff_mod, only: netcdffile, vmec_B_scale, vmec_RZ_scale, rmajor
+        use new_vmec_stuff_mod, only: netcdffile, vmec_B_scale, vmec_RZ_scale, rmajor, &
+                                      raxis_cc, zaxis_cs, raxis_cs, zaxis_cc
         use nctools_module, only: nc_open, nc_close, nc_get
 
         real(dp), parameter :: fac_b0 = 1d4, fac_r0 = 1d2, EPS = 1d-10, pi=3.14159265358979d0
@@ -91,14 +92,28 @@ contains
         call nc_get(ncid, 'rmnc', rmnc)
         call nc_get(ncid, 'zmns', zmns)
         call nc_get(ncid, 'lmns', lmns)
+        ! Exact magnetic axis harmonics (n=0..ntor), independent of the flux
+        ! surfaces. Used for the analytic near-axis chartmap limit at s=0.
+        if (allocated(raxis_cc)) then
+            call nc_get(ncid, 'raxis_cc', raxis_cc)
+            call nc_get(ncid, 'zaxis_cs', zaxis_cs)
+        end if
         if (lasym) then
             call nc_get(ncid, 'rmns', rmns)
             call nc_get(ncid, 'zmnc', zmnc)
             call nc_get(ncid, 'lmnc', lmnc)
+            if (allocated(raxis_cs)) then
+                call nc_get(ncid, 'raxis_cs', raxis_cs)
+                call nc_get(ncid, 'zaxis_cc', zaxis_cc)
+            end if
         else
             rmns = 0d0
             zmnc = 0d0
             lmnc = 0d0
+            if (allocated(raxis_cs)) then
+                raxis_cs = 0d0
+                zaxis_cc = 0d0
+            end if
         end if
         ! Convert half-mesh to full mesh for lambda
         ! added by Christopher Albert, 2020-02-11
@@ -120,6 +135,12 @@ contains
         zmnc = zmnc*fac_r
         rmns = rmns*fac_r
         zmns = zmns*fac_r
+        if (allocated(raxis_cc)) then
+            raxis_cc = raxis_cc*fac_r
+            zaxis_cs = zaxis_cs*fac_r
+            raxis_cs = raxis_cs*fac_r
+            zaxis_cc = zaxis_cc*fac_r
+        end if
 
         call nc_close(ncid)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,13 @@ target_link_libraries(test_axis_power_law_regularization.x
   neo
 )
 
+add_executable(test_axis_polyfit_regularization.x
+  source/test_axis_polyfit_regularization.f90
+)
+target_link_libraries(test_axis_polyfit_regularization.x
+  neo
+)
+
 add_executable(test_flux_pseudocartesian.x
   source/test_flux_pseudocartesian.f90
 )
@@ -223,6 +230,8 @@ target_link_libraries(test_nctools_nc_get3.x
 add_test(NAME test_binsrc COMMAND test_binsrc.x)
 add_test(NAME test_axis_power_law_regularization
   COMMAND test_axis_power_law_regularization.x)
+add_test(NAME test_axis_polyfit_regularization
+  COMMAND test_axis_polyfit_regularization.x)
 add_test(NAME test_flux_pseudocartesian
   COMMAND test_flux_pseudocartesian.x)
 add_test(NAME test_christoffel_symflux

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,6 +103,13 @@ target_link_libraries(test_coordinate_christoffel.x
   neo
 )
 
+add_executable(test_axis_healing_mode.x
+  source/test_axis_healing_mode.f90
+)
+target_link_libraries(test_axis_healing_mode.x
+  neo
+)
+
 add_executable(test_geqdsk_tools.x source/test_geqdsk_tools.f90)
 target_link_libraries(test_geqdsk_tools.x
   ${MAIN_LIB}
@@ -238,6 +245,8 @@ add_test(NAME test_christoffel_symflux
   COMMAND test_christoffel_symflux.x)
 add_test(NAME test_coordinate_christoffel
   COMMAND test_coordinate_christoffel.x)
+add_test(NAME test_axis_healing_mode
+  COMMAND test_axis_healing_mode.x)
 add_test(NAME test_boozer_coordinates_exports
   COMMAND test_boozer_coordinates_exports.x
 )

--- a/test/source/test_axis_healing_mode.f90
+++ b/test/source/test_axis_healing_mode.f90
@@ -1,0 +1,68 @@
+program test_axis_healing_mode
+    !> resolve_axis_healing_mode maps the axis_healing / axis_healing_boundary
+    !> selectors and the deprecated boolean switches to a (mode, boundary) pair.
+    !> Explicit selectors win and are case-insensitive; when axis_healing is empty
+    !> the legacy booleans are mapped for back-compat.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use new_vmec_stuff_mod, only: axis_healing, axis_healing_boundary, &
+                                  old_axis_healing, old_axis_healing_boundary, &
+                                  axis_healing_power_law, axis_healing_polyfit
+    use spline_vmec_sub, only: resolve_axis_healing_mode
+    implicit none
+
+    character(len=16) :: mode, boundary
+
+    ! Defaults (everything unset) reproduce the legacy/fixed behavior.
+    call reset()
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'legacy', boundary, 'fixed', 'defaults')
+
+    ! Deprecated booleans map to the right mode.
+    call reset(); axis_healing_power_law = .True.
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'powerlaw', boundary, 'fixed', 'legacy bool powerlaw')
+
+    call reset(); axis_healing_polyfit = .True.
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'polyfit', boundary, 'fixed', 'legacy bool polyfit')
+
+    call reset(); old_axis_healing_boundary = .False.
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'legacy', boundary, 'adaptive', 'legacy bool adaptive boundary')
+
+    ! Explicit selector overrides the booleans and is case-insensitive.
+    call reset(); axis_healing = 'polyfit'; axis_healing_power_law = .True.
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'polyfit', boundary, 'fixed', 'explicit overrides bool')
+
+    call reset(); axis_healing = 'POWERLAW'
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'powerlaw', boundary, 'fixed', 'case-insensitive')
+
+    call reset(); axis_healing = 'legacy'; axis_healing_boundary = 'Adaptive'
+    call resolve_axis_healing_mode(mode, boundary)
+    call expect(mode, 'legacy', boundary, 'adaptive', 'explicit boundary')
+
+    print *, 'axis healing mode resolution: all checks passed'
+
+contains
+
+    subroutine reset()
+        axis_healing = ''
+        axis_healing_boundary = ''
+        old_axis_healing = .True.
+        old_axis_healing_boundary = .True.
+        axis_healing_power_law = .False.
+        axis_healing_polyfit = .False.
+    end subroutine reset
+
+    subroutine expect(mode, mode_exp, boundary, boundary_exp, label)
+        character(len=*), intent(in) :: mode, mode_exp, boundary, boundary_exp, label
+        if (trim(mode) /= mode_exp .or. trim(boundary) /= boundary_exp) then
+            print *, 'FAIL [', label, ']: got mode=', trim(mode), ' boundary=', trim(boundary), &
+                ' expected mode=', mode_exp, ' boundary=', boundary_exp
+            error stop 1
+        end if
+    end subroutine expect
+
+end program test_axis_healing_mode

--- a/test/source/test_axis_healing_mode.f90
+++ b/test/source/test_axis_healing_mode.f90
@@ -1,11 +1,10 @@
 program test_axis_healing_mode
-    !> resolve_axis_healing_mode maps the axis_healing / axis_healing_boundary
-    !> selectors and the deprecated boolean switches to a (mode, boundary) pair.
+    !> resolve_axis_healing_mode maps the axis_healing selector and the
+    !> deprecated boolean switches to a (mode, boundary) pair.
     !> Explicit selectors win and are case-insensitive; when axis_healing is empty
     !> the legacy booleans are mapped for back-compat.
-    use, intrinsic :: iso_fortran_env, only: dp => real64
-    use new_vmec_stuff_mod, only: axis_healing, axis_healing_boundary, &
-                                  old_axis_healing, old_axis_healing_boundary, &
+    use new_vmec_stuff_mod, only: axis_healing, old_axis_healing, &
+                                  old_axis_healing_boundary, &
                                   axis_healing_power_law, axis_healing_polyfit
     use spline_vmec_sub, only: resolve_axis_healing_mode
     implicit none
@@ -20,28 +19,28 @@ program test_axis_healing_mode
     ! Deprecated booleans map to the right mode.
     call reset(); axis_healing_power_law = .True.
     call resolve_axis_healing_mode(mode, boundary)
-    call expect(mode, 'powerlaw', boundary, 'fixed', 'legacy bool powerlaw')
+    call expect(mode, 'powerlaw', boundary, '', 'legacy bool powerlaw')
 
     call reset(); axis_healing_polyfit = .True.
     call resolve_axis_healing_mode(mode, boundary)
-    call expect(mode, 'polyfit', boundary, 'fixed', 'legacy bool polyfit')
+    call expect(mode, 'polyfit', boundary, '', 'legacy bool polyfit')
 
     call reset(); old_axis_healing_boundary = .False.
     call resolve_axis_healing_mode(mode, boundary)
-    call expect(mode, 'legacy', boundary, 'adaptive', 'legacy bool adaptive boundary')
+    call expect(mode, 'legacy_adaptive', boundary, 'adaptive', 'legacy bool adaptive boundary')
 
     ! Explicit selector overrides the booleans and is case-insensitive.
     call reset(); axis_healing = 'polyfit'; axis_healing_power_law = .True.
     call resolve_axis_healing_mode(mode, boundary)
-    call expect(mode, 'polyfit', boundary, 'fixed', 'explicit overrides bool')
+    call expect(mode, 'polyfit', boundary, '', 'explicit overrides bool')
 
     call reset(); axis_healing = 'POWERLAW'
     call resolve_axis_healing_mode(mode, boundary)
-    call expect(mode, 'powerlaw', boundary, 'fixed', 'case-insensitive')
+    call expect(mode, 'powerlaw', boundary, '', 'case-insensitive')
 
-    call reset(); axis_healing = 'legacy'; axis_healing_boundary = 'Adaptive'
+    call reset(); axis_healing = 'legacy_adaptive'; axis_healing_power_law = .True.
     call resolve_axis_healing_mode(mode, boundary)
-    call expect(mode, 'legacy', boundary, 'adaptive', 'explicit boundary')
+    call expect(mode, 'legacy_adaptive', boundary, 'adaptive', 'explicit adaptive legacy')
 
     print *, 'axis healing mode resolution: all checks passed'
 
@@ -49,7 +48,6 @@ contains
 
     subroutine reset()
         axis_healing = ''
-        axis_healing_boundary = ''
         old_axis_healing = .True.
         old_axis_healing_boundary = .True.
         axis_healing_power_law = .False.

--- a/test/source/test_axis_polyfit_regularization.f90
+++ b/test/source/test_axis_polyfit_regularization.f90
@@ -20,6 +20,7 @@ program test_axis_polyfit_regularization
     call test_zernike_reproduction()
     call test_anchor_continuity()
     call test_no_noise_oscillation()
+    call test_axis_anchor_pinning()
 
     print *, 'axis polyfit regularization: all checks passed'
 
@@ -114,6 +115,38 @@ contains
             error stop 'polyfit continuation oscillates near the axis'
         end if
     end subroutine test_no_noise_oscillation
+
+    !> The m=0 axis pin: with an explicit anchor, s_to_rho_polyfit forces the
+    !> healed amplitude at rho=0 to equal the supplied axis value (raxis_cc /
+    !> zaxis_cs in production), regardless of what the bare polyfit extrapolates.
+    !> For m/=0 the anchor is ignored (the amplitude still vanishes at the axis).
+    subroutine test_axis_anchor_pinning()
+        integer :: i_anchor
+        real(dp) :: arr_in(ns), arr_out(nrho), arr_ref(nrho), anchor
+        i_anchor = axis_anchor_index(ns)
+
+        ! m=0: the bare polyfit yields some axis value; pin it to a different one.
+        call fill_zernike(0, arr_in)
+        call s_to_rho_polyfit(0, ns, nrho, i_anchor, ndeg, arr_in, arr_ref)
+        anchor = arr_ref(1) + 0.3_dp
+        call s_to_rho_polyfit(0, ns, nrho, i_anchor, ndeg, arr_in, arr_out, anchor=anchor)
+        if (abs(arr_out(1) - anchor) > 1.0e-12_dp) then
+            print *, 'arr_out(1) =', arr_out(1), ' anchor =', anchor
+            error stop 'm=0 anchor not pinned at rho=0'
+        end if
+        ! The pin must actually move the axis value, not silently no-op.
+        if (abs(arr_out(1) - arr_ref(1)) < 1.0e-3_dp) then
+            error stop 'anchor had no effect on the axis value'
+        end if
+
+        ! m/=0: the anchor must be ignored; the amplitude still vanishes at rho=0.
+        call fill_zernike(2, arr_in)
+        call s_to_rho_polyfit(2, ns, nrho, i_anchor, ndeg, arr_in, arr_out, anchor=anchor)
+        if (abs(arr_out(1)) > 1.0e-13_dp) then
+            print *, 'm=2 arr_out(1) with anchor =', arr_out(1)
+            error stop 'anchor wrongly applied to m/=0 harmonic'
+        end if
+    end subroutine test_axis_anchor_pinning
 
     subroutine fill_zernike(m, arr_in)
         integer, intent(in) :: m

--- a/test/source/test_axis_polyfit_regularization.f90
+++ b/test/source/test_axis_polyfit_regularization.f90
@@ -5,7 +5,7 @@ program test_axis_polyfit_regularization
     !> the continuation is continuous at the anchor, and unlike the pure power-law
     !> path it does not amplify noise into near-axis oscillations.
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use new_vmec_stuff_mod, only: ns_s, rho_axis_heal
+    use new_vmec_stuff_mod, only: ns_s, s_axis_heal, rho_axis_heal
     use spline_vmec_sub, only: s_to_rho_polyfit, axis_anchor_index
     implicit none
 
@@ -13,7 +13,8 @@ program test_axis_polyfit_regularization
     real(dp), parameter :: amp = 0.75_dp
 
     ns_s = 5
-    rho_axis_heal = 0.1_dp
+    s_axis_heal = 1.0e-2_dp
+    rho_axis_heal = -1.0_dp
 
     call test_axis_vanishing()
     call test_zernike_reproduction()

--- a/test/source/test_axis_polyfit_regularization.f90
+++ b/test/source/test_axis_polyfit_regularization.f90
@@ -1,0 +1,128 @@
+program test_axis_polyfit_regularization
+    !> rho**|m| * polyfit(s) near-axis continuation (s_to_rho_polyfit): a harmonic
+    !> with m>0 vanishes at the axis, an exact Zernike radial input c = rho**m *
+    !> P(s) is reproduced (the reduced amplitude is a low-degree polynomial in s),
+    !> the continuation is continuous at the anchor, and unlike the pure power-law
+    !> path it does not amplify noise into near-axis oscillations.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use new_vmec_stuff_mod, only: ns_s, rho_axis_heal
+    use spline_vmec_sub, only: s_to_rho_polyfit, axis_anchor_index
+    implicit none
+
+    integer, parameter :: ns = 100, nrho = 100, ndeg = 3
+    real(dp), parameter :: amp = 0.75_dp
+
+    ns_s = 5
+    rho_axis_heal = 0.1_dp
+
+    call test_axis_vanishing()
+    call test_zernike_reproduction()
+    call test_anchor_continuity()
+    call test_no_noise_oscillation()
+
+    print *, 'axis polyfit regularization: all checks passed'
+
+contains
+
+    subroutine test_axis_vanishing()
+        integer :: i_anchor
+        real(dp) :: arr_in(ns), arr_out(nrho)
+        i_anchor = axis_anchor_index(ns)
+        call fill_zernike(2, arr_in)
+        call s_to_rho_polyfit(2, ns, nrho, i_anchor, ndeg, arr_in, arr_out)
+        if (abs(arr_out(1)) > 1.0e-13_dp) then
+            print *, 'arr_out at rho=0 =', arr_out(1)
+            error stop 'm>0 harmonic does not vanish at the axis'
+        end if
+    end subroutine test_axis_vanishing
+
+    !> c(rho) = amp*rho**m*(1 + 0.5 s + 0.2 s**2) has reduced amplitude
+    !> c/rho**m = amp*(1 + 0.5 s + 0.2 s**2), a degree-2 polynomial in s, so a
+    !> degree-3 polyfit must reproduce it on the whole rho grid.
+    subroutine test_zernike_reproduction()
+        integer, parameter :: ms(3) = [1, 2, 4]
+        integer :: im, m, i_anchor, irho
+        real(dp) :: arr_in(ns), arr_out(nrho)
+        real(dp) :: rho, s, expected, max_err
+        i_anchor = axis_anchor_index(ns)
+        do im = 1, size(ms)
+            m = ms(im)
+            call fill_zernike(m, arr_in)
+            call s_to_rho_polyfit(m, ns, nrho, i_anchor, ndeg, arr_in, arr_out)
+            max_err = 0.0_dp
+            do irho = 1, nrho
+                rho = real(irho - 1, dp)/real(nrho - 1, dp)
+                s = rho*rho
+                expected = amp*rho**m*(1.0_dp + 0.5_dp*s + 0.2_dp*s*s)
+                max_err = max(max_err, abs(arr_out(irho) - expected))
+            end do
+            if (max_err > 1.0e-8_dp) then
+                print *, 'm =', m, ' max |arr_out - zernike| =', max_err
+                error stop 'Zernike radial polynomial not reproduced'
+            end if
+        end do
+    end subroutine test_zernike_reproduction
+
+    subroutine test_anchor_continuity()
+        integer :: i_anchor, irho, irho_below, irho_above
+        real(dp) :: arr_in(ns), arr_out(nrho), rho, rho_anchor, jump
+        i_anchor = axis_anchor_index(ns)
+        rho_anchor = sqrt(real(i_anchor - 1, dp)/real(ns - 1, dp))
+        call fill_zernike(2, arr_in)
+        call s_to_rho_polyfit(2, ns, nrho, i_anchor, ndeg, arr_in, arr_out)
+        irho_below = 0; irho_above = 0
+        do irho = 1, nrho
+            rho = real(irho - 1, dp)/real(nrho - 1, dp)
+            if (rho < rho_anchor) irho_below = irho
+            if (rho >= rho_anchor .and. irho_above == 0) irho_above = irho
+        end do
+        jump = abs(arr_out(irho_above) - arr_out(irho_below))
+        if (jump > 5.0e-3_dp) then
+            print *, 'jump across anchor =', jump
+            error stop 'discontinuity in polyfit continuation at the anchor'
+        end if
+    end subroutine test_anchor_continuity
+
+    !> Reduced-amplitude noise on the reliable surfaces must not blow up into
+    !> a near-axis oscillation: the least-squares fit smooths it. The second
+    !> difference of arr_out below the anchor stays comparable to the input
+    !> perturbation, not orders of magnitude larger (the power-law failure mode).
+    subroutine test_no_noise_oscillation()
+        integer :: i_anchor, irho, n_below
+        real(dp) :: arr_in(ns), arr_out(nrho)
+        real(dp) :: rho, rho_anchor, d2, max_d2
+        i_anchor = axis_anchor_index(ns)
+        rho_anchor = sqrt(real(i_anchor - 1, dp)/real(ns - 1, dp))
+        call fill_zernike(1, arr_in)
+        ! add a small deterministic perturbation to the reliable surfaces
+        do irho = i_anchor, ns
+            arr_in(irho) = arr_in(irho) + 1.0e-3_dp*amp*sin(7.0_dp*real(irho, dp))
+        end do
+        call s_to_rho_polyfit(1, ns, nrho, i_anchor, ndeg, arr_in, arr_out)
+        max_d2 = 0.0_dp
+        n_below = 0
+        do irho = 2, nrho - 1
+            rho = real(irho - 1, dp)/real(nrho - 1, dp)
+            if (rho >= rho_anchor) cycle
+            d2 = abs(arr_out(irho + 1) - 2.0_dp*arr_out(irho) + arr_out(irho - 1))
+            max_d2 = max(max_d2, d2)
+            n_below = n_below + 1
+        end do
+        if (n_below > 0 .and. max_d2 > 1.0e-2_dp) then
+            print *, 'max |second difference| below anchor =', max_d2
+            error stop 'polyfit continuation oscillates near the axis'
+        end if
+    end subroutine test_no_noise_oscillation
+
+    subroutine fill_zernike(m, arr_in)
+        integer, intent(in) :: m
+        real(dp), intent(out) :: arr_in(ns)
+        integer :: is
+        real(dp) :: s
+        do is = 1, ns
+            s = real(is - 1, dp)/real(ns - 1, dp)
+            arr_in(is) = amp*sqrt(s)**m*(1.0_dp + 0.5_dp*s + 0.2_dp*s*s)
+        end do
+    end subroutine fill_zernike
+
+end program test_axis_polyfit_regularization

--- a/test/source/test_axis_power_law_regularization.f90
+++ b/test/source/test_axis_power_law_regularization.f90
@@ -1,6 +1,6 @@
 program test_axis_power_law_regularization
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use new_vmec_stuff_mod, only: ns_s, rho_axis_heal
+    use new_vmec_stuff_mod, only: ns_s, s_axis_heal, rho_axis_heal
     use spline_vmec_sub, only: s_to_rho_power_law, axis_anchor_index
     implicit none
 
@@ -20,17 +20,24 @@ contains
 
     !> The innermost reliable surface index used by the rho**|m| continuation.
     subroutine test_anchor_index()
-        rho_axis_heal = 0.1_dp
+        s_axis_heal = 1.0e-2_dp
+        rho_axis_heal = -1.0_dp
         if (axis_anchor_index(ns) /= 2) then
-            print *, 'i_anchor(rho_heal=0.1) =', axis_anchor_index(ns), 'expected 2'
-            error stop 'axis_anchor_index mismatch for rho_axis_heal=0.1'
+            print *, 'i_anchor(s_axis_heal=0.01) =', axis_anchor_index(ns), 'expected 2'
+            error stop 'axis_anchor_index mismatch for s_axis_heal=0.01'
+        end if
+        s_axis_heal = 9.0e-2_dp
+        if (axis_anchor_index(ns) /= 10) then
+            print *, 'i_anchor(s_axis_heal=0.09) =', axis_anchor_index(ns), 'expected 10'
+            error stop 'axis_anchor_index mismatch for s_axis_heal=0.09'
         end if
         rho_axis_heal = 0.3_dp
         if (axis_anchor_index(ns) /= 10) then
-            print *, 'i_anchor(rho_heal=0.3) =', axis_anchor_index(ns), 'expected 10'
-            error stop 'axis_anchor_index mismatch for rho_axis_heal=0.3'
+            print *, 'i_anchor(rho_axis_heal=0.3) =', axis_anchor_index(ns), 'expected 10'
+            error stop 'deprecated rho_axis_heal conversion mismatch'
         end if
-        rho_axis_heal = 0.1_dp
+        s_axis_heal = 1.0e-2_dp
+        rho_axis_heal = -1.0_dp
     end subroutine test_anchor_index
 
     !> A harmonic with m>0 must vanish at the magnetic axis (rho=0).
@@ -38,7 +45,8 @@ contains
         integer :: i_anchor
         real(dp) :: arr_in(ns), arr_out(nrho)
 
-        rho_axis_heal = 0.1_dp
+        s_axis_heal = 1.0e-2_dp
+        rho_axis_heal = -1.0_dp
         i_anchor = axis_anchor_index(ns)
         call fill_power_law(2, arr_in)
         call s_to_rho_power_law(2, ns, nrho, i_anchor, arr_in, arr_out)
@@ -57,7 +65,8 @@ contains
         real(dp) :: arr_in(ns), arr_out(nrho)
         real(dp) :: rho, expected, err, max_err
 
-        rho_axis_heal = 0.1_dp
+        s_axis_heal = 1.0e-2_dp
+        rho_axis_heal = -1.0_dp
         i_anchor = axis_anchor_index(ns)
         do im = 1, size(ms)
             m = ms(im)
@@ -83,7 +92,8 @@ contains
         real(dp) :: arr_in(ns), arr_out(nrho)
         real(dp) :: rho, rho_anchor, jump
 
-        rho_axis_heal = 0.1_dp
+        s_axis_heal = 1.0e-2_dp
+        rho_axis_heal = -1.0_dp
         i_anchor = axis_anchor_index(ns)
         rho_anchor = sqrt(real(i_anchor - 1, dp)/real(ns - 1, dp))
         call fill_power_law(2, arr_in)


### PR DESCRIPTION
## Summary

Brings the Boozer chartmap down to the exact magnetic axis (s=0) and makes the
near-axis flux-surface representation consistent all the way to the axis.

**1. Near-axis healing infrastructure** (incorporates #320, fully contained here)
- `axis_healing` mode selector: `legacy` | `legacy_adaptive` | `powerlaw` | `polyfit`; deprecates the old boolean switches.
- `polyfit` healing: `rho**|m| * least-squares poly(s)` below `s_axis_heal`, a smooth Zernike-local continuation of the reliable surfaces.
- Pseudo-Cartesian near-axis chart and regularization tests.
- `near_axis_field_diag` app to compare healing variants on a radial cut.

**2. Exact analytic chartmap axis at s=0** (new)
- Export reaches `rho=0` (was `rho=sqrt(1e-6)`). At `s=0` the flux maps are singular: `boozer_to_vmec`'s poloidal Newton degenerates (theta_V undefined) and `splint_boozer_coord`'s s-derivatives carry `0.5/rho`. The axis slice is therefore the analytic m=0 limit: the exact VMEC axis curve `raxis_cc/zaxis_cs`, theta-independent, evaluated at the regular toroidal limit `phi_V(phi_B)` (theta-averaged to cancel the O(rho) poloidal term). Field profiles use the regular limit at `s_axis_eval`; `Bmod` at the axis is the theta-averaged m=0 value.
- The m=0 `polyfit` healing is anchored to the exact axis (`s_to_rho_polyfit` gains an optional `anchor`; `perform_axis_healing` passes `raxis_cc/zaxis_cs` per harmonic). Without it the polyfit discards the unreliable near-axis surfaces and extrapolates, missing the true axis; with it `splint_vmec_data(s=0)` equals the exact axis and the interior meets the axis slice with no kink.
- Reader: `raxis_cc/zaxis_cs` (and lasym partners) read into `new_vmec_stuff_mod`; the axis arrays persist past the post-spline harmonic deallocation, since the export needs them later.
- `doc/near_axis_chartmap_limit.wl` (+`.out`): Mathematica derivation of the limit; NAE references (Landreman & Sengupta 2018 arXiv:1809.10233 cylindrical NAE `r ~ sqrt(s)`; generalized Frenet G-frame arXiv:2410.17595, `x = X0(zeta) + q1 N + q2 B`).

## Verification

Built (gfortran, Release) and tested on the rebased branch:

```
ctest -R "boozer_chartmap_roundtrip|axis_polyfit|axis_healing|axis_power_law|chartmap_matches_vmec|boozer_coordinates_exports|flux_pseudocartesian"
100% tests passed, 0 tests failed out of 7
```

Real W7-X high-mirror reactor export (polyfit healing), built-in axis gate
`max|dR|+|dZ|` between the exact axis and the s=0 limit of `splint_vmec_data`:

```
exact axis vs healed interior, WITHOUT the m=0 anchor: 3.37e-2 cm
exact axis vs healed interior, WITH    the m=0 anchor: 1.41e-7 cm   (2.6e-10 of R)
```

Exported chartmap (ns=501 incl. rho=0, 55 x 300):
```
NaN in x/y/z/Bmod:                 none
theta-spread at rho=0 (x,y,z,Bmod): 0.0  (exact m=0 regularity)
axis vs rho->0 interior extrapolation: 4.2e-4 cm  (smooth match)
```

End-to-end: SIMPLE GC (orbit_model=0, isw_field_type=2) loads the new chartmap
(`ns=501`, sane `bmod00/bmin/bmax`) and traces without error.

## Note on #320

This branch contains #320's healing commits (rebased) plus the exact-axis work
that builds on and modifies the polyfit healing. They are one cohesive change, so
I bundled them here. Close #320 as superseded, or I can split this into a
healing PR and a stacked chartmap-axis PR if you prefer.
