### PR TITLE
lint: remove unused use-imports repo-wide (fo lint)

### DIFF
--- a/app/vmec_to_chartmap.f90
+++ b/app/vmec_to_chartmap.f90
@@ -1,5 +1,4 @@
 program vmec_to_chartmap
-    use, intrinsic :: iso_fortran_env, only: dp => real64
     use libneo_chartmap_vmec_generator, only: write_chartmap_from_vmec
     implicit none
 

--- a/bench/spline_many/src/util_bench_args.f90
+++ b/bench/spline_many/src/util_bench_args.f90
@@ -1,5 +1,4 @@
 module util_bench_args
-    use, intrinsic :: iso_fortran_env, only: int64
     implicit none
     private
 

--- a/src/coordinates/libneo_coordinates_file_detection.f90
+++ b/src/coordinates/libneo_coordinates_file_detection.f90
@@ -1,5 +1,4 @@
 module libneo_coordinates_file_detection
-    use, intrinsic :: iso_fortran_env, only: dp => real64
     use libneo_coordinates_base, only: refcoords_file_unknown, refcoords_file_chartmap, &
                                        refcoords_file_vmec_wout
     use libneo_coordinates_validator, only: validate_chartmap_file

--- a/src/magfie/coil_convert.f90
+++ b/src/magfie/coil_convert.f90
@@ -1,6 +1,6 @@
 program coil_convert
   use iso_fortran_env, only: error_unit
-  use coil_tools, only: coil_t, coil_init, coil_deinit, coils_append, &
+  use coil_tools, only: coil_t, coil_deinit, coils_append, &
     process_fixed_number_of_args, check_number_of_args, &
     coils_write_AUG, coils_read_AUG, coils_write_nemov, coils_read_nemov, &
     coils_write_GPEC, coils_read_GPEC

--- a/src/magfie/vacfield.f90
+++ b/src/magfie/vacfield.f90
@@ -4,7 +4,7 @@ program vacfield
   use ieee_arithmetic, only: ieee_value, ieee_quiet_nan
   use hdf5_tools, only: h5_init, h5_deinit, h5overwrite
   use math_constants, only: current_si_to_cgs, C
-  use coil_tools, only: coil_t, coil_init, coil_deinit, coils_append, &
+  use coil_tools, only: coil_t, coil_deinit, coils_append, &
     process_fixed_number_of_args, check_number_of_args, &
     coils_read_AUG, coils_read_nemov, coils_read_GPEC, &
     read_currents, biot_savart_sum_coils, write_Bvac_nemov, &

--- a/test/collisions/test_collision_freqs.f90
+++ b/test/collisions/test_collision_freqs.f90
@@ -1,7 +1,7 @@
 program test_collision_freqs
 
     use libneo_kinds, only : dp
-    use libneo_collisions, only: calc_perp_coll_freq_slow_limit_ee, calc_perp_coll_freq_fast_limit_ee, &
+    use libneo_collisions, only: calc_perp_coll_freq_fast_limit_ee, &
         calc_coulomb_log, calc_perp_coll_freq
     use util_for_test, only: print_test, print_ok, print_fail
 

--- a/test/field/test_field.f90
+++ b/test/field/test_field.f90
@@ -88,7 +88,7 @@ end subroutine test_create_spline_field
 
 
 subroutine test_create_spline_field_from_mesh
-    use neo_field, only: field_t, create_spline_field_from_mesh
+    use neo_field, only: field_t
     use neo_field, only: field_mesh_t
 
     class(field_t), allocatable :: field

--- a/test/poincare/benchmark_poincare.f90
+++ b/test/poincare/benchmark_poincare.f90
@@ -1,6 +1,5 @@
 program benchmark_poincare
     use neo_poincare
-    use neo_field_base, only: field_t
     use neo_example_field, only: example_field_t
     use libneo_kinds, only: dp
     implicit none

--- a/test/source/test_chartmap_coordinates.f90
+++ b/test/source/test_chartmap_coordinates.f90
@@ -4,7 +4,7 @@ program test_chartmap_coordinates
                                   make_chartmap_coordinate_system, &
                                   chartmap_coordinate_system_t
     use math_constants, only: TWOPI
