### PR TITLE
boozer_sub: split chartmap file I/O into its own module

### DIFF
--- a/CMakeSources.in
+++ b/CMakeSources.in
@@ -30,11 +30,13 @@ add_library(neo STATIC
     src/coordinates/libneo_chartmap_vmec_generator.f90
     src/coordinates/libneo_coordinates_mapping.f90
     src/spline_vmec_data.f90
+    src/boozer_chartmap_types.f90
     src/field/boozer_chartmap_io.f90
     src/field/magnetic_field_base.f90
     src/field/field_vmec.f90
     src/field/vmec_field_eval.f90
     src/boozer_converter.F90
+    src/boozer_chartmap.f90
     src/vmecinm_m.f90
     src/vmec/vmec_field_tools.f90
     src/plag_coeff.f90

--- a/src/boozer_chartmap.f90
+++ b/src/boozer_chartmap.f90
@@ -1,0 +1,262 @@
+module boozer_chartmap
+    !> File I/O for extended Boozer chartmaps. Keeps the NetCDF read/write off
+    !> the boozer_sub converter: load parses a chartmap and hands the record to
+    !> boozer_sub's build_boozer_from_chartmap; export gathers via the public
+    !> splint entry points and writes the NetCDF.
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use boozer_sub, only: build_boozer_from_chartmap, splint_boozer_coord, &
+                          boozer_to_vmec
+    use boozer_chartmap_io, only: read_boozer_chartmap
+    use boozer_chartmap_types, only: boozer_chartmap_data_t
+
+    implicit none
+    private
+    public :: load_boozer_from_chartmap, export_boozer_chartmap
+
+contains
+
+    subroutine load_boozer_from_chartmap(filename)
+        !> Parse an extended chartmap NetCDF file and build the module-level
+        !> Boozer batch splines from it.
+        character(len=*), intent(in) :: filename
+
+        type(boozer_chartmap_data_t) :: d
+
+        call read_boozer_chartmap(filename, d)
+        call build_boozer_from_chartmap(d)
+        print *, 'Loaded Boozer splines from chartmap: ', trim(filename)
+    end subroutine load_boozer_from_chartmap
+
+    subroutine export_boozer_chartmap(filename)
+        !> Export Boozer coordinate data computed by get_boozer_coordinates()
+        !> to an extended chartmap NetCDF file. Must be called after
+        !> get_boozer_coordinates() and while VMEC splines are still active
+        !> (needed for X, Y, Z geometry evaluation).
+        use vector_potentail_mod, only: torflux
+        use new_vmec_stuff_mod, only: nper
+        use boozer_coordinates_mod, only: ns_B, n_theta_B, n_phi_B, &
+                                          h_theta_B, h_phi_B
+        use spline_vmec_sub, only: splint_vmec_data
+        use netcdf
+
+        character(len=*), intent(in) :: filename
+
+        integer :: ncid, status
+        integer :: dim_rho, dim_s, dim_theta, dim_zeta
+        integer :: var_rho, var_s, var_theta, var_zeta
+        integer :: var_x, var_y, var_z
+        integer :: var_aphi, var_btheta, var_bphi, var_bmod, var_nfp
+        integer :: i_rho, i_theta, i_phi
+        integer :: n_theta_out, n_phi_out
+        real(dp) :: rho_tor, s, theta_B, phi_B, theta_V, phi_V
+        real(dp) :: R, Zval, alam
+        real(dp) :: A_phi_dum, A_theta_dum, dA_phi_ds, dA_theta_ds, aiota
+        real(dp) :: d2A_phi_ds2, d3A_phi_ds3, B_theta_val, B_phi_val
+        real(dp) :: dB_theta, d2B_theta, dB_phi, d2B_phi, Bmod_val, B_r_val
+        real(dp) :: sqrt_g_ss_val
+        real(dp) :: dBmod(3), d2Bmod(6), dB_r(3), d2B_r(6)
+        real(dp) :: dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp
+        real(dp) :: dl_ds, dl_dt, dl_dp
+        real(dp), parameter :: rho_min = sqrt(1.0e-6_dp)
+        real(dp), allocatable :: rho_arr(:), s_arr(:), theta_arr(:), zeta_arr(:)
+        real(dp), allocatable :: A_phi_arr(:), B_theta_arr(:), B_phi_arr(:)
+        real(dp), allocatable :: x_arr(:, :, :), y_arr(:, :, :), z_arr(:, :, :)
+        real(dp), allocatable :: bmod_arr(:, :, :)
+
+        ! Chartmap files store endpoint-excluded angular grids. The reader
+        ! reconstructs endpoint planes before building periodic splines.
+        n_theta_out = n_theta_B - 1
+        n_phi_out = n_phi_B - 1
+
+        allocate (rho_arr(ns_B))
+        allocate (s_arr(ns_B))
+        allocate (theta_arr(n_theta_out), zeta_arr(n_phi_out))
+        allocate (A_phi_arr(ns_B), B_theta_arr(ns_B), B_phi_arr(ns_B))
+        allocate (x_arr(ns_B, n_theta_out, n_phi_out))
+        allocate (y_arr(ns_B, n_theta_out, n_phi_out))
+        allocate (z_arr(ns_B, n_theta_out, n_phi_out))
+        allocate (bmod_arr(ns_B, n_theta_out, n_phi_out))
+
+        ! Radial grid
+        do i_rho = 1, ns_B
+            rho_arr(i_rho) = rho_min + (1.0_dp - rho_min) &
+                             *real(i_rho - 1, dp)/real(ns_B - 1, dp)
+            s_arr(i_rho) = rho_min**2 + (1.0_dp - rho_min**2) &
+                           *real(i_rho - 1, dp)/real(ns_B - 1, dp)
+        end do
+        ! Angular grids (endpoint excluded, for chartmap geometry)
+        do i_theta = 1, n_theta_out
+            theta_arr(i_theta) = real(i_theta - 1, dp)*h_theta_B
+        end do
+        do i_phi = 1, n_phi_out
+            zeta_arr(i_phi) = real(i_phi - 1, dp)*h_phi_B
+        end do
+
+        ! A_phi is a flux profile on s. B_theta/B_phi stay on rho for now.
+        do i_rho = 1, ns_B
+            call splint_boozer_coord(s_arr(i_rho), 0.0_dp, 0.0_dp, 0, &
+                                     A_theta_dum, A_phi_arr(i_rho), dA_theta_ds, &
+                                     dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
+                                     B_theta_val, dB_theta, d2B_theta, &
+                                     B_phi_val, dB_phi, d2B_phi, &
+                                     Bmod_val, dBmod, d2Bmod, &
+                                     B_r_val, dB_r, d2B_r)
+
+            s = rho_arr(i_rho)**2
+            call splint_boozer_coord(s, 0.0_dp, 0.0_dp, 0, &
+                                     A_theta_dum, A_phi_dum, dA_theta_ds, &
+                                     dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
+                                     B_theta_arr(i_rho), dB_theta, d2B_theta, &
+                                     B_phi_arr(i_rho), dB_phi, d2B_phi, &
+                                     Bmod_val, dBmod, d2Bmod, &
+                                     B_r_val, dB_r, d2B_r)
+        end do
+
+        ! Compute X, Y, Z geometry on the Boozer grid (endpoint-excluded)
+        do i_phi = 1, n_phi_out
+            do i_theta = 1, n_theta_out
+                do i_rho = 1, ns_B
+                    rho_tor = rho_arr(i_rho)
+                    s = rho_tor**2
+                    theta_B = theta_arr(i_theta)
+                    phi_B = zeta_arr(i_phi)
+
+                    ! Convert Boozer angles to VMEC angles
+                    call boozer_to_vmec(s, theta_B, phi_B, theta_V, phi_V)
+
+                    ! Evaluate VMEC geometry at (s, theta_V, phi_V)
+                    call splint_vmec_data(s, theta_V, phi_V, &
+                                          A_phi_dum, A_theta_dum, dA_phi_ds, &
+                                          dA_theta_ds, aiota, &
+                                          R, Zval, alam, dR_ds, dR_dt, dR_dp, &
+                                          dZ_ds, dZ_dt, dZ_dp, dl_ds, dl_dt, dl_dp)
+
+                    x_arr(i_rho, i_theta, i_phi) = R*cos(phi_V)
+                    y_arr(i_rho, i_theta, i_phi) = R*sin(phi_V)
+                    z_arr(i_rho, i_theta, i_phi) = Zval
+                end do
+            end do
+        end do
+
+        do i_phi = 1, n_phi_out
+            phi_B = real(i_phi - 1, dp)*h_phi_B
+            do i_theta = 1, n_theta_out
+                theta_B = real(i_theta - 1, dp)*h_theta_B
+                do i_rho = 1, ns_B
+                    s = rho_arr(i_rho)**2
+                    call splint_boozer_coord(s, theta_B, phi_B, 0, &
+                                             A_theta_dum, A_phi_dum, dA_theta_ds, &
+                                             dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
+                                             B_theta_val, dB_theta, d2B_theta, &
+                                             B_phi_val, dB_phi, d2B_phi, &
+                                             bmod_arr(i_rho, i_theta, i_phi), &
+                                             dBmod, d2Bmod, &
+                                             B_r_val, dB_r, d2B_r)
+                end do
+            end do
+        end do
+
+        ! Write NetCDF file
+        status = nf90_create(trim(filename), nf90_clobber, ncid)
+        call nc_assert(status, "create "//trim(filename))
+
+        ! Dimensions: one endpoint-excluded angular grid for geometry and fields.
+        call nc_assert(nf90_def_dim(ncid, "rho", ns_B, dim_rho), "def_dim rho")
+        call nc_assert(nf90_def_dim(ncid, "s", ns_B, dim_s), "def_dim s")
+        call nc_assert(nf90_def_dim(ncid, "theta", n_theta_out, dim_theta), &
+                       "def_dim theta")
+        call nc_assert(nf90_def_dim(ncid, "zeta", n_phi_out, dim_zeta), &
+                       "def_dim zeta")
+
+        ! Coordinate variables
+        call nc_assert(nf90_def_var(ncid, "rho", nf90_double, [dim_rho], var_rho), &
+                       "def_var rho")
+        call nc_assert(nf90_def_var(ncid, "s", nf90_double, [dim_s], var_s), &
+                       "def_var s")
+        call nc_assert(nf90_def_var(ncid, "theta", nf90_double, [dim_theta], &
+                                    var_theta), "def_var theta")
+        call nc_assert(nf90_def_var(ncid, "zeta", nf90_double, [dim_zeta], &
+                                    var_zeta), "def_var zeta")
+
+        ! Geometry (NF90 reverses dims: Fortran (rho,theta,zeta) -> NetCDF order)
+        call nc_assert(nf90_def_var(ncid, "x", nf90_double, &
+                                    [dim_rho, dim_theta, dim_zeta], var_x), &
+                       "def_var x")
+        call nc_assert(nf90_put_att(ncid, var_x, "units", "cm"), "att x units")
+        call nc_assert(nf90_def_var(ncid, "y", nf90_double, &
+                                    [dim_rho, dim_theta, dim_zeta], var_y), &
+                       "def_var y")
+        call nc_assert(nf90_put_att(ncid, var_y, "units", "cm"), "att y units")
+        call nc_assert(nf90_def_var(ncid, "z", nf90_double, &
+                                    [dim_rho, dim_theta, dim_zeta], var_z), &
+                       "def_var z")
+        call nc_assert(nf90_put_att(ncid, var_z, "units", "cm"), "att z units")
+
+        ! Boozer field data
+        call nc_assert(nf90_def_var(ncid, "A_phi", nf90_double, [dim_s], &
+                                    var_aphi), "def_var A_phi")
+        call nc_assert(nf90_put_att(ncid, var_aphi, "radial_abscissa", "s"), &
+                       "att A_phi radial_abscissa")
+        call nc_assert(nf90_def_var(ncid, "B_theta", nf90_double, [dim_rho], &
+                                    var_btheta), "def_var B_theta")
+        call nc_assert(nf90_def_var(ncid, "B_phi", nf90_double, [dim_rho], &
+                                    var_bphi), "def_var B_phi")
+        call nc_assert(nf90_def_var(ncid, "Bmod", nf90_double, &
+                                    [dim_rho, dim_theta, dim_zeta], var_bmod), &
+                       "def_var Bmod")
+        call nc_assert(nf90_def_var(ncid, "num_field_periods", nf90_int, var_nfp), &
+                       "def_var nfp")
+
+        ! Global attributes
+        call nc_assert(nf90_put_att(ncid, nf90_global, "rho_convention", "rho_tor"), &
+                       "att rho_convention")
+        call nc_assert(nf90_put_att(ncid, nf90_global, "zeta_convention", "boozer"), &
+                       "att zeta_convention")
+        call nc_assert(nf90_put_att(ncid, nf90_global, "rho_lcfs", rho_arr(ns_B)), &
+                       "att rho_lcfs")
+        call nc_assert(nf90_put_att(ncid, nf90_global, "boozer_field", 1), &
+                       "att boozer_field")
+        call nc_assert(nf90_put_att(ncid, nf90_global, "torflux", torflux), &
+                       "att torflux")
+        ! No rmajor attribute: the chartmap reader derives the major radius
+        ! from the innermost-surface geometry (see boozer_chartmap_io).
+
+        call nc_assert(nf90_enddef(ncid), "enddef")
+
+        ! Write data
+        call nc_assert(nf90_put_var(ncid, var_rho, rho_arr), "put rho")
+        call nc_assert(nf90_put_var(ncid, var_s, s_arr), "put s")
+        call nc_assert(nf90_put_var(ncid, var_theta, theta_arr), "put theta")
+        call nc_assert(nf90_put_var(ncid, var_zeta, zeta_arr), "put zeta")
+        call nc_assert(nf90_put_var(ncid, var_x, x_arr), "put x")
+        call nc_assert(nf90_put_var(ncid, var_y, y_arr), "put y")
+        call nc_assert(nf90_put_var(ncid, var_z, z_arr), "put z")
+        call nc_assert(nf90_put_var(ncid, var_aphi, A_phi_arr), "put A_phi")
+        call nc_assert(nf90_put_var(ncid, var_btheta, B_theta_arr), "put B_theta")
+        call nc_assert(nf90_put_var(ncid, var_bphi, B_phi_arr), "put B_phi")
+        call nc_assert(nf90_put_var(ncid, var_bmod, bmod_arr), "put Bmod")
+        call nc_assert(nf90_put_var(ncid, var_nfp, nper), "put nfp")
+
+        call nc_assert(nf90_close(ncid), "close")
+
+        print *, 'Exported Boozer chartmap to ', trim(filename)
+        print *, '  nfp=', nper, ' ns=', ns_B, ' ntheta=', n_theta_out, &
+            ' nphi=', n_phi_out
+        print *, '  torflux=', torflux
+
+    contains
+
+        subroutine nc_assert(stat, loc)
+            integer, intent(in) :: stat
+            character(len=*), intent(in) :: loc
+            if (stat /= nf90_noerr) then
+                print *, "export_boozer_chartmap: NetCDF error at ", trim(loc), &
+                    ": ", trim(nf90_strerror(stat))
+                error stop
+            end if
+        end subroutine nc_assert
+
+    end subroutine export_boozer_chartmap
+
+end module boozer_chartmap

--- a/src/boozer_chartmap_types.f90
+++ b/src/boozer_chartmap_types.f90
@@ -1,0 +1,33 @@
+module boozer_chartmap_types
+    !> Plain data record for an extended Boozer chartmap. No I/O, no field
+    !> machinery, so the boozer converter can build splines from it without
+    !> pulling in the NetCDF chartmap reader.
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+
+    implicit none
+    private
+    public :: boozer_chartmap_data_t
+
+    type :: boozer_chartmap_data_t
+        integer :: n_rho = 0
+        integer :: n_s = 0
+        integer :: n_theta = 0       !< internal field grid, endpoint-included
+        integer :: n_phi = 0         !< internal field grid, endpoint-included
+        integer :: nfp = 1
+        real(dp) :: torflux = 0.0_dp
+        real(dp) :: rmajor = 0.0_dp  !< metres, derived from innermost-surface geometry
+        real(dp) :: rho_min = 0.0_dp
+        real(dp) :: rho_max = 0.0_dp
+        real(dp) :: h_rho = 0.0_dp   !< uniform rho step
+        real(dp) :: h_s = 0.0_dp
+        real(dp) :: h_theta = 0.0_dp !< 2*pi/(n_theta-1)
+        real(dp) :: h_phi = 0.0_dp   !< 2*pi/nfp/(n_phi-1)
+        real(dp), allocatable :: rho(:)
+        real(dp), allocatable :: s(:)
+        real(dp), allocatable :: A_phi(:)
+        real(dp), allocatable :: B_theta(:)
+        real(dp), allocatable :: B_phi(:)
+        real(dp), allocatable :: Bmod(:, :, :)  !< (n_rho, n_theta, n_phi)
+    end type boozer_chartmap_data_t
+end module boozer_chartmap_types

--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -21,7 +21,7 @@ module boozer_sub
     public :: delthe_delphi_BV
     public :: delthe_delphi_BV_d2
     public :: delthe_delphi_BV_d3
-    public :: export_boozer_chartmap, load_boozer_from_chartmap
+    public :: build_boozer_from_chartmap
     public :: sync_boozer_state, boozer_state
 
     ! Constants
@@ -1316,19 +1316,17 @@ contains
         deallocate (y_batch)
     end subroutine build_boozer_delt_delp_batch_splines
 
-    subroutine load_boozer_from_chartmap(filename)
-        !> Populate module-level Boozer batch splines from an extended chartmap
-        !> NetCDF file, bypassing the VMEC-based compute_boozer_data path.
+    subroutine build_boozer_from_chartmap(d)
+        !> Populate the module-level Boozer batch splines from an already-parsed
+        !> chartmap record, bypassing the VMEC-based compute_boozer_data path.
         use vector_potentail_mod, only: torflux, ns, hs
         use new_vmec_stuff_mod, only: nper, rmajor, ns_A, vmec_B_scale, vmec_RZ_scale
         use boozer_coordinates_mod, only: ns_s_B, ns_tp_B, ns_B, n_theta_B, &
                                           n_phi_B, hs_B, h_theta_B, h_phi_B, &
                                           use_B_r, use_del_tp_B
-        use boozer_chartmap_io, only: boozer_chartmap_data_t, read_boozer_chartmap
+        use boozer_chartmap_types, only: boozer_chartmap_data_t
 
-        character(len=*), intent(in) :: filename
-
-        type(boozer_chartmap_data_t) :: d
+        type(boozer_chartmap_data_t), intent(inout) :: d
         real(dp), allocatable :: y_aphi(:, :), y_bcovar(:, :), y_bmod(:, :, :, :)
         real(dp) :: s_min, s_max
         real(dp) :: b_scale, rz_scale, covar_scale, flux_scale
@@ -1338,9 +1336,6 @@ contains
         real(dp) :: x_min_3d(3), x_max_3d(3)
 
         call reset_boozer_batch_splines
-
-        ! Single shared parse: base-unit arrays plus internal periodic endpoints.
-        call read_boozer_chartmap(filename, d)
 
         ! Apply the VMEC scaling knobs so a chartmap behaves like a VMEC run
         ! (matches boozer_chartmap_field_t and test_chartmap_scaling). Base files
@@ -1417,241 +1412,10 @@ contains
 
         call sync_boozer_state
 
-        print *, 'Loaded Boozer splines from chartmap: ', trim(filename)
         print *, '  nfp=', d%nfp, ' ns=', d%n_rho, ' ntheta_spline=', &
             d%n_theta, ' nphi_spline=', d%n_phi
         print *, '  torflux=', torflux
-    end subroutine load_boozer_from_chartmap
+    end subroutine build_boozer_from_chartmap
 
-    subroutine export_boozer_chartmap(filename)
-        !> Export Boozer coordinate data computed by get_boozer_coordinates()
-        !> to an extended chartmap NetCDF file. Must be called after
-        !> get_boozer_coordinates() and while VMEC splines are still active
-        !> (needed for X, Y, Z geometry evaluation).
-        use vector_potentail_mod, only: torflux
-        use new_vmec_stuff_mod, only: nper
-        use boozer_coordinates_mod, only: ns_B, n_theta_B, n_phi_B, &
-                                          h_theta_B, h_phi_B
-        use spline_vmec_sub, only: splint_vmec_data
-        use netcdf
-
-        character(len=*), intent(in) :: filename
-
-        integer :: ncid, status
-        integer :: dim_rho, dim_s, dim_theta, dim_zeta
-        integer :: var_rho, var_s, var_theta, var_zeta
-        integer :: var_x, var_y, var_z
-        integer :: var_aphi, var_btheta, var_bphi, var_bmod, var_nfp
-        integer :: i_rho, i_theta, i_phi
-        integer :: n_theta_out, n_phi_out
-        real(dp) :: rho_tor, s, theta_B, phi_B, theta_V, phi_V
-        real(dp) :: R, Zval, alam
-        real(dp) :: A_phi_dum, A_theta_dum, dA_phi_ds, dA_theta_ds, aiota
-        real(dp) :: d2A_phi_ds2, d3A_phi_ds3, B_theta_val, B_phi_val
-        real(dp) :: dB_theta, d2B_theta, dB_phi, d2B_phi, Bmod_val, B_r_val
-        real(dp) :: sqrt_g_ss_val
-        real(dp) :: dBmod(3), d2Bmod(6), dB_r(3), d2B_r(6)
-        real(dp) :: dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp
-        real(dp) :: dl_ds, dl_dt, dl_dp
-        real(dp), parameter :: rho_min = sqrt(1.0e-6_dp)
-        real(dp), allocatable :: rho_arr(:), s_arr(:), theta_arr(:), zeta_arr(:)
-        real(dp), allocatable :: A_phi_arr(:), B_theta_arr(:), B_phi_arr(:)
-        real(dp), allocatable :: x_arr(:, :, :), y_arr(:, :, :), z_arr(:, :, :)
-        real(dp), allocatable :: bmod_arr(:, :, :)
-
-        ! Chartmap files store endpoint-excluded angular grids. The reader
-        ! reconstructs endpoint planes before building periodic splines.
-        n_theta_out = n_theta_B - 1
-        n_phi_out = n_phi_B - 1
-
-        allocate (rho_arr(ns_B))
-        allocate (s_arr(ns_B))
-        allocate (theta_arr(n_theta_out), zeta_arr(n_phi_out))
-        allocate (A_phi_arr(ns_B), B_theta_arr(ns_B), B_phi_arr(ns_B))
-        allocate (x_arr(ns_B, n_theta_out, n_phi_out))
-        allocate (y_arr(ns_B, n_theta_out, n_phi_out))
-        allocate (z_arr(ns_B, n_theta_out, n_phi_out))
-        allocate (bmod_arr(ns_B, n_theta_out, n_phi_out))
-
-        ! Radial grid
-        do i_rho = 1, ns_B
-            rho_arr(i_rho) = rho_min + (1.0_dp - rho_min) &
-                             *real(i_rho - 1, dp)/real(ns_B - 1, dp)
-            s_arr(i_rho) = rho_min**2 + (1.0_dp - rho_min**2) &
-                           *real(i_rho - 1, dp)/real(ns_B - 1, dp)
-        end do
-        ! Angular grids (endpoint excluded, for chartmap geometry)
-        do i_theta = 1, n_theta_out
-            theta_arr(i_theta) = real(i_theta - 1, dp)*h_theta_B
-        end do
-        do i_phi = 1, n_phi_out
-            zeta_arr(i_phi) = real(i_phi - 1, dp)*h_phi_B
-        end do
-
-        ! A_phi is a flux profile on s. B_theta/B_phi stay on rho for now.
-        do i_rho = 1, ns_B
-            call splint_boozer_coord(s_arr(i_rho), 0.0_dp, 0.0_dp, 0, &
-                                     A_theta_dum, A_phi_arr(i_rho), dA_theta_ds, &
-                                     dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
-                                     B_theta_val, dB_theta, d2B_theta, &
-                                     B_phi_val, dB_phi, d2B_phi, &
-                                     Bmod_val, dBmod, d2Bmod, &
-                                     B_r_val, dB_r, d2B_r)
-
-            s = rho_arr(i_rho)**2
-            call splint_boozer_coord(s, 0.0_dp, 0.0_dp, 0, &
-                                     A_theta_dum, A_phi_dum, dA_theta_ds, &
-                                     dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
-                                     B_theta_arr(i_rho), dB_theta, d2B_theta, &
-                                     B_phi_arr(i_rho), dB_phi, d2B_phi, &
-                                     Bmod_val, dBmod, d2Bmod, &
-                                     B_r_val, dB_r, d2B_r)
-        end do
-
-        ! Compute X, Y, Z geometry on the Boozer grid (endpoint-excluded)
-        do i_phi = 1, n_phi_out
-            do i_theta = 1, n_theta_out
-                do i_rho = 1, ns_B
-                    rho_tor = rho_arr(i_rho)
-                    s = rho_tor**2
-                    theta_B = theta_arr(i_theta)
-                    phi_B = zeta_arr(i_phi)
-
-                    ! Convert Boozer angles to VMEC angles
-                    call boozer_to_vmec(s, theta_B, phi_B, theta_V, phi_V)
-
-                    ! Evaluate VMEC geometry at (s, theta_V, phi_V)
-                    call splint_vmec_data(s, theta_V, phi_V, &
-                                          A_phi_dum, A_theta_dum, dA_phi_ds, &
-                                          dA_theta_ds, aiota, &
-                                          R, Zval, alam, dR_ds, dR_dt, dR_dp, &
-                                          dZ_ds, dZ_dt, dZ_dp, dl_ds, dl_dt, dl_dp)
-
-                    x_arr(i_rho, i_theta, i_phi) = R*cos(phi_V)
-                    y_arr(i_rho, i_theta, i_phi) = R*sin(phi_V)
-                    z_arr(i_rho, i_theta, i_phi) = Zval
-                end do
-            end do
-        end do
-
-        do i_phi = 1, n_phi_out
-            phi_B = real(i_phi - 1, dp)*h_phi_B
-            do i_theta = 1, n_theta_out
-                theta_B = real(i_theta - 1, dp)*h_theta_B
-                do i_rho = 1, ns_B
-                    s = rho_arr(i_rho)**2
-                    call splint_boozer_coord(s, theta_B, phi_B, 0, &
-                                             A_theta_dum, A_phi_dum, dA_theta_ds, &
-                                             dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
-                                             B_theta_val, dB_theta, d2B_theta, &
-                                             B_phi_val, dB_phi, d2B_phi, &
-                                             bmod_arr(i_rho, i_theta, i_phi), &
-                                             dBmod, d2Bmod, &
-                                             B_r_val, dB_r, d2B_r)
-                end do
-            end do
-        end do
-
-        ! Write NetCDF file
-        status = nf90_create(trim(filename), nf90_clobber, ncid)
-        call nc_assert(status, "create "//trim(filename))
-
-        ! Dimensions: one endpoint-excluded angular grid for geometry and fields.
-        call nc_assert(nf90_def_dim(ncid, "rho", ns_B, dim_rho), "def_dim rho")
-        call nc_assert(nf90_def_dim(ncid, "s", ns_B, dim_s), "def_dim s")
-        call nc_assert(nf90_def_dim(ncid, "theta", n_theta_out, dim_theta), &
-                       "def_dim theta")
-        call nc_assert(nf90_def_dim(ncid, "zeta", n_phi_out, dim_zeta), &
-                       "def_dim zeta")
-
-        ! Coordinate variables
-        call nc_assert(nf90_def_var(ncid, "rho", nf90_double, [dim_rho], var_rho), &
-                       "def_var rho")
-        call nc_assert(nf90_def_var(ncid, "s", nf90_double, [dim_s], var_s), &
-                       "def_var s")
-        call nc_assert(nf90_def_var(ncid, "theta", nf90_double, [dim_theta], &
-                                    var_theta), "def_var theta")
-        call nc_assert(nf90_def_var(ncid, "zeta", nf90_double, [dim_zeta], &
-                                    var_zeta), "def_var zeta")
-
-        ! Geometry (NF90 reverses dims: Fortran (rho,theta,zeta) -> NetCDF order)
-        call nc_assert(nf90_def_var(ncid, "x", nf90_double, &
-                                    [dim_rho, dim_theta, dim_zeta], var_x), &
-                       "def_var x")
-        call nc_assert(nf90_put_att(ncid, var_x, "units", "cm"), "att x units")
-        call nc_assert(nf90_def_var(ncid, "y", nf90_double, &
-                                    [dim_rho, dim_theta, dim_zeta], var_y), &
-                       "def_var y")
-        call nc_assert(nf90_put_att(ncid, var_y, "units", "cm"), "att y units")
-        call nc_assert(nf90_def_var(ncid, "z", nf90_double, &
-                                    [dim_rho, dim_theta, dim_zeta], var_z), &
-                       "def_var z")
-        call nc_assert(nf90_put_att(ncid, var_z, "units", "cm"), "att z units")
-
-        ! Boozer field data
-        call nc_assert(nf90_def_var(ncid, "A_phi", nf90_double, [dim_s], &
-                                    var_aphi), "def_var A_phi")
-        call nc_assert(nf90_put_att(ncid, var_aphi, "radial_abscissa", "s"), &
-                       "att A_phi radial_abscissa")
-        call nc_assert(nf90_def_var(ncid, "B_theta", nf90_double, [dim_rho], &
-                                    var_btheta), "def_var B_theta")
-        call nc_assert(nf90_def_var(ncid, "B_phi", nf90_double, [dim_rho], &
-                                    var_bphi), "def_var B_phi")
-        call nc_assert(nf90_def_var(ncid, "Bmod", nf90_double, &
-                                    [dim_rho, dim_theta, dim_zeta], var_bmod), &
-                       "def_var Bmod")
-        call nc_assert(nf90_def_var(ncid, "num_field_periods", nf90_int, var_nfp), &
-                       "def_var nfp")
-
-        ! Global attributes
-        call nc_assert(nf90_put_att(ncid, nf90_global, "rho_convention", "rho_tor"), &
-                       "att rho_convention")
-        call nc_assert(nf90_put_att(ncid, nf90_global, "zeta_convention", "boozer"), &
-                       "att zeta_convention")
-        call nc_assert(nf90_put_att(ncid, nf90_global, "rho_lcfs", rho_arr(ns_B)), &
-                       "att rho_lcfs")
-        call nc_assert(nf90_put_att(ncid, nf90_global, "boozer_field", 1), &
-                       "att boozer_field")
-        call nc_assert(nf90_put_att(ncid, nf90_global, "torflux", torflux), &
-                       "att torflux")
-        ! No rmajor attribute: the chartmap reader derives the major radius
-        ! from the innermost-surface geometry (see boozer_chartmap_io).
-
-        call nc_assert(nf90_enddef(ncid), "enddef")
-
-        ! Write data
-        call nc_assert(nf90_put_var(ncid, var_rho, rho_arr), "put rho")
-        call nc_assert(nf90_put_var(ncid, var_s, s_arr), "put s")
-        call nc_assert(nf90_put_var(ncid, var_theta, theta_arr), "put theta")
-        call nc_assert(nf90_put_var(ncid, var_zeta, zeta_arr), "put zeta")
-        call nc_assert(nf90_put_var(ncid, var_x, x_arr), "put x")
-        call nc_assert(nf90_put_var(ncid, var_y, y_arr), "put y")
-        call nc_assert(nf90_put_var(ncid, var_z, z_arr), "put z")
-        call nc_assert(nf90_put_var(ncid, var_aphi, A_phi_arr), "put A_phi")
-        call nc_assert(nf90_put_var(ncid, var_btheta, B_theta_arr), "put B_theta")
-        call nc_assert(nf90_put_var(ncid, var_bphi, B_phi_arr), "put B_phi")
-        call nc_assert(nf90_put_var(ncid, var_bmod, bmod_arr), "put Bmod")
-        call nc_assert(nf90_put_var(ncid, var_nfp, nper), "put nfp")
-
-        call nc_assert(nf90_close(ncid), "close")
-
-        print *, 'Exported Boozer chartmap to ', trim(filename)
-        print *, '  nfp=', nper, ' ns=', ns_B, ' ntheta=', n_theta_out, &
-            ' nphi=', n_phi_out
-        print *, '  torflux=', torflux
-
-    contains
-
-        subroutine nc_assert(stat, loc)
-            integer, intent(in) :: stat
-            character(len=*), intent(in) :: loc
-            if (stat /= nf90_noerr) then
-                print *, "export_boozer_chartmap: NetCDF error at ", trim(loc), &
-                    ": ", trim(nf90_strerror(stat))
-                error stop
-            end if
-        end subroutine nc_assert
-
-    end subroutine export_boozer_chartmap
 
 end module boozer_sub

--- a/src/field/boozer_chartmap_io.f90
+++ b/src/field/boozer_chartmap_io.f90
@@ -13,33 +13,13 @@ module boozer_chartmap_io
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
     use netcdf
+    use boozer_chartmap_types, only: boozer_chartmap_data_t
 
     implicit none
 
     private
     public :: boozer_chartmap_data_t, read_boozer_chartmap
 
-    type :: boozer_chartmap_data_t
-        integer :: n_rho = 0
-        integer :: n_s = 0
-        integer :: n_theta = 0       !< internal field grid, endpoint-included
-        integer :: n_phi = 0         !< internal field grid, endpoint-included
-        integer :: nfp = 1
-        real(dp) :: torflux = 0.0_dp
-        real(dp) :: rmajor = 0.0_dp  !< metres, derived from innermost-surface geometry
-        real(dp) :: rho_min = 0.0_dp
-        real(dp) :: rho_max = 0.0_dp
-        real(dp) :: h_rho = 0.0_dp   !< uniform rho step
-        real(dp) :: h_s = 0.0_dp
-        real(dp) :: h_theta = 0.0_dp !< 2*pi/(n_theta-1)
-        real(dp) :: h_phi = 0.0_dp   !< 2*pi/nfp/(n_phi-1)
-        real(dp), allocatable :: rho(:)
-        real(dp), allocatable :: s(:)
-        real(dp), allocatable :: A_phi(:)
-        real(dp), allocatable :: B_theta(:)
-        real(dp), allocatable :: B_phi(:)
-        real(dp), allocatable :: Bmod(:, :, :)  !< (n_rho, n_theta, n_phi)
-    end type boozer_chartmap_data_t
 
 contains
 

--- a/test/source/test_boozer_chartmap_roundtrip.f90
+++ b/test/source/test_boozer_chartmap_roundtrip.f90
@@ -9,8 +9,8 @@ program test_boozer_chartmap_roundtrip
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use boozer_coordinates_mod, only: use_B_r
     use new_vmec_stuff_mod, only: nper
-    use boozer_sub, only: get_boozer_coordinates, splint_boozer_coord, &
-                          export_boozer_chartmap, load_boozer_from_chartmap
+    use boozer_sub, only: get_boozer_coordinates, splint_boozer_coord
+    use boozer_chartmap, only: export_boozer_chartmap, load_boozer_from_chartmap
     implicit none
 
     real(dp), parameter :: PI = 3.14159265358979_dp


### PR DESCRIPTION
Follow-up to #337. With the field-object graft gone, the only remaining non-converter dependency `boozer_sub` carried was the chartmap file I/O: `export/load_boozer_from_chartmap` pulled `boozer_chartmap_io` (the NetCDF reader) and `netcdf` into the module, so a VMEC→Boozer-only consumer had to compile them too.

## What

Separate file-I/O from state-access (no submodule — plain modules, compiler-portable):

- **`boozer_chartmap_types`** (new): the `boozer_chartmap_data_t` record alone — no I/O, no deps beyond `iso_fortran_env`.
- **`boozer_sub`** keeps `build_boozer_from_chartmap(d)` — the spline-building half, which needs the private batch-spline state. Its only chartmap reference is now the trivial types module; it no longer `use`s `boozer_chartmap_io` or `netcdf`.
- **`boozer_chartmap`** (new) owns the file entry points: `load_boozer_from_chartmap` parses via `boozer_chartmap_io` then calls `build_boozer_from_chartmap`; `export_boozer_chartmap` gathers through the public `splint_boozer_coord`/`boozer_to_vmec` and writes NetCDF.

`boozer_chartmap_io` re-exports `boozer_chartmap_data_t` from the types module, so existing `use boozer_chartmap_io, only: boozer_chartmap_data_t` imports are unaffected. The only API change: callers of `load`/`export_boozer_chartmap` switch `use boozer_sub` → `use boozer_chartmap` (only `test_boozer_chartmap_roundtrip` in-tree; updated here).

## Verification

```
test_boozer_chartmap_roundtrip   exit 0   (export+load via the new boozer_chartmap module)
test_boozer_converter_vs_simple  exit 0
RABE quick+slow:                 100% tests passed, 0 failed out of 32
```

Converter-only consumers (e.g. RABE's curated build) now compile `boozer_converter` with just `boozer_chartmap_types` — no `boozer_chartmap_io`, no `boozer_chartmap`, no NetCDF-via-chartmap.