### PR TITLE
Fix off-by-one radial grid in bc_to_booz_xform

### DIFF
--- a/python/libneo/bc_to_booz_xform.py
+++ b/python/libneo/bc_to_booz_xform.py
@@ -6,8 +6,10 @@ passed directly to convert_boozmn_to_chartmap.
 
 Radial staggering convention (matches booz_xform output):
   Full grid (ns points):  iota_b, buco_b, bvco_b, phi_b
-  Half grid (ns-2 points): bmnc_b, rmnc_b, zmns_b, pmns_b
-  jlist[k] = k+2  (1-based, half-grid surface k sits between full-grid k+1 and k+2)
+  Half grid (nsurf points): bmnc_b, rmnc_b, zmns_b, pmns_b
+  jlist and ns are chosen so the reader's reconstructed half-grid
+  s_half = (jlist - 1.5)/(ns - 1) reproduces the .bc surface labels bc.s
+  exactly, with each surface function placed at full-grid index jlist - 1.
 
 Unit conversions:
   .bc curr_pol/nper [A] -> bvco_b [T*m] = curr_pol/nper * nfp * mu_0 / (2*pi)
@@ -89,10 +91,31 @@ def write_boozmn(bc, output, source=None):
 
     nsurf = bc.nsurf
     nfp = bc.nper
-    ns = nsurf + 2  # axis (j=1) + nsurf half-grid + LCFS (j=ns)
 
