### PR TITLE
ci: add parallel Debug build matrix with -ffpe-trap

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,14 @@ concurrency:
 jobs:
   GNU:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release, Debug]
     env:
       LIBNEO_TESTING: "1"
 
-    name: Build and test
+    name: Build and test (${{ matrix.build_type }})
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,7 +63,12 @@ jobs:
 
       - name: Build
         run: |
-          make
+          if [ "${{ matrix.build_type }}" = "Release" ]; then
+            make
+          else
+            cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+            cmake --build build --parallel
+          fi
 
       - name: Install Python dependencies for tests
         run: |
@@ -70,6 +79,7 @@ jobs:
           cd build && ctest --output-on-failure
 
       - name: Upload GEQDSK plots
+        if: matrix.build_type == 'Release'
         uses: actions/upload-artifact@v4
         with:
           name: geqdsk-plots
@@ -77,10 +87,12 @@ jobs:
           if-no-files-found: ignore
 
       - name: Editable install of libneo
+        if: matrix.build_type == 'Release'
         run: |
           python -m pip install -e .
 
       - name: Run Python tests (pytest)
+        if: matrix.build_type == 'Release'
         env:
           PYTHONFAULTHANDLER: "1"
           LIBNEO_DEBUG_BOOZER: "1"
@@ -89,19 +101,21 @@ jobs:
           python -m pytest python/tests -vv -s
 
       - name: Build ASCOT5 and install a5py
+        if: matrix.build_type == 'Release'
         run: |
           git clone --depth 1 --branch 5.6.1 https://github.com/ascot4fusion/ascot5.git build/test/ascot5_compare/ascot5
           make -C build/test/ascot5_compare/ascot5 libascot
           python -m pip install --force-reinstall build/test/ascot5_compare/ascot5
 
       - name: Compare with ASCOT5 reference
+        if: matrix.build_type == 'Release'
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/build/test/ascot5_compare/ascot5/build
         run: |
           python test/scripts/test_ascot5_compare.py --build-dir build --output-dir build/test/ascot5_compare
 
       - name: Upload test image artifacts
-        if: always()
+        if: always() && matrix.build_type == 'Release'
         uses: actions/upload-artifact@v4
         with:
           name: test-images

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,9 @@ if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
                           -Wall -Wextra
                           -Wno-unused-function)
         add_compile_options($<$<COMPILE_LANGUAGE:C>:-Wno-error=cast-function-type>)
-        add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-fcheck=all>)
+        # no-recursion: gfortran < 14 emits an undefined reference to the
+        # is_recursive guard for deferred-TBP targets under -Og -fcheck=recursion.
+        add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-fcheck=all,no-recursion>)
         add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-Wno-external-argument-mismatch>)
         add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-ffpe-trap=invalid,zero,overflow>)
     elseif(CMAKE_BUILD_TYPE MATCHES "Release|Fast")


### PR DESCRIPTION
## What

Run the `GNU` CI job as a `[Release, Debug]` matrix (`fail-fast: false`).

- **Release** leg: unchanged (`make` + ctest + pytest + ASCOT5 compare + artifacts).
- **Debug** leg: builds `-DCMAKE_BUILD_TYPE=Debug` (enables `-ffpe-trap=invalid,zero,overflow`
  and `-fcheck=all`) and runs `ctest` only. The expensive post-ctest steps
  (pytest, ASCOT5 compare, artifact upload) stay Release-only.

The two legs run on separate runners, so **wall-clock is unchanged** (~`max(Release, Debug)`);
only billed compute increases. The Debug `ctest` itself is ~40s. This catches the
invalid/zero-division FP class that Release silently hides (NaN comparisons are false).

## Merge order (important)

This Debug leg is **red on current `main`**: main still has the latent FP defects.
Land in this order:

1. **#349** (fixes 8 of the 9 Debug `-ffpe-trap` failures) — merge first.
2. Resolve the 9th, `test_coil_tools_biot_savart` Debug SIGFPE (#350, filament
   self-singularity). Until then the Debug leg stays red.
3. Then this PR goes green and can be squash-merged.

No source/behaviour change here — workflow only.
