### PR TITLE
Fix latent FP/init bugs caught by Debug -ffpe-trap

### DIFF
--- a/src/field/field_mesh.f90
+++ b/src/field/field_mesh.f90
@@ -81,6 +81,9 @@ subroutine field_mesh_init_with_field(self, limits, field, n_points, is_periodic
         x3 = linspace(limits(3,1), limits(3,2), n_points(3))
     else
         allocate(x1(10), x2(10), x3(10))
+        x1 = linspace(limits(1,1), limits(1,2), 10)
+        x2 = linspace(limits(2,1), limits(2,2), 10)
+        x3 = linspace(limits(3,1), limits(3,2), 10)
     end if
 
     call self%A1%mesh_init(x1, x2, x3, is_periodic=is_periodic)

--- a/src/spline_vmec_data.f90
+++ b/src/spline_vmec_data.f90
@@ -696,9 +696,18 @@ contains
                                      R, Z, alam, dR_ds, dZ_ds, dl_ds, &
                                      dR_dt, dZ_dt, dl_dt, dR_dp, dZ_dp, dl_dp)
 
-      dR_ds = 0.5d0*dR_ds/rho_tor
-      dZ_ds = 0.5d0*dZ_ds/rho_tor
-      dl_ds = 0.5d0*dl_ds/rho_tor
+      if (rho_tor > 0.0d0) then
+         dR_ds = 0.5d0*dR_ds/rho_tor
+         dZ_ds = 0.5d0*dZ_ds/rho_tor
+         dl_ds = 0.5d0*dl_ds/rho_tor
+      else
+         ! Magnetic axis (s=0): d/ds carries the 1/(2*sqrt(s)) coordinate
+         ! singularity and is undefined here. R, Z and lambda above are the exact
+         ! axis position; callers that evaluate the axis use only those values.
+         dR_ds = 0.0d0
+         dZ_ds = 0.0d0
+         dl_ds = 0.0d0
+      end if
 
    end subroutine splint_vmec_data
 

--- a/src/util.f90
+++ b/src/util.f90
@@ -13,6 +13,11 @@ contains
         real(dp) :: dx
         integer :: i
 
+        if (n <= 1) then
+            if (n == 1) x(1) = a
+            return
+        end if
+
         dx = (b - a) / (n - 1)
         do i = 1, n
             x(i) = a + (i - 1) * dx


### PR DESCRIPTION
## What

Three latent floating-point / initialization defects that the Debug build's
`-ffpe-trap=invalid,zero,overflow` turns into hard `SIGFPE` crashes. In Release
(CI default) they silently produce `inf`/`NaN` that slips through because `NaN`
comparisons are false, so the tests "pass" without exercising the code.

- **`util%linspace`** divided by `n-1`, so `n=1` gave `NaN`. Return `[a]` for `n==1`.
- **`field_mesh_init_with_field`** (no `n_points` branch) allocated the mesh axes
  but never filled them, feeding uninitialized memory to the field as coordinates.
  Fill them with a 10-point `linspace` over the limits.
- **`splint_vmec_data`** computed `dX_ds = 0.5*dX_ds/rho_tor` with
  `rho_tor = sqrt(s) = 0` at the magnetic axis. `R/Z/lambda` (position) are
  computed before that scaling and stay exact; the s-derivative is genuinely
  singular at `s=0`, so set it to `0` there instead of dividing by zero. The only
  `s=0` caller, `vmec_from_cyl`, uses the axis position only.

No tolerances were relaxed; Release numerical results are unchanged.

## Verification

Debug build (`-DCMAKE_BUILD_TYPE=Debug`), `ctest`.

Before (on `main`):
```
The following tests FAILED:
   12 - test_util (NUMERICAL)
   49 - test_vmec_chartmap_generator (NUMERICAL)
   53 - test_vmec_from_cyl (NUMERICAL)
   55 - test_chartmap_matches_vmec (NUMERICAL)
   58 - test_boozer_chartmap_roundtrip (NUMERICAL)
   61 - test_chartmap_vmec_mapping (NUMERICAL)
   62 - test_chartmap_derivatives (NUMERICAL)
   70 - test_spline_field (NUMERICAL)
   74 - test_coil_tools_biot_savart (NUMERICAL)
```

After (this branch):
```
The following tests FAILED:
   74 - test_coil_tools_biot_savart (NUMERICAL)
```
The eight tests fixed here now pass; full Release `ctest` is unchanged.

`test_coil_tools_biot_savart` is intentionally **not** addressed here: it
self-reports an unresolved Fourier-vs-direct "scaling mismatch" and its Debug
SIGFPE is the Biot-Savart filament self-singularity (denominator → 0 when a grid
point lands on a coil segment). That needs dedicated work, tracked separately.

Note: CI builds Release, so it never exercises `-ffpe-trap`. Adding a Debug
`ctest` leg would prevent these latent issues from regressing.