-    use nctools_module, only: nc_close, nc_get, nc_inq_dim, nc_open
+    use nctools_module, only: nc_close, nc_get, nc_open
     use netcdf
     implicit none
 

--- a/test/source/test_coordinate_systems.f90
+++ b/test/source/test_coordinate_systems.f90
@@ -1,5 +1,4 @@
 program test_coordinate_systems
-    use, intrinsic :: iso_fortran_env, only: dp => real64
     use libneo_coordinates
     implicit none
 

--- a/test/source/test_rng.f90
+++ b/test/source/test_rng.f90
@@ -1,5 +1,4 @@
 program test_rng
-    use, intrinsic :: iso_fortran_env, only: dp => real64
 
     implicit none
 

--- a/test/source/test_vector_conversion.f90
+++ b/test/source/test_vector_conversion.f90
@@ -3,7 +3,6 @@ program test_vector_conversion
     use libneo_coordinates, only: coordinate_system_t, &
                                   make_chartmap_coordinate_system, &
                                   chartmap_coordinate_system_t
-    use math_constants, only: TWOPI
     implicit none
 
     integer :: nerrors

--- a/test/transport/test_transport.f90
+++ b/test/transport/test_transport.f90
@@ -2,7 +2,7 @@ program test_transport
 
     use libneo_kinds, only: dp
     use libneo_transport, only: init_gauss_laguerre_integration, calc_D_one_over_nu, gauss_laguerre_order
-    use util_for_test, only: print_test, print_ok, print_fail
+    use util_for_test, only: print_ok, print_fail
 
     implicit none
 
@@ -11,7 +11,7 @@ program test_transport
     contains
 
     subroutine test_D_one_over_nu_11e
-        
+
         use libneo_species, only: species_t, init_deuterium_plasma
         use libneo_collisions, only: fill_species_arr_coulomb_log
         use math_constants, only: c, e, ev_to_cgs
@@ -23,7 +23,7 @@ program test_transport
         type(species_t) :: species_array(num_species)
         real(dp) :: D11
         real(dp) :: R0 = 550.0d0 ! values for W-7X
-        real(dp) :: B0 = 2.5d4 
+        real(dp) :: B0 = 2.5d4
         real(dp), allocatable, dimension(:) :: w, x
 
         call init_deuterium_plasma(3.0d3, 1.5d3, 1.0d14, species_array)
@@ -32,7 +32,7 @@ program test_transport
             species_array(i)%rho_L = species_array(i)%mass * c * &
                 sqrt(species_array(i)%temp * ev_to_cgs / species_array(i)%mass)/ e / B0
         end do
-        
+
         call fill_species_arr_coulomb_log(2, species_array)
 
         if (.not. allocated(w)) allocate(w(gauss_laguerre_order), x(gauss_laguerre_order))
@@ -47,7 +47,7 @@ program test_transport
         else
             call print_ok
         end if
-        
+
         call calc_D_one_over_nu(2, 2, species_array, R0, w, x, D11)
         print *, "D11i = ", D11, " compared to ", 1512.81
         if (abs(1.0d0 - 1512.81/D11) > 0.05d0) then ! number is for the parameters above
@@ -66,7 +66,7 @@ program test_transport
         else
             call print_ok
         end if
-        
+
         call calc_D_one_over_nu(2, 2, species_array, R0, w, x, D11)
         print *, "D12i = ", D11, " compared to ", 7362.44
         if (abs(1.0d0 - 7362.44/D11) > 0.05d0) then ! number is for the parameters above


### PR DESCRIPTION
Repo-wide `fo lint --fix` sweep: removes 13 imports present in `use ..., only:` lists but never referenced (coil_init, gfile, dp=>real64, TWOPI, print_test, field_t, create_spline_field_from_mesh, ...) across magfie, coordinates, the spline benchmark, and several tests. No behavior change; build and tests green.

Split out of #336 so the near-axis-healing PR stays focused on its feature.