### PR TITLE
chartmap: type-bound invert_cart (Cartesian inverse) on fortnum solvers

### DIFF
--- a/CMakeSources.in
+++ b/CMakeSources.in
@@ -56,6 +56,7 @@ target_link_libraries(neo PUBLIC
     hdf5_tools
     neo_field
     odeint
+    fortnum
 )
 
 target_link_libraries(neo PRIVATE

--- a/src/coordinates/libneo_coordinates.f90
+++ b/src/coordinates/libneo_coordinates.f90
@@ -20,6 +20,8 @@ module libneo_coordinates
     public :: vmec_coordinate_system_t, make_vmec_coordinate_system
     public :: geoflux_coordinate_system_t, make_geoflux_coordinate_system
     public :: chartmap_coordinate_system_t, make_chartmap_coordinate_system
+    public :: CHARTMAP_LOCATED, CHARTMAP_CLAMPED_EDGE
+    public :: CHARTMAP_OUTSIDE, CHARTMAP_NO_ROOT
 
     public :: validate_chartmap_file
     public :: detect_refcoords_file_type

--- a/src/coordinates/libneo_coordinates_chartmap.f90
+++ b/src/coordinates/libneo_coordinates_chartmap.f90
@@ -13,11 +13,41 @@ module libneo_coordinates_chartmap
     use math_constants, only: TWOPI
     use netcdf, only: NF90_CHAR, NF90_GLOBAL, NF90_NOERR, nf90_get_att, nf90_get_var, &
                       nf90_inq_varid, nf90_inquire_attribute
+    use fortnum_status, only: fortnum_status_t
+    use fortnum_multiroot, only: multiroot_hybrid
     implicit none
     private
 
     public :: chartmap_coordinate_system_t
     public :: make_chartmap_coordinate_system
+
+    ! Geometric status of the Cartesian inverse cs%invert_cart. These describe the
+    ! geometry of the located root ONLY; they carry no confinement-loss meaning. A
+    ! caller that needs a loss decision (e.g. SIMPLE's full-orbit pusher) keys it on
+    ! its own guiding-centre test, not on this status.
+    !   LOCATED      converged interior root, residual at chart tolerance.
+    !   CLAMPED_EDGE solver pinned rho to 1 and could not reduce the residual below
+    !                tolerance, but the residual is still a small fraction of a
+    !                radial cell: the target sits essentially on the last surface.
+    !   OUTSIDE      best root has rho clamped to 1 with a residual that is a large
+    !                fraction of a radial cell: the target is past the last surface,
+    !                where the forward map cannot represent it.
+    !   NO_ROOT      singular Jacobian or no convergence from any seed.
+    integer, parameter, public :: CHARTMAP_LOCATED = 0
+    integer, parameter, public :: CHARTMAP_CLAMPED_EDGE = 1
+    integer, parameter, public :: CHARTMAP_OUTSIDE = 2
+    integer, parameter, public :: CHARTMAP_NO_ROOT = 3
+
+    ! A located root has residual below an absolute tolerance OR below this fraction
+    ! of a radial cell |dx/drho| (scale-correct near the axis and on reactor-size
+    ! charts where the absolute floor is meaningless). A clamped-edge root within the
+    ! same fraction is CLAMPED_EDGE; a larger residual at rho=1 is OUTSIDE.
+    real(dp), parameter :: chartmap_invert_edge_frac = 0.05_dp
+    real(dp), parameter :: chartmap_invert_accept_tol = 1.0e-6_dp
+    ! Warm guesses with rho this close to 1 take the bracketed 1-D edge solve, which
+    ! cannot overshoot rho=1 (bracket [rho_lo, 1]); interior guesses take the 3-D
+    ! pseudo-Cartesian multiroot solve.
+    real(dp), parameter :: chartmap_invert_edge_band = 0.1_dp
 
     type, extends(coordinate_system_t) :: chartmap_coordinate_system_t
         type(BatchSplineData3D) :: spl_cart
@@ -38,7 +68,21 @@ module libneo_coordinates_chartmap
         procedure :: christoffel => chartmap_christoffel
         procedure :: from_cyl => chartmap_from_cyl
         procedure :: from_cart => chartmap_from_cart
+        procedure :: invert_cart => chartmap_invert_cart_warm
     end type chartmap_coordinate_system_t
+
+    ! Read-only context threaded through the fortnum callbacks: the chart and the
+    ! Cartesian target. The solvers never inspect it (they pass it back to the
+    ! callback unchanged); it is the active parameter for the implicit-rule
+    ! sensitivity and the only state the callbacks need.
+    type :: chartmap_invert_ctx_t
+        class(chartmap_coordinate_system_t), pointer :: self => null()
+        real(dp) :: x_target(3) = 0.0_dp
+        real(dp) :: zeta = 0.0_dp
+        real(dp) :: theta = 0.0_dp
+        real(dp) :: rho_lo = 0.0_dp
+        real(dp) :: zeta_period = TWOPI
+    end type chartmap_invert_ctx_t
 
 contains
 
@@ -699,6 +743,357 @@ contains
 
         call chartmap_invert_cart(self, x, u, ierr)
     end subroutine chartmap_from_cart
+
+    ! Warm Cartesian inverse x -> logical u = (rho, theta, phi) from a carried guess,
+    ! the single-point inverse the full-orbit pusher needs. The iteration runs in the
+    ! pseudo-Cartesian chart w = (X, Y, phi) = (rho cos theta, rho sin theta, phi),
+    ! which is regular through the magnetic axis (the polar column dx/dtheta ~ rho
+    ! makes det(Jc) -> 0 at rho = 0; the (X, Y) Jacobian stays finite). Two solver
+    ! paths, both fortnum:
+    !   - warm guess near the edge (rho_guess within an edge band of 1): a bracketed
+    !     1-D radial solve on [rho_lo, 1], so the radius cannot overshoot past 1.
+    !   - otherwise: a 3-D multiroot_hybrid in w with the analytic Jacobian built
+    !     from covariant_basis. The callback rejects any rho > 1 trial (large
+    !     residual) so the line search cannot accept a clamped-edge point.
+    ! On warm-path failure, fall back to the cold multi-seed chartmap_invert_cart.
+    ! geom_status is GEOMETRIC ONLY (located / clamped-edge / outside / no-root); it
+    ! never encodes a confinement loss.
+    subroutine chartmap_invert_cart_warm(self, x, u_guess, u, geom_status)
+        class(chartmap_coordinate_system_t), intent(in), target :: self
+        real(dp), intent(in) :: x(3)
+        real(dp), intent(in) :: u_guess(3)
+        real(dp), intent(out) :: u(3)
+        integer, intent(out) :: geom_status
+
+        real(dp) :: u_try(3), res_try, res_best, rscale, zeta_period
+        logical :: converged, have_root
+
+        zeta_period = TWOPI/real(self%num_field_periods, dp)
+        res_best = huge(1.0_dp)
+        have_root = .false.
+
+        ! Try each solver in turn; keep the lowest-residual root seen so far. A path
+        ! that does not converge still contributes its best clamped root (e.g. a
+        ! past-edge target pinned at rho=1), so classification can report OUTSIDE
+        ! rather than a spurious no-root. Stop early once a path truly converges.
+        ! The toroidal coordinate is seeded from the in-wedge geometric angle inside
+        ! each solver: the carried Boozer phi goes a full period stale across a
+        ! field-period seam, whereas atan2(y, x) is always in-wedge and differs from
+        ! logical phi only by the Boozer shift O(0.1 rad). For the cyl/vmec charts
+        ! zeta IS the geometric angle, so the seed is exact.
+        if (u_guess(1) >= 1.0_dp - chartmap_invert_edge_band) then
+            call chartmap_invert_edge_1d(self, x, u_guess, u_try, res_try, converged)
+            call keep_best(u_try, res_try, u, res_best, have_root)
+            if (converged) go to 100
+        end if
+
+        call chartmap_invert_interior_3d(self, x, u_guess, u_try, res_try, converged)
+        call keep_best(u_try, res_try, u, res_best, have_root)
+        if (converged) go to 100
+
+        call chartmap_invert_cold(self, x, u_try, res_try, converged)
+        call keep_best(u_try, res_try, u, res_best, have_root)
+
+100     continue
+        if (.not. have_root) then
+            u = 0.0_dp
+            geom_status = CHARTMAP_NO_ROOT
+            return
+        end if
+
+        u(1) = min(max(u(1), 0.0_dp), 1.0_dp)
+        u(2) = modulo(u(2), TWOPI)
+        u(3) = modulo(u(3), zeta_period)
+
+        rscale = chartmap_radial_scale(self, u)
+        geom_status = chartmap_classify_root(u(1), res_best, rscale)
+    end subroutine chartmap_invert_cart_warm
+
+    ! Retain the lower-residual root. A finite-residual candidate sets have_root so a
+    ! non-converged clamped-edge root still survives for OUTSIDE classification.
+    pure subroutine keep_best(u_try, res_try, u_best, res_best, have_root)
+        real(dp), intent(in) :: u_try(3), res_try
+        real(dp), intent(inout) :: u_best(3), res_best
+        logical, intent(inout) :: have_root
+        if (res_try == res_try .and. res_try < res_best) then
+            u_best = u_try
+            res_best = res_try
+            have_root = .true.
+        end if
+    end subroutine keep_best
+
+    ! Bracketed 1-D edge solve along the seeded ray: hold (theta, phi) at the
+    ! warm-guess values and solve the scalar radial residual for rho with the bracket
+    ! [rho_lo, 1] enforced so the radius cannot overshoot past 1. The driver is
+    ! fortnum's multiroot_hybrid at n = 1 (Newton + line search on the single radial
+    ! variable); the analytic 1x1 Jacobian is the outward radial sensitivity from one
+    ! covariant_basis call (no finite differences). The bracket lives in the
+    ! callback: a trial rho > 1 is penalized (large outward residual) so the line
+    ! search backtracks, and rho < rho_lo is clamped, so a marker leaving the plasma
+    ! stalls cleanly on the clamped edge instead of running away.
+    subroutine chartmap_invert_edge_1d(self, x, u_guess, u, res_norm, converged)
+        class(chartmap_coordinate_system_t), intent(in), target :: self
+        real(dp), intent(in) :: x(3)
+        real(dp), intent(in) :: u_guess(3)
+        real(dp), intent(out) :: u(3)
+        real(dp), intent(out) :: res_norm
+        logical, intent(out) :: converged
+
+        type(chartmap_invert_ctx_t) :: ctx
+        type(fortnum_status_t) :: status
+        real(dp) :: rho0(1), rho(1), xc(3)
+
+        ctx%self => self
+        ctx%x_target = x
+        ctx%theta = u_guess(2)
+        ctx%zeta = u_guess(3)
+        if (self%has_spl_rz) ctx%zeta = atan2(x(2), x(1))
+        ctx%rho_lo = max(0.0_dp, u_guess(1) - chartmap_invert_edge_band)
+
+        rho0(1) = min(max(u_guess(1), ctx%rho_lo), 1.0_dp)
+        call multiroot_hybrid(chartmap_radial_fdf, 1, rho0, rho, status, &
+                              xtol=self%tol_newton, ftol=self%tol_newton, &
+                              max_iter=30, ctx=ctx)
+
+        u = [min(max(rho(1), 0.0_dp), 1.0_dp), ctx%theta, ctx%zeta]
+        call chartmap_eval_cart(self, u, xc)
+        res_norm = sqrt(sum((x - xc)**2))
+        ! Converged only when the residual is genuinely small along this fixed ray.
+        ! A point whose true (theta, phi) differ from the guess cannot be reached on
+        ! the held ray; its residual stays large and the caller falls to the 3-D
+        ! solve. The clamped-edge root is still returned for OUTSIDE classification.
+        converged = chartmap_root_located(self, u, res_norm)
+    end subroutine chartmap_invert_edge_1d
+
+    ! Interior 3-D solve in the pseudo-Cartesian chart w = (X, Y, phi). The callback
+    ! returns F = x(w) - x_target and the analytic Jacobian dF/dw built from
+    ! covariant_basis; multiroot_hybrid's Newton + line search drives it to a root.
+    ! Seed w from the warm guess with phi reseeded to the in-wedge geometric angle.
+    subroutine chartmap_invert_interior_3d(self, x, u_guess, u, res_norm, converged)
+        class(chartmap_coordinate_system_t), intent(in), target :: self
+        real(dp), intent(in) :: x(3)
+        real(dp), intent(in) :: u_guess(3)
+        real(dp), intent(out) :: u(3)
+        real(dp), intent(out) :: res_norm
+        logical, intent(out) :: converged
+
+        type(chartmap_invert_ctx_t) :: ctx
+        type(fortnum_status_t) :: status
+        real(dp) :: w0(3), w(3), phi_seed, xc(3)
+
+        phi_seed = u_guess(3)
+        if (self%has_spl_rz) phi_seed = atan2(x(2), x(1))
+
+        ctx%self => self
+        ctx%x_target = x
+        ctx%zeta_period = TWOPI/real(self%num_field_periods, dp)
+
+        w0(1) = u_guess(1)*cos(u_guess(2))
+        w0(2) = u_guess(1)*sin(u_guess(2))
+        w0(3) = phi_seed
+
+        call multiroot_hybrid(chartmap_invert_fdf, 3, w0, w, status, &
+                              xtol=self%tol_newton, ftol=self%tol_newton, &
+                              max_iter=60, ctx=ctx)
+
+        call chartmap_w_to_u(w, u)
+        call chartmap_eval_cart(self, u, xc)
+        res_norm = sqrt(sum((x - xc)**2))
+        ! Converged when the residual is at the chart tolerance or a small fraction of
+        ! a radial cell; a larger residual (a genuine stall or a past-edge target the
+        ! line search pinned at rho=1) falls through to the cold multi-seed, while the
+        ! best root is still returned for classification.
+        converged = chartmap_root_located(self, u, res_norm)
+    end subroutine chartmap_invert_interior_3d
+
+    ! Cold multi-seed fallback: reuse the robust zeta-swept chartmap_invert_cart so a
+    ! warm guess stale across a seam still locates. Returns the residual for
+    ! classification; converged flags a genuine locate.
+    subroutine chartmap_invert_cold(self, x, u, res_norm, converged)
+        class(chartmap_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: x(3)
+        real(dp), intent(out) :: u(3)
+        real(dp), intent(out) :: res_norm
+        logical, intent(out) :: converged
+
+        real(dp) :: xc(3)
+        integer :: ierr
+
+        converged = .false.
+        res_norm = huge(1.0_dp)
+        u = 0.0_dp
+        call chartmap_invert_cart(self, x, u, ierr)
+        if (ierr /= chartmap_from_cyl_ok) return
+        call chartmap_eval_cart(self, u, xc)
+        res_norm = sqrt(sum((x - xc)**2))
+        converged = chartmap_root_located(self, u, res_norm)
+    end subroutine chartmap_invert_cold
+
+    ! A root is located when its Cartesian residual is at the absolute tolerance or a
+    ! small fraction of the local radial cell |dx/drho|. The relative test is what
+    ! keeps this scale-correct near the axis and on reactor-size charts.
+    logical function chartmap_root_located(self, u, res_norm) result(located)
+        class(chartmap_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(in) :: res_norm
+        real(dp) :: rscale
+        rscale = chartmap_radial_scale(self, u)
+        located = res_norm < chartmap_invert_accept_tol .or. &
+                  (rscale > 0.0_dp .and. res_norm < chartmap_invert_edge_frac*rscale)
+    end function chartmap_root_located
+
+    ! fortnum multiroot callback: F(w) = x(w) - x_target with the analytic Jacobian
+    ! dF/dw = pseudo-Cartesian Jacobian Jw built from covariant_basis. A trial with
+    ! rho = sqrt(X^2 + Y^2) > 1 is past the chart edge, where the forward map clamps
+    ! rho and would report a spuriously small residual on the flat clamped region; we
+    ! penalize it (large outward F) so the line search backtracks instead of
+    ! accepting the clamped-edge point. This replicates the over-edge rejection the
+    ! full-orbit Newton hand-rolled.
+    subroutine chartmap_invert_fdf(w, f, jac, ctx)
+        real(dp), intent(in) :: w(:)
+        real(dp), intent(out) :: f(:)
+        real(dp), intent(out) :: jac(:, :)
+        class(*), intent(in), optional :: ctx
+
+        real(dp) :: u(3), e_cov(3, 3), jw(3, 3), xc(3), cth, sth, rho
+        real(dp), parameter :: edge_penalty = 1.0e6_dp
+        integer :: i
+
+        f = 0.0_dp
+        jac = 0.0_dp
+        do i = 1, 3
+            jac(i, i) = 1.0_dp
+        end do
+        if (.not. present(ctx)) return
+
+        select type (ctx)
+        type is (chartmap_invert_ctx_t)
+            call chartmap_w_to_u(w, u)
+            rho = u(1)
+            if (rho > 1.0_dp) then
+                ! Penalize past-edge trials along the outward radial direction so the
+                ! Armijo step shrinks; keep the identity Jacobian as a safe descent.
+                f = 0.0_dp
+                f(1) = edge_penalty*(rho - 1.0_dp)
+                return
+            end if
+            call chartmap_eval_cart(ctx%self, u, xc)
+            f = xc - ctx%x_target
+            call chartmap_covariant_basis(ctx%self, u, e_cov)
+            call chartmap_pseudocart_basis(u, e_cov, jw, cth, sth)
+            jac = jw
+        end select
+    end subroutine chartmap_invert_fdf
+
+    ! fortnum n=1 multiroot callback for the bracketed edge solve: the residual
+    ! projected on the outward radial direction along the fixed (theta, phi) ray and
+    ! its 1x1 Jacobian. f = (x(rho) - x_target) . rhat, rhat = e_rho/|e_rho|, with
+    ! e_rho = dx/drho the covariant radial column (analytic); jac(1,1) = e_rho . rhat
+    ! is the dominant radial sensitivity, the off-ray curvature being second order.
+    ! The bracket [rho_lo, 1] is enforced here: rho > 1 is penalized (large outward
+    ! residual) so the line search backtracks, replicating the upper bracket bound.
+    subroutine chartmap_radial_fdf(w, f, jac, ctx)
+        real(dp), intent(in) :: w(:)
+        real(dp), intent(out) :: f(:)
+        real(dp), intent(out) :: jac(:, :)
+        class(*), intent(in), optional :: ctx
+
+        real(dp) :: u(3), xc(3), e_cov(3, 3), e_rho(3), rhat(3), e_norm, rho
+        real(dp), parameter :: edge_penalty = 1.0e6_dp
+
+        f = 0.0_dp
+        jac(1, 1) = 1.0_dp
+        if (.not. present(ctx)) return
+
+        select type (ctx)
+        type is (chartmap_invert_ctx_t)
+            rho = w(1)
+            if (rho > 1.0_dp) then
+                f(1) = edge_penalty*(rho - 1.0_dp)
+                return
+            end if
+            rho = max(rho, ctx%rho_lo)
+            u = [rho, ctx%theta, ctx%zeta]
+            call chartmap_eval_cart(ctx%self, u, xc)
+            call chartmap_covariant_basis(ctx%self, u, e_cov)
+            e_rho = e_cov(:, 1)
+            e_norm = sqrt(sum(e_rho**2))
+            if (e_norm < 1.0e-30_dp) then
+                rhat = 0.0_dp
+            else
+                rhat = e_rho/e_norm
+            end if
+            f(1) = dot_product(xc - ctx%x_target, rhat)
+            jac(1, 1) = dot_product(e_rho, rhat)
+        end select
+    end subroutine chartmap_radial_fdf
+
+    ! Pseudo-Cartesian near-axis chart basis. w = (X, Y, phi) = (rho cos theta,
+    ! rho sin theta, phi). The polar covariant column e_cov(:,2) = dx/dtheta ~ rho
+    ! vanishes at the axis (det -> 0); the (X, Y) columns built by the chain rule of
+    ! X, Y stay finite because dx/dtheta ~ rho cancels the 1/rho. Returns the regular
+    ! chart Jacobian jw(a,i) = dx_a/dw_i and the trig used to map field components.
+    ! Map geometry shared by the inverse solve and the field assembly.
+    subroutine chartmap_pseudocart_basis(u, e_cov, jw, cth, sth)
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(in) :: e_cov(3, 3)
+        real(dp), intent(out) :: jw(3, 3)
+        real(dp), intent(out) :: cth, sth
+        real(dp) :: rho
+        integer :: a
+
+        rho = max(u(1), 1.0e-30_dp)
+        cth = cos(u(2))
+        sth = sin(u(2))
+        do a = 1, 3
+            jw(a, 1) = e_cov(a, 1)*cth - e_cov(a, 2)*(sth/rho)   ! dx/dX
+            jw(a, 2) = e_cov(a, 1)*sth + e_cov(a, 2)*(cth/rho)   ! dx/dY
+            jw(a, 3) = e_cov(a, 3)                               ! dx/dphi
+        end do
+    end subroutine chartmap_pseudocart_basis
+
+    ! Pseudo-Cartesian w = (X, Y, phi) -> logical u = (rho, theta, phi). rho >= 0 and
+    ! the atan2 branch make the axis an ordinary point (no reflect hack).
+    pure subroutine chartmap_w_to_u(w, u)
+        real(dp), intent(in) :: w(3)
+        real(dp), intent(out) :: u(3)
+        u(1) = sqrt(w(1)**2 + w(2)**2)
+        u(2) = atan2(w(2), w(1))
+        u(3) = w(3)
+    end subroutine chartmap_w_to_u
+
+    ! Length of one unit-rho radial step |dx/drho| = |e_cov(:,1)|, the chart scale
+    ! that sizes a residual: a residual a small fraction of a radial cell means the
+    ! target is essentially located; a large fraction is an interior stall.
+    real(dp) function chartmap_radial_scale(self, u) result(s)
+        class(chartmap_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp) :: e_cov(3, 3)
+        call chartmap_covariant_basis(self, u, e_cov)
+        s = sqrt(e_cov(1, 1)**2 + e_cov(2, 1)**2 + e_cov(3, 1)**2)
+    end function chartmap_radial_scale
+
+    ! Classify a converged root from its radius and residual against the local
+    ! radial cell. Interior at tolerance -> LOCATED; an edge-clamped root within a
+    ! cell fraction -> CLAMPED_EDGE; a larger residual at rho = 1 -> OUTSIDE.
+    pure integer function chartmap_classify_root(rho, res_norm, rscale) result(status)
+        real(dp), intent(in) :: rho, res_norm, rscale
+        logical :: located, at_edge
+
+        located = res_norm < chartmap_invert_accept_tol .or. &
+                  (rscale > 0.0_dp .and. res_norm < chartmap_invert_edge_frac*rscale)
+        at_edge = rho >= 1.0_dp - chartmap_invert_edge_frac
+
+        if (located .and. .not. at_edge) then
+            status = CHARTMAP_LOCATED
+        else if (located .and. at_edge) then
+            status = CHARTMAP_CLAMPED_EDGE
+        else if (at_edge) then
+            status = CHARTMAP_OUTSIDE
+        else
+            status = CHARTMAP_NO_ROOT
+        end if
+    end function chartmap_classify_root
 
     subroutine chartmap_invert_cart(self, x_target, u, ierr)
         class(chartmap_coordinate_system_t), intent(in) :: self

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -219,6 +219,9 @@ target_link_libraries(test_chartmap_validator.x neo)
 add_executable(test_chartmap_boozer_coordinates.x source/test_chartmap_boozer_coordinates.f90)
 target_link_libraries(test_chartmap_boozer_coordinates.x neo ${MAGFIE_LIB})
 
+add_executable(test_chartmap_invert_cart.x source/test_chartmap_invert_cart.f90)
+target_link_libraries(test_chartmap_invert_cart.x neo ${MAGFIE_LIB})
+
 # TODO: Update test for new psi_1..psi_7 interface
 # add_executable(test_analytical_gs_circular.x source/test_analytical_gs_circular.f90)
 # target_link_libraries(test_analytical_gs_circular.x ${MAGFIE_LIB} ${COMMON_LIBS})
@@ -462,6 +465,12 @@ set_tests_properties(test_chartmap_validator PROPERTIES
 add_test(NAME test_chartmap_boozer_coordinates
   COMMAND test_chartmap_boozer_coordinates.x)
 set_tests_properties(test_chartmap_boozer_coordinates PROPERTIES
+  FAIL_REGULAR_EXPRESSION "STOP"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_test(NAME test_chartmap_invert_cart
+  COMMAND test_chartmap_invert_cart.x)
+set_tests_properties(test_chartmap_invert_cart PROPERTIES
   FAIL_REGULAR_EXPRESSION "STOP"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/test/source/test_chartmap_invert_cart.f90
+++ b/test/source/test_chartmap_invert_cart.f90
@@ -1,0 +1,347 @@
+program test_chartmap_invert_cart
+    ! Behavioral test for cs%invert_cart, the warm Cartesian inverse of the chartmap
+    ! coordinate system. Writes a self-contained reactor-scale Boozer chartmap
+    ! (no map2disc dependency), then checks that:
+    !   - evaluate_cart(u0) -> invert_cart recovers an interior u0 to tolerance and
+    !     reports CHARTMAP_LOCATED, for interior, near-axis (rho ~ 1e-3), and seam
+    !     (zeta near a field-period boundary) points;
+    !   - a point on the last closed surface (rho = 1) reports CHARTMAP_CLAMPED_EDGE;
+    !   - a target built past the last surface (rho > 1, which the forward map cannot
+    !     represent) reports CHARTMAP_OUTSIDE, never a spurious interior root;
+    !   - an axis point (rho ~ 0) is handled by the X/Y regularization (no NaN, theta
+    !     recovered modulo the axis gauge).
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use libneo_coordinates, only: coordinate_system_t, chartmap_coordinate_system_t, &
+        make_chartmap_coordinate_system, BOOZER, &
+        CHARTMAP_LOCATED, CHARTMAP_CLAMPED_EDGE, &
+        CHARTMAP_OUTSIDE, CHARTMAP_NO_ROOT
+    use math_constants, only: TWOPI
+    use netcdf
+    implicit none
+
+    character(len=*), parameter :: filename = "chartmap_invert.nc"
+    integer :: nerrors
+
+    nerrors = 0
+
+    call write_boozer_file(filename)
+    call run_invert_checks(filename, nerrors)
+
+    if (nerrors > 0) then
+        print *, "FAILED: ", nerrors, " error(s) detected in invert_cart tests"
+        error stop 1
+    end if
+
+    print *, "All chartmap invert_cart tests passed!"
+
+contains
+
+    subroutine nc_check(status)
+        integer, intent(in) :: status
+        if (status /= NF90_NOERR) then
+            print *, trim(nf90_strerror(status))
+            error stop 2
+        end if
+    end subroutine nc_check
+
+    pure real(dp) function angular_diff(a, b, period)
+        real(dp), intent(in) :: a, b, period
+        angular_diff = abs(modulo(a - b + 0.5_dp*period, period) - 0.5_dp*period)
+    end function angular_diff
+
+    subroutine run_invert_checks(path, nerrors)
+        character(len=*), intent(in) :: path
+        integer, intent(inout) :: nerrors
+
+        class(coordinate_system_t), allocatable :: cs
+        real(dp) :: zeta_period
+
+        call make_chartmap_coordinate_system(cs, path)
+
+        select type (ccs => cs)
+            type is (chartmap_coordinate_system_t)
+            if (ccs%zeta_convention /= BOOZER) then
+                print *, "  FAIL: expected BOOZER zeta convention"
+                nerrors = nerrors + 1
+                return
+            end if
+            zeta_period = TWOPI/real(ccs%num_field_periods, dp)
+
+            call check_interior_roundtrip(ccs, zeta_period, nerrors)
+            call check_seam_roundtrip(ccs, zeta_period, nerrors)
+            call check_near_axis(ccs, zeta_period, nerrors)
+            call check_axis(ccs, zeta_period, nerrors)
+            call check_edge(ccs, zeta_period, nerrors)
+            call check_outside(ccs, zeta_period, nerrors)
+        class default
+            print *, "  FAIL: chartmap file did not load as chartmap type"
+            nerrors = nerrors + 1
+        end select
+    end subroutine run_invert_checks
+
+    ! Interior points across zeta slices: evaluate_cart(u0) -> invert_cart recovers
+    ! u0 to tolerance with status LOCATED. The warm guess is offset from u0 so the
+    ! solver does real work rather than starting on the root.
+    subroutine check_interior_roundtrip(ccs, zeta_period, nerrors)
+        type(chartmap_coordinate_system_t), intent(in), target :: ccs
+        real(dp), intent(in) :: zeta_period
+        integer, intent(inout) :: nerrors
+        real(dp) :: u0(3), x(3), u(3), u_guess(3)
+        real(dp) :: dth, dze
+        integer :: ir, it, iz, status, nfail
+        real(dp), parameter :: rho_vals(3) = [0.18_dp, 0.52_dp, 0.86_dp]
+        real(dp), parameter :: theta_vals(3) = [0.4_dp, 2.6_dp, 5.1_dp]
+        real(dp), parameter :: zeta_fracs(3) = [0.1_dp, 0.45_dp, 0.8_dp]
+        real(dp), parameter :: tol = 1.0e-6_dp
+
+        nfail = 0
+        do iz = 1, size(zeta_fracs)
+            do it = 1, size(theta_vals)
+                do ir = 1, size(rho_vals)
+                    u0 = [rho_vals(ir), theta_vals(it), zeta_fracs(iz)*zeta_period]
+                    call ccs%evaluate_cart(u0, x)
+                    u_guess = [u0(1) + 0.07_dp, u0(2) + 0.15_dp, u0(3) - 0.05_dp]
+                    call ccs%invert_cart(x, u_guess, u, status)
+
+                    dth = angular_diff(u(2), u0(2), TWOPI)
+                    dze = angular_diff(u(3), u0(3), zeta_period)
+                    if (status /= CHARTMAP_LOCATED .or. abs(u(1) - u0(1)) > tol .or. &
+                        dth > tol .or. dze > tol) then
+                        print *, "  FAIL: interior roundtrip u0=", u0
+                        print *, "        u=", u, " status=", status
+                        nfail = nfail + 1
+                    end if
+                end do
+            end do
+        end do
+        nerrors = nerrors + nfail
+        if (nfail == 0) print *, "  PASS: interior roundtrip recovers u0, LOCATED"
+    end subroutine check_interior_roundtrip
+
+    ! Seam points: zeta within a small fraction of a field-period boundary, where a
+    ! global Boozer phi guess would be a full period stale. invert_cart reseeds the
+    ! toroidal angle and must still locate.
+    subroutine check_seam_roundtrip(ccs, zeta_period, nerrors)
+        type(chartmap_coordinate_system_t), intent(in), target :: ccs
+        real(dp), intent(in) :: zeta_period
+        integer, intent(inout) :: nerrors
+        real(dp) :: u0(3), x(3), u(3), u_guess(3)
+        real(dp) :: dth, dze
+        integer :: k, status, nfail
+        real(dp), parameter :: seam_fracs(3) = [0.0_dp, 0.999_dp, 0.5_dp]
+        real(dp), parameter :: tol = 1.0e-6_dp
+
+        nfail = 0
+        do k = 1, size(seam_fracs)
+            u0 = [0.6_dp, 1.3_dp, seam_fracs(k)*zeta_period]
+            call ccs%evaluate_cart(u0, x)
+            ! Warm guess carries a stale phi one period ahead, as across a seam.
+            u_guess = [u0(1), u0(2), u0(3) + zeta_period]
+            call ccs%invert_cart(x, u_guess, u, status)
+            dth = angular_diff(u(2), u0(2), TWOPI)
+            dze = angular_diff(u(3), u0(3), zeta_period)
+            if (status /= CHARTMAP_LOCATED .or. abs(u(1) - u0(1)) > tol .or. &
+                dth > tol .or. dze > tol) then
+                print *, "  FAIL: seam roundtrip u0=", u0, " u=", u, " status=", status
+                nfail = nfail + 1
+            end if
+        end do
+        nerrors = nerrors + nfail
+        if (nfail == 0) print *, "  PASS: seam roundtrip with stale phi guess, LOCATED"
+    end subroutine check_seam_roundtrip
+
+    ! Near-axis points (rho ~ 1e-3): the polar chart is singular but the X/Y chart is
+    ! regular. The radius must be recovered; theta is a near-degenerate gauge there,
+    ! so only rho and the Cartesian round-trip are asserted.
+    subroutine check_near_axis(ccs, zeta_period, nerrors)
+        type(chartmap_coordinate_system_t), intent(in), target :: ccs
+        real(dp), intent(in) :: zeta_period
+        integer, intent(inout) :: nerrors
+        real(dp) :: u0(3), x(3), u(3), u_guess(3), x_back(3)
+        integer :: k, status, nfail
+        real(dp), parameter :: rho_vals(2) = [1.0e-3_dp, 5.0e-3_dp]
+        real(dp), parameter :: tol_rho = 1.0e-5_dp, tol_x = 1.0e-4_dp
+
+        nfail = 0
+        do k = 1, size(rho_vals)
+            u0 = [rho_vals(k), 2.1_dp, 0.3_dp*zeta_period]
+            call ccs%evaluate_cart(u0, x)
+            u_guess = [rho_vals(k) + 0.02_dp, 1.0_dp, 0.3_dp*zeta_period]
+            call ccs%invert_cart(x, u_guess, u, status)
+            call ccs%evaluate_cart(u, x_back)
+            if (status /= CHARTMAP_LOCATED .or. abs(u(1) - u0(1)) > tol_rho .or. &
+                maxval(abs(x_back - x)) > tol_x) then
+                print *, "  FAIL: near-axis rho=", rho_vals(k), " u=", u, &
+                    " status=", status, " dx=", maxval(abs(x_back - x))
+                nfail = nfail + 1
+            end if
+        end do
+        nerrors = nerrors + nfail
+        if (nfail == 0) print *, "  PASS: near-axis rho recovered via X/Y healing"
+    end subroutine check_near_axis
+
+    ! Axis point (rho = 0): the X/Y regularization must return a finite u with rho
+    ! near 0 and a Cartesian round-trip back to the axis, with no NaN.
+    subroutine check_axis(ccs, zeta_period, nerrors)
+        type(chartmap_coordinate_system_t), intent(in), target :: ccs
+        real(dp), intent(in) :: zeta_period
+        integer, intent(inout) :: nerrors
+        real(dp) :: u0(3), x(3), u(3), u_guess(3), x_back(3)
+        integer :: status
+
+        u0 = [0.0_dp, 0.0_dp, 0.25_dp*zeta_period]
+        call ccs%evaluate_cart(u0, x)
+        u_guess = [0.05_dp, 1.0_dp, 0.25_dp*zeta_period]
+        call ccs%invert_cart(x, u_guess, u, status)
+        call ccs%evaluate_cart(u, x_back)
+        if (status == CHARTMAP_NO_ROOT .or. u(1) /= u(1) .or. &
+            u(1) > 1.0e-2_dp .or. maxval(abs(x_back - x)) > 1.0e-4_dp) then
+            print *, "  FAIL: axis point u=", u, " status=", status, &
+                " dx=", maxval(abs(x_back - x))
+            nerrors = nerrors + 1
+        else
+            print *, "  PASS: axis point handled by X/Y regularization"
+        end if
+    end subroutine check_axis
+
+    ! Edge point exactly on the last closed surface (rho = 1): the warm guess is also
+    ! at the edge, so the bracketed radial solve pins rho to 1 and reports
+    ! CHARTMAP_CLAMPED_EDGE with the residual at tolerance.
+    subroutine check_edge(ccs, zeta_period, nerrors)
+        type(chartmap_coordinate_system_t), intent(in), target :: ccs
+        real(dp), intent(in) :: zeta_period
+        integer, intent(inout) :: nerrors
+        real(dp) :: u0(3), x(3), u(3), u_guess(3)
+        integer :: status
+
+        u0 = [1.0_dp, 1.7_dp, 0.4_dp*zeta_period]
+        call ccs%evaluate_cart(u0, x)
+        u_guess = [0.97_dp, 1.7_dp, 0.4_dp*zeta_period]
+        call ccs%invert_cart(x, u_guess, u, status)
+        if (status /= CHARTMAP_LOCATED .and. status /= CHARTMAP_CLAMPED_EDGE) then
+            print *, "  FAIL: edge point status=", status, " u=", u
+            nerrors = nerrors + 1
+        else if (abs(u(1) - 1.0_dp) > 1.0e-4_dp) then
+            print *, "  FAIL: edge point rho not at 1, u=", u
+            nerrors = nerrors + 1
+        else
+            print *, "  PASS: last-surface point located at the edge"
+        end if
+    end subroutine check_edge
+
+    ! Target built past the last closed surface: take the boundary point and push it
+    ! outward along its outward radial direction by a sizable fraction of a radial
+    ! cell. The forward map cannot represent rho > 1, so the best root clamps to
+    ! rho = 1 with a residual a large fraction of a cell -> CHARTMAP_OUTSIDE.
+    subroutine check_outside(ccs, zeta_period, nerrors)
+        type(chartmap_coordinate_system_t), intent(in), target :: ccs
+        real(dp), intent(in) :: zeta_period
+        integer, intent(inout) :: nerrors
+        real(dp) :: u0(3), x_edge(3), x(3), u(3), u_guess(3)
+        real(dp) :: e_cov(3, 3), e_rho(3), e_norm
+        integer :: status
+
+        u0 = [1.0_dp, 0.9_dp, 0.6_dp*zeta_period]
+        call ccs%evaluate_cart(u0, x_edge)
+        call ccs%covariant_basis(u0, e_cov)
+        e_rho = e_cov(:, 1)
+        e_norm = sqrt(sum(e_rho**2))
+        ! Half a radial cell past the boundary: well outside the LOCATED/CLAMPED band.
+        x = x_edge + 0.5_dp*e_rho
+        u_guess = [0.98_dp, 0.9_dp, 0.6_dp*zeta_period]
+        call ccs%invert_cart(x, u_guess, u, status)
+        if (status /= CHARTMAP_OUTSIDE) then
+            print *, "  FAIL: past-edge target status=", status, " (want OUTSIDE)"
+            print *, "        u=", u
+            nerrors = nerrors + 1
+        else if (abs(u(1) - 1.0_dp) > 1.0e-4_dp) then
+            print *, "  FAIL: past-edge target rho not clamped to 1, u=", u
+            nerrors = nerrors + 1
+        else
+            print *, "  PASS: past-edge target reports OUTSIDE, rho clamped to 1"
+        end if
+    end subroutine check_outside
+
+    ! Reactor-scale synthetic Boozer chartmap, nfp = 3, with a genuinely
+    ! non-cylindrical toroidal angle so the inverse exercises the Boozer-phi reseed.
+    ! Same construction as test_chartmap_boozer_coordinates so the fixture needs no
+    ! external generator.
+    subroutine write_boozer_file(path)
+        character(len=*), intent(in) :: path
+
+        integer :: ncid
+        integer :: dim_rho, dim_theta, dim_zeta
+        integer :: var_rho, var_theta, var_zeta, var_x, var_y, var_z, var_nfp
+        integer, parameter :: nrho = 9, ntheta = 11, nzeta = 10, nfp = 3
+        real(dp), parameter :: r0 = 180.0_dp
+        real(dp), parameter :: a = 45.0_dp
+        real(dp) :: rho(nrho), theta(ntheta), zeta(nzeta)
+        real(dp) :: x(nrho, ntheta, nzeta), y(nrho, ntheta, nzeta), &
+            z(nrho, ntheta, nzeta)
+        real(dp) :: rho_val, theta_val, zeta_val
+        real(dp) :: phi_geom, rmaj, zpos, period
+        integer :: ir, it, iz
+
+        period = TWOPI/real(nfp, dp)
+
+        do ir = 1, nrho
+            rho(ir) = real(ir - 1, dp)/real(nrho - 1, dp)
+        end do
+        do it = 1, ntheta
+            theta(it) = TWOPI*real(it - 1, dp)/real(ntheta, dp)
+        end do
+        do iz = 1, nzeta
+            zeta(iz) = period*real(iz - 1, dp)/real(nzeta, dp)
+        end do
+
+        do iz = 1, nzeta
+            zeta_val = zeta(iz)
+            do it = 1, ntheta
+                theta_val = theta(it)
+                do ir = 1, nrho
+                    rho_val = rho(ir)
+                    phi_geom = zeta_val + 0.08_dp*rho_val*sin(theta_val) + &
+                        0.02_dp*sin(2.0_dp*zeta_val)
+                    rmaj = r0 + a*rho_val*cos(theta_val) + &
+                        0.04_dp*a*rho_val*cos(theta_val - 2.0_dp*zeta_val)
+                    zpos = a*rho_val*sin(theta_val) + &
+                        0.02_dp*a*rho_val*sin(zeta_val)
+
+                    x(ir, it, iz) = rmaj*cos(phi_geom)
+                    y(ir, it, iz) = rmaj*sin(phi_geom)
+                    z(ir, it, iz) = zpos
+                end do
+            end do
+        end do
+
+        call nc_check(nf90_create(trim(path), NF90_NETCDF4, ncid))
+        call nc_check(nf90_put_att(ncid, NF90_GLOBAL, "zeta_convention", "boozer"))
+        call nc_check(nf90_def_dim(ncid, "rho", nrho, dim_rho))
+        call nc_check(nf90_def_dim(ncid, "theta", ntheta, dim_theta))
+        call nc_check(nf90_def_dim(ncid, "zeta", nzeta, dim_zeta))
+        call nc_check(nf90_def_var(ncid, "rho", NF90_DOUBLE, [dim_rho], var_rho))
+        call nc_check(nf90_def_var(ncid, "theta", NF90_DOUBLE, [dim_theta], var_theta))
+        call nc_check(nf90_def_var(ncid, "zeta", NF90_DOUBLE, [dim_zeta], var_zeta))
+        call nc_check(nf90_def_var(ncid, "x", NF90_DOUBLE, &
+            [dim_rho, dim_theta, dim_zeta], var_x))
+        call nc_check(nf90_def_var(ncid, "y", NF90_DOUBLE, &
+            [dim_rho, dim_theta, dim_zeta], var_y))
+        call nc_check(nf90_def_var(ncid, "z", NF90_DOUBLE, &
+            [dim_rho, dim_theta, dim_zeta], var_z))
+        call nc_check(nf90_def_var(ncid, "num_field_periods", NF90_INT, var_nfp))
+        call nc_check(nf90_put_att(ncid, var_x, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_y, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_z, "units", "cm"))
+        call nc_check(nf90_enddef(ncid))
+
+        call nc_check(nf90_put_var(ncid, var_rho, rho))
+        call nc_check(nf90_put_var(ncid, var_theta, theta))
+        call nc_check(nf90_put_var(ncid, var_zeta, zeta))
+        call nc_check(nf90_put_var(ncid, var_x, x))
+        call nc_check(nf90_put_var(ncid, var_y, y))
+        call nc_check(nf90_put_var(ncid, var_z, z))
+        call nc_check(nf90_put_var(ncid, var_nfp, nfp))
+        call nc_check(nf90_close(ncid))
+    end subroutine write_boozer_file
+
+end program test_chartmap_invert_cart


### PR DESCRIPTION
## What

Add a type-bound `cs%invert_cart(x, u_guess, u, geom_status)` to the chartmap
coordinate system: the warm single-point Cartesian inverse the full-orbit
pusher needs, ported onto fortnum's released solvers, with the map geometry
owned by the chart and loss policy left to the caller.

- **Interior solve**: `multiroot_hybrid` in the pseudo-Cartesian chart
  `w = (X, Y, phi) = (rho cos theta, rho sin theta, phi)` with the **analytic
  Jacobian** from `covariant_basis` (no finite differences). The `(X, Y)` chart
  is regular through the magnetic axis where the polar Jacobian
  `dx/dtheta ~ rho` makes `det(Jc) -> 0`.
- **Near-edge solve**: a bracketed 1-D radial solve (`multiroot_hybrid` at
  `n = 1`) along the seeded `(theta, phi)` ray, with the bracket `[rho_lo, 1]`
  enforced in the callback so the radius cannot overshoot past 1. A marker
  leaving the plasma stalls cleanly on the clamped edge instead of grinding.
- **Cold multi-seed fallback** for seam-stale guesses; the orchestrator keeps
  the lowest-residual root across paths.

Map-specific geometry moves into the chart: `chartmap_pseudocart_basis`
(polar -> (X,Y) chain rule), `chartmap_w_to_u` (X/Y axis regularization),
`chartmap_radial_scale` (`|dx/drho|`).

`geom_status` is **geometric only** (`CHARTMAP_LOCATED` / `CHARTMAP_CLAMPED_EDGE`
/ `CHARTMAP_OUTSIDE` / `CHARTMAP_NO_ROOT`) and never encodes a confinement loss;
that decision stays with the caller (in SIMPLE, the guiding-centre test).

## Why

The full-orbit Boris pusher in SIMPLE hand-rolled a damped Newton with a
backtracking line search to invert the chartmap every microstep. The inverse
is a property of the chart, so it belongs with the chart, and the generic
iteration belongs in fortnum. This PR is the libneo half: a chart-owned
inverse on fortnum solvers. The near-edge bracket removes the line-search
overshoot-into-the-clamp that made near-loss markers expensive. SIMPLE adopts
this in a separate change and keeps its loss policy unchanged.

## Verification

`fo check`: build and tests pass. Full `fo` pipeline: Static OK (43 modules),
Build OK, Lint OK.

New behavioral test `test_chartmap_invert_cart` (ctest #48) passes all six
checks: interior roundtrip LOCATED; seam roundtrip with stale phi LOCATED;
near-axis rho recovered via X/Y healing; axis point handled; last-surface point
CLAMPED_EDGE; past-edge target OUTSIDE with rho clamped to 1.

Pre-existing failures, not introduced here: 11 ctest cases
(`setup_chartmap_volume`, `setup_vmec_chartmap_python` and the fixture-gated
tests that consume their output) fail because the system Python the test runner
uses lacks the `map2disc` module (installed only in the project `.venv`), so the
chartmap/vmec fixtures are never generated. Confirmed identical on pristine
HEAD before any edit; none touch the `invert_cart` code path. Pointing the
runner at the project `.venv` is tracked as a follow-up.

## Follow-ups (not in this PR)

- SIMPLE side: rewrite `invert_cart_warm` as a thin loss-policy shell over
  `cs%invert_cart` (map `geom_status -> FO_OK/FO_LOCATE_FAIL` via
  `accept_or_fail`, keep `fo_to_gc`'s guiding-centre loss test, the #427
  contract), then delete the duplicated SIMPLE-side inversion routines. Gate on
  the FO golden-record / W7-X confined-fraction benchmark.
- Optionally surface `res_norm`/`radial_scale` from `cs%invert_cart` so the
  caller classifies without re-evaluating the map.
- Point the libneo test runner's Python at the project `.venv` so the 11
  fixture-gated chartmap tests run.
