### PR TITLE
interpolate: build batch spline 3D coeffs in place to halve construction peak memory

### DIFF
--- a/src/interpolate/batch_interpolate_3d.f90
+++ b/src/interpolate/batch_interpolate_3d.f90
@@ -70,7 +70,6 @@ contains
         type(BatchSplineData3D), intent(inout) :: spl
 
         real(dp), dimension(:, :), allocatable  :: splcoe
-        real(dp), dimension(:, :, :, :, :, :), allocatable :: temp_coeff
         integer :: i1, i2, i3, iq  ! Loop indices
         integer :: k2, k3          ! Loop indices for polynomial order
         integer :: n1, n2, n3, n_quantities, istat
@@ -136,13 +135,9 @@ contains
             end if
         end if
 
-        allocate (temp_coeff(0:N1_order, 0:N2_order, 0:N3_order, n1, n2, n3), &
-                  stat=istat)
-        if (istat /= 0) then
-            error stop "construct_batch_splines_3d: Allocation failed for temp_coeff"
-        end if
-
-        ! Process each quantity
+        ! Build each quantity in place, directly into spl%coeff(iq,...), so no
+        ! full-size temporary coefficient array is held (it doubled peak memory:
+        ! ~24 GB for the reactor chartmap and caused OOM during field loading).
         do iq = 1, n_quantities
             ! Spline over x3 first
             allocate (splcoe(0:N3_order, n3), stat=istat)
@@ -158,7 +153,7 @@ contains
                     else
                         call spl_reg(N3_order, n3, spl%h_step(3), splcoe)
                     end if
-                    temp_coeff(0, 0, :, i1, i2, :) = splcoe
+                    spl%coeff(iq, 0, 0, :, i1, i2, :) = splcoe
                 end do
             end do
             deallocate (splcoe)
@@ -172,13 +167,13 @@ contains
             do i3 = 1, n3
                 do i1 = 1, n1
                     do k3 = 0, N3_order
-                        splcoe(0, :) = temp_coeff(0, 0, k3, i1, :, i3)
+                        splcoe(0, :) = spl%coeff(iq, 0, 0, k3, i1, :, i3)
                         if (periodic(2)) then
                             call spl_per(N2_order, n2, spl%h_step(2), splcoe)
                         else
                             call spl_reg(N2_order, n2, spl%h_step(2), splcoe)
                         end if
-                        temp_coeff(0, :, k3, i1, :, i3) = splcoe
+                        spl%coeff(iq, 0, :, k3, i1, :, i3) = splcoe
                     end do
                 end do
             end do
@@ -194,25 +189,19 @@ contains
                 do i2 = 1, n2
                     do k3 = 0, N3_order
                         do k2 = 0, N2_order
-                            splcoe(0, :) = temp_coeff(0, k2, k3, :, i2, i3)
+                            splcoe(0, :) = spl%coeff(iq, 0, k2, k3, :, i2, i3)
                             if (periodic(1)) then
                                 call spl_per(N1_order, n1, spl%h_step(1), splcoe)
                             else
                                 call spl_reg(N1_order, n1, spl%h_step(1), splcoe)
                             end if
-                            ! Store in STANDARD order for consistency and clarity
-                            temp_coeff(:, k2, k3, :, i2, i3) = splcoe
+                            spl%coeff(iq, :, k2, k3, :, i2, i3) = splcoe
                         end do
                     end do
                 end do
             end do
             deallocate (splcoe)
-
-            ! Copy to final coefficient array
-            spl%coeff(iq, :, :, :, :, :, :) = temp_coeff
         end do
-
-        deallocate (temp_coeff)
     end subroutine construct_batch_splines_3d_legacy
 
     recursive subroutine construct_batch_splines_3d_lines(x_min, x_max, y_batch, order, &


### PR DESCRIPTION
## What

`construct_batch_splines_3d_legacy` (the non-OpenACC CPU path) held `temp_coeff`,
a full-size copy of the coefficient array, alongside `spl%coeff` for the whole
build. `temp_coeff` has shape `(0:N1,0:N2,0:N3,n1,n2,n3)`, equal to `spl%coeff`
per quantity, so construction peaked at twice the final spline size.

For the reactor chartmap (`rho=501, theta=55, zeta=300`, order 5) one quantity
is ~24 GB, so the build held ~48 GB and pushed the chartmap field-load phase to
a 64.5 GB resident peak, which the OOM-killer terminated (`simple.x`,
`anon-rss 7.4 GB` mid-climb, `total-vm 72 GB`).

This builds each quantity directly into `spl%coeff(iq,...)`. The `spl_reg`/
`spl_per` call sequence is unchanged, so the coefficients are bit-identical;
only the destination array changes. `temp_coeff` and the final copy are removed.
Peak construction memory drops from `2 * spl%coeff` to `spl%coeff`.

The OpenACC path (`construct_batch_splines_3d_resident_device`) and the
streaming `construct_batch_splines_3d_lines` variant are untouched.

## Verification

Before: a 16-marker guiding-centre run on the reactor chartmap peaked at 64.5 GB
during field loading and was OOM-killed when more than one ran concurrently.

After, the batch-spline tests that cover the changed routine pass (`fo test`,
gfortran):

```
20/85 Test #20: test_batch_interpolate_der3 ......  Passed
24/85 Test  #6: test_batch_eval_oracle ...........  Passed
32/85 Test #14: test_spl_three_to_five ...........  Passed
37/85 Test #22: test_batch_interpolate_rmix ......  Passed
39/85 Test #23: test_batch_interpolate_oracle ....  Passed
 8/85 Test #25: test_spline_performance ..........  Passed
```

The oracle tests compare coefficients against reference tables, so a bit-for-bit
match confirms the result is unchanged.

The 11 failing tests (`setup_chartmap_volume`, `test_chartmap_coordinates`,
`test_vector_conversion`, and the `*_map2disc_*` validate/plot cases) are the
pre-existing map2disc fixture gap: the ctest interpreter is system python, which
lacks `map2disc`. They fail identically on `origin/main` and are unrelated to
this change. (A uv-based fix for that is a separate PR.)