-    # Half-grid surface indices (1-based): 2 .. ns-1
-    jlist = np.arange(2, ns, dtype=int)  # shape (nsurf,)
+    # The booz_xform reader reconstructs each half-grid surface as
+    # s_half = (jlist - 1.5)/(ns - 1) and samples the radial surface functions
+    # at full-grid index jlist - 1. Choose ns and jlist so that reconstruction
+    # reproduces the .bc surface labels bc.s exactly (no half/full-grid offset),
+    # and place the .bc surface-function values at jlist - 1 so the reader reads
+    # them back without resampling. This keeps the chartmap radially aligned with
+    # the .bc; any residual is plain interpolation error that shrinks with the
+    # chartmap grid, not a fixed off-by-one shift.
+    # .bc files store s to finite precision, so test uniformity and integer
+    # alignment within that rounding rather than to machine epsilon.
+    s_bc = np.array(bc.s, dtype=float)
+    ds = np.diff(s_bc)
+    ns = int(round(1.0 / np.mean(ds))) + 1
+    jlist_f = s_bc * (ns - 1) + 1.5
+    jlist = np.rint(jlist_f).astype(int)
+    if (np.ptp(ds) > 1e-2 * np.mean(ds)
+            or np.max(np.abs(jlist - jlist_f)) > 0.25
+            or jlist[0] < 2 or jlist[-1] > ns
+            or np.any(np.diff(jlist) != 1)):
+        raise ValueError(
+            "bc_to_booz_xform requires a uniform .bc s-grid that lands on the "
+            "booz_xform half-grid; resampling a non-uniform grid is not "
+            "implemented."
+        )
 
     # Build mode arrays from .bc.
     m0, n0, rmnc_h, zmns_h, pmns_h, bmnc_h, rmns_h, zmnc_h, bmns_h, lasym = (
@@ -101,26 +124,24 @@ def write_boozmn(bc, output, source=None):
     ixm = m0.astype(np.int32)
     ixn = (n0 * nfp).astype(np.int32)  # booz_xform stores n*nfp in ixn_b
 
-    # Surface functions on half grid from .bc.
-    s_half = np.array(bc.s, dtype=float)  # shape (nsurf,)
+    # Surface functions, defined on the .bc surfaces (= s_half).
     iota_h = np.array(bc.iota, dtype=float)
     bvco_h = np.array(bc.Jpol_divided_by_nper, dtype=float) * nfp * MU0 / TWOPI
     buco_h = np.array(bc.Itor, dtype=float) * MU0 / TWOPI
 
-    # Full-grid arrays by linear extrapolation from half grid (axis + LCFS).
+    # Full-grid arrays: put the true .bc value at jlist - 1 (where the reader
+    # samples it); fill the axis side by spline extrapolation (those entries are
+    # not read for the half-grid surfaces).
     from scipy.interpolate import CubicSpline
 
-    spl_iota = CubicSpline(s_half, iota_h, extrapolate=True)
-    spl_bvco = CubicSpline(s_half, bvco_h, extrapolate=True)
-    spl_buco = CubicSpline(s_half, buco_h, extrapolate=True)
-
-    # Full-grid s: 0, 1/(ns-1), 2/(ns-1), ..., 1
     s_full = np.linspace(0.0, 1.0, ns)
-    iota_full = spl_iota(s_full)
-    bvco_full = spl_bvco(s_full)
-    buco_full = spl_buco(s_full)
-    iota_full[0] = spl_iota(0.0)
-    bvco_full[0] = spl_bvco(0.0)
+    iota_full = CubicSpline(s_bc, iota_h, extrapolate=True)(s_full)
+    bvco_full = CubicSpline(s_bc, bvco_h, extrapolate=True)(s_full)
+    buco_full = CubicSpline(s_bc, buco_h, extrapolate=True)(s_full)
+    idx = jlist - 1
+    iota_full[idx] = iota_h
+    bvco_full[idx] = bvco_h
+    buco_full[idx] = buco_h
     buco_full[0] = 0.0   # zero poloidal current at axis
 
     # Toroidal flux: bc.flux is the edge value in T*m^2.

--- a/python/tests/test_bc_to_booz_xform.py
+++ b/python/tests/test_bc_to_booz_xform.py
@@ -91,8 +91,14 @@ def test_boozmn_structure(boozmn_path):
     assert d["ns"] == 65, f"expected ns=63+2=65, got {d['ns']}"
     assert d["nfp"] == 1, f"expected nfp=1, got {d['nfp']}"
     assert len(d["jlist"]) == 63, f"expected 63 half-grid surfaces"
-    assert d["jlist"][0] == 2, f"jlist[0]={d['jlist'][0]}, expected 2"
-    assert d["jlist"][-1] == 64, f"jlist[-1]={d['jlist'][-1]}, expected 64"
+    assert d["jlist"][0] == 3, f"jlist[0]={d['jlist'][0]}, expected 3"
+    assert d["jlist"][-1] == 65, f"jlist[-1]={d['jlist'][-1]}, expected 65"
+    # The reconstructed half-grid must land on the .bc surface labels, otherwise
+    # the chartmap is radially shifted by a fraction of a cell (off-by-one guard).
+    s_half = (d["jlist"] - 1.5) / (d["ns"] - 1)
+    assert abs(s_half[0] - 0.023438) < 1e-4 and abs(s_half[-1] - 0.992188) < 1e-4, (
+        f"s_half {s_half[0]:.6f}..{s_half[-1]:.6f} does not match the .bc surfaces"
+    )
 
 
 def test_boozmn_iota_range(boozmn_path):

--- a/python/tests/test_cross_path_field_equality.py
+++ b/python/tests/test_cross_path_field_equality.py
@@ -70,12 +70,12 @@ def chartmap_path(tmp_path_factory):
 
 
 def test_bmod_cross_path(chartmap_path):
-    """Bmod from .bc Fourier sum matches chartmap interpolation to 5e-3 relative.
+    """Bmod from .bc Fourier sum matches chartmap interpolation to 1e-4 relative.
 
-    The error budget: the booz_xform_to_boozer_chartmap spline in rho introduces
-    ~1-3e-3 error at mid-radius and up to 1% near the axis (s < 0.1) due to the
-    near-axis power-law extrapolation for non-zero poloidal modes.  Test points
-    are restricted to 0.2 < s < 0.9 where the error is bounded by 5e-3.
+    The radial grids are aligned to the .bc surfaces (bc_to_booz_xform chooses
+    jlist/ns so the reader's s_half reproduces bc.s), so the only residual is
+    plain interpolation plus the .bc's ~1e-5 s-storage precision.  Test points
+    are restricted to 0.2 < s < 0.9 where the error is below 1e-4.
     """
     import netCDF4
     from scipy.interpolate import RegularGridInterpolator
@@ -118,7 +118,7 @@ def test_bmod_cross_path(chartmap_path):
 
     for i in range(n_test):
         rel_err = abs(bmod_direct[i] - bmod_chartmap[i]) / abs(bmod_direct[i])
-        assert rel_err < 5e-3, (
+        assert rel_err < 1e-4, (
             f"point {i}: s={s_test[i]:.3f}, theta={theta_b_test[i]:.3f} rad; "
             f"|B|_direct={bmod_direct[i]:.5f} T, |B|_chartmap={bmod_chartmap[i]:.5f} T, "
             f"rel_err={rel_err:.2e}"


### PR DESCRIPTION
## Goal

Fix an off-by-one in the radial s-grid of the `.bc -> boozmn` converter so the chartmap reproduces the `.bc` field to floating point, removing a ~0.5-1% systematic in the `.bc`-retirement cross-checks.

## Root cause

`bc_to_booz_xform` wrote `jlist = arange(2, ns)` with `ns = nsurf+2` and resampled the surface functions onto a `linspace` grid. The `booz_xform -> chartmap` reader reconstructs each half-grid surface as `s_half = (jlist-1.5)/(ns-1)` and samples surface functions at `jlist-1`. With the old `jlist`, `s_half` landed one full cell below the true `.bc` surfaces `bc.s`, so every quantity was read at a slightly wrong `s`. The error tracked `d(quantity)/ds` and scaled as `1/nsurf` (a radial shift, not the Fourier sums).

## Fix

Choose `ns`/`jlist` so the reader's `s_half` reproduces `bc.s` exactly, and place each `.bc` surface-function value at full-grid index `jlist-1`.

## Files

- `python/libneo/bc_to_booz_xform.py`: grid construction in `write_boozmn`.
- `python/tests/test_bc_to_booz_xform.py`: assert the reconstructed `s_half` lands on the `.bc` surfaces (off-by-one regression guard).
- `python/tests/test_cross_path_field_equality.py`: tighten tolerance `5e-3 -> 1e-4`.

## Verification

chartmap vs `.bc` at a mid-radius point, before -> after:

```
iota   : 0.56%   -> 6.6e-08
bmod   : 0.23%   -> 1.1e-08
sqrtg  : 0.45%   -> 5.5e-06 (nrho=50) -> 2.3e-08 (nrho=1000)
```

cross-path worst rel_err over 20 points: `5e-3 bound -> 1.03e-5` (now the `.bc`'s ~1e-5 s-storage precision). The residual now shrinks with the chartmap grid, confirming the rest was the off-by-one.

```
14 passed in 1.46s   (test_bc_to_booz_xform, test_cross_path_field_equality, test_eqdsk_to_boozer_chartmap)
```
