### PR TITLE
Add nemec2vmec converter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 # Standalone builds run libneo's own Python tests and f2py; resolve Python from
 # the uv-managed project venv so their dependencies are available.
-if(LIBNEO_IS_STANDALONE)
+if(LIBNEO_IS_STANDALONE AND NOT SKBUILD)
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/UvPython.cmake)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,30 @@ For the magnetic axis, VMEC stores `zaxis_cs` but uses the same phase convention
 
 - `Z_axis(zeta) = sum_n zaxis_cs(n) * sin(-n*nfp*zeta)` (using `sin(-x) = -sin(x)`).
 
+#### NEMEC to VMEC conversion
+
+`nemec2vmec` converts text NEMEC `wout.*` files to VMEC-style NetCDF `wout.nc`
+files:
+
+    nemec2vmec wout.nemec wout.nc
+
+The converter targets VMEC wout conventions. The NEMEC output manual distributed
+with Strumberger/Tichmann data defines the same geometric phase:
+
+- `R` and `Z` use `cos(m*theta - n*zeta*nfp)` and
+  `sin(m*theta - n*zeta*nfp)`.
+- The output stores `hphip = (1 / (2*pi)) * dPhi/ds`; VMEC `phipf` and `phips`
+  store `dPhi/ds`, so `nemec2vmec` writes `-2*pi*hphip` for AUG-like NEMEC
+  equilibria where `Phi` decreases from axis to edge.
+- `signgs` is written as `-1`, matching VMEC's negative Jacobian convention.
+
+The VMEC-side convention is cross-checked against [STELLOPT `read_wout_mod.f90`][stellopt-wout]
+and [DESC `vmec.py`][desc-vmec]:
+`xn` includes `nfp`, and real-space evaluation uses `m*theta - xn*zeta`.
+
+[stellopt-wout]: https://github.com/PrincetonUniversity/STELLOPT/blob/develop/LIBSTELL/Sources/Modules/read_wout_mod.f90
+[desc-vmec]: https://github.com/PlasmaControl/DESC/blob/master/desc/vmec.py
+
 Install dependencies:
 
     pip install -e ".[chartmap]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "libneo"
 version = "0.0.3"
-dependencies = ["numpy"]
+dependencies = ["numpy", "netCDF4"]
 classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
@@ -41,6 +41,7 @@ docs = [
 
 [project.scripts]
 libneo-write-chartmap = "libneo.chartmap_cli:main"
+nemec2vmec = "libneo.nemec2vmec:main"
 
 [tool.scikit-build]
 build-dir = "build/skbuild"

--- a/python/libneo/nemec.py
+++ b/python/libneo/nemec.py
@@ -8,6 +8,15 @@ from netCDF4 import Dataset
 
 
 TWOPI = 2.0 * np.pi
+SOURCE_NOTES = (
+    "NEMEC manual and readnemec.f90 in the Strumberger output bundle: "
+    "R/Z and all field components use phase m*theta - n*zeta*nfp, with "
+    "left-handed flux coordinates and hphip=(1/2*pi)*dPhi/ds. "
+    "VMEC/STELLOPT wout stores xn=n*nfp and uses cos/sin(m*theta - xn*zeta); "
+    "DESC's VMEC reader/writer uses the same phase and signgs=-1. "
+    "SFINCS read_NEMEC_file.f90 flips n and several signs for its own "
+    "downstream convention; those flips are not applied for VMEC wout output."
+)
 
 
 @dataclass(frozen=True)
@@ -124,6 +133,7 @@ def read_nemec(path: str | Path) -> NemecData:
 def write_vmec_wout(data: NemecData, path: str | Path) -> None:
     out = Path(path)
     with Dataset(out, "w") as ds:
+        ds.source_conventions = SOURCE_NOTES
         ds.createDimension("dim_00100", 100)
         ds.createDimension("dim_00200", 200)
         ds.createDimension("dim_00020", 20)
@@ -168,11 +178,11 @@ def write_vmec_wout(data: NemecData, path: str | Path) -> None:
         _array(ds, "zmnc", ("radius", "mn_mode"), data.zmnc)
         _array(ds, "lmnc", ("radius", "mn_mode"), data.lmnc)
 
-        zeros = np.zeros_like(data.rmnc)
-        _array(ds, "gmnc", ("radius", "mn_mode_nyq"), zeros)
-        _array(ds, "gmns", ("radius", "mn_mode_nyq"), zeros)
-        _array(ds, "bmnc", ("radius", "mn_mode_nyq"), zeros)
-        _array(ds, "bmns", ("radius", "mn_mode_nyq"), zeros)
+        bmnc, bmns, gmnc, gmns = _magnetic_spectra(data)
+        _array(ds, "gmnc", ("radius", "mn_mode_nyq"), gmnc)
+        _array(ds, "gmns", ("radius", "mn_mode_nyq"), gmns)
+        _array(ds, "bmnc", ("radius", "mn_mode_nyq"), bmnc)
+        _array(ds, "bmns", ("radius", "mn_mode_nyq"), bmns)
         _array(ds, "bsubumnc", ("radius", "mn_mode_nyq"), data.bsubumnc)
         _array(ds, "bsubvmnc", ("radius", "mn_mode_nyq"), data.bsubvmnc)
         _array(ds, "bsubsmns", ("radius", "mn_mode_nyq"), data.bsubsmns)
@@ -192,6 +202,68 @@ def _mode_numbers(nfp: int, mpol: int, ntor: int) -> np.ndarray:
         for n in range(n_min, ntor + 1):
             modes.append((m, n * nfp))
     return np.asarray(modes, dtype=int)
+
+
+def _magnetic_spectra(data: NemecData) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    cos_phase, sin_phase = _projection_grid(data)
+    bmnc = np.zeros_like(data.rmnc)
+    bmns = np.zeros_like(data.rmnc)
+    gmnc = np.zeros_like(data.rmnc)
+    gmns = np.zeros_like(data.rmnc)
+
+    for js in range(data.ns):
+        bsupu = _series(data.bsupumnc[js], data.bsupumns[js], cos_phase, sin_phase)
+        bsupv = _series(data.bsupvmnc[js], data.bsupvmns[js], cos_phase, sin_phase)
+        bsubu = _series(data.bsubumnc[js], data.bsubumns[js], cos_phase, sin_phase)
+        bsubv = _series(data.bsubvmnc[js], data.bsubvmns[js], cos_phase, sin_phase)
+        bdotb = np.maximum(bsupu * bsubu + bsupv * bsubv, 0.0)
+        bmnc[js], bmns[js] = _project(np.sqrt(bdotb), cos_phase, sin_phase, data.xm, data.xn)
+
+        lamu = _lambda_theta(data, js, cos_phase, sin_phase)
+        numerator = (1.0 + lamu) * data.phipf[js]
+        sqrtg = np.zeros_like(bsupv)
+        np.divide(numerator, bsupv, out=sqrtg, where=np.abs(bsupv) > 1.0e-14)
+        gmnc[js], gmns[js] = _project(sqrtg, cos_phase, sin_phase, data.xm, data.xn)
+
+    return bmnc, bmns, gmnc, gmns
+
+
+def _projection_grid(data: NemecData) -> tuple[np.ndarray, np.ndarray]:
+    ntheta = max(64, 4 * data.mpol + 1)
+    nzeta = max(64, 4 * data.ntor + 1)
+    theta = np.linspace(0.0, TWOPI, ntheta, endpoint=False)
+    zeta = np.linspace(0.0, TWOPI / max(data.nfp, 1), nzeta, endpoint=False)
+    angle = (
+        data.xm[:, None, None] * theta[None, :, None]
+        - data.xn[:, None, None] * zeta[None, None, :]
+    )
+    return np.cos(angle), np.sin(angle)
+
+
+def _series(cos_coeff: np.ndarray, sin_coeff: np.ndarray, cos_phase: np.ndarray, sin_phase: np.ndarray) -> np.ndarray:
+    return np.tensordot(cos_coeff, cos_phase, axes=(0, 0)) + np.tensordot(sin_coeff, sin_phase, axes=(0, 0))
+
+
+def _lambda_theta(data: NemecData, js: int, cos_phase: np.ndarray, sin_phase: np.ndarray) -> np.ndarray:
+    return (
+        np.tensordot(data.xm * data.lmns[js], cos_phase, axes=(0, 0))
+        - np.tensordot(data.xm * data.lmnc[js], sin_phase, axes=(0, 0))
+    )
+
+
+def _project(
+    values: np.ndarray,
+    cos_phase: np.ndarray,
+    sin_phase: np.ndarray,
+    xm: np.ndarray,
+    xn: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    cos_coeff = 2.0 * np.mean(values[None, :, :] * cos_phase, axis=(1, 2))
+    sin_coeff = 2.0 * np.mean(values[None, :, :] * sin_phase, axis=(1, 2))
+    axis = (xm == 0.0) & (xn == 0.0)
+    cos_coeff[axis] *= 0.5
+    sin_coeff[axis] = 0.0
+    return cos_coeff, sin_coeff
 
 
 def _with_axis(values: np.ndarray, first_value: float = 0.0) -> np.ndarray:

--- a/python/libneo/nemec.py
+++ b/python/libneo/nemec.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from netCDF4 import Dataset
+
+
+TWOPI = 2.0 * np.pi
+
+
+@dataclass(frozen=True)
+class NemecData:
+    nfp: int
+    ns: int
+    mpol: int
+    ntor: int
+    iasym: int
+    phiedge: float
+    xm: np.ndarray
+    xn: np.ndarray
+    rmnc: np.ndarray
+    zmns: np.ndarray
+    rmns: np.ndarray
+    zmnc: np.ndarray
+    lmns: np.ndarray
+    lmnc: np.ndarray
+    bsupumnc: np.ndarray
+    bsupvmnc: np.ndarray
+    bsupumns: np.ndarray
+    bsupvmns: np.ndarray
+    bsubumnc: np.ndarray
+    bsubvmnc: np.ndarray
+    bsubsmns: np.ndarray
+    bsubumns: np.ndarray
+    bsubvmns: np.ndarray
+    bsubsmnc: np.ndarray
+    iotaf: np.ndarray
+    iotas: np.ndarray
+    mass: np.ndarray
+    pres: np.ndarray
+    phipf: np.ndarray
+    phips: np.ndarray
+    buco: np.ndarray
+    bvco: np.ndarray
+    phi: np.ndarray
+    vp: np.ndarray
+    over_r: np.ndarray
+    jcuru: np.ndarray
+    jcurv: np.ndarray
+    specw: np.ndarray
+
+
+def read_nemec(path: str | Path) -> NemecData:
+    values = np.fromstring(Path(path).read_text(), sep=" ")
+    if values.size < 8:
+        raise ValueError("NEMEC file is too short")
+
+    _, nfp_f, nrho_f, mpol_f, ntor_f, mpnt_f, iasym_f, phiedge = values[:8]
+    nfp = int(round(nfp_f))
+    nrho = int(round(nrho_f))
+    mpol = int(round(mpol_f))
+    ntor = int(round(ntor_f))
+    mpnt = int(round(mpnt_f))
+    iasym = int(round(iasym_f))
+    modes = _mode_numbers(nfp, mpol, ntor)
+    if mpnt != modes.shape[0]:
+        raise ValueError(f"NEMEC mpnt={mpnt} does not match mpol/ntor modes={modes.shape[0]}")
+
+    fourier_size = nrho * mpnt * 16
+    profile_size = (nrho - 1) * 12
+    expected = 8 + fourier_size + profile_size
+    if values.size < expected:
+        raise ValueError(f"NEMEC file has {values.size} values, expected at least {expected}")
+
+    fourier = values[8:8 + fourier_size].reshape(nrho, mpnt, 16)
+    profile = values[8 + fourier_size:expected].reshape(nrho - 1, 12)
+
+    iota = _with_axis(profile[:, 0])
+    hphip = _with_axis(profile[:, 3], first_value=profile[0, 3])
+    return NemecData(
+        nfp=nfp,
+        ns=nrho,
+        mpol=mpol,
+        ntor=ntor,
+        iasym=iasym,
+        phiedge=float(phiedge),
+        xm=modes[:, 0].astype(float),
+        xn=modes[:, 1].astype(float),
+        rmnc=fourier[:, :, 0],
+        zmns=fourier[:, :, 1],
+        rmns=fourier[:, :, 2],
+        zmnc=fourier[:, :, 3],
+        bsupumnc=fourier[:, :, 4],
+        bsupvmnc=fourier[:, :, 5],
+        bsupumns=fourier[:, :, 6],
+        bsupvmns=fourier[:, :, 7],
+        lmns=fourier[:, :, 8],
+        lmnc=fourier[:, :, 9],
+        bsubumnc=fourier[:, :, 10],
+        bsubvmnc=fourier[:, :, 11],
+        bsubsmns=fourier[:, :, 12],
+        bsubumns=fourier[:, :, 13],
+        bsubvmns=fourier[:, :, 14],
+        bsubsmnc=fourier[:, :, 15],
+        iotaf=iota,
+        iotas=iota,
+        mass=_with_axis(profile[:, 1]),
+        pres=_with_axis(profile[:, 2]),
+        phipf=-TWOPI * hphip,
+        phips=-TWOPI * hphip,
+        buco=_with_axis(profile[:, 4]),
+        bvco=_with_axis(profile[:, 5]),
+        phi=_with_axis(profile[:, 6]),
+        vp=_with_axis(profile[:, 7]),
+        over_r=_with_axis(profile[:, 8]),
+        jcuru=_with_axis(profile[:, 9]),
+        jcurv=_with_axis(profile[:, 10]),
+        specw=_with_axis(profile[:, 11]),
+    )
+
+
+def write_vmec_wout(data: NemecData, path: str | Path) -> None:
+    out = Path(path)
+    with Dataset(out, "w") as ds:
+        ds.createDimension("dim_00100", 100)
+        ds.createDimension("dim_00200", 200)
+        ds.createDimension("dim_00020", 20)
+        ds.createDimension("dim_00001", 1)
+        ds.createDimension("mn_mode", data.xm.size)
+        ds.createDimension("mn_mode_nyq", data.xm.size)
+        ds.createDimension("n_tor", data.ntor + 1)
+        ds.createDimension("radius", data.ns)
+        ds.createDimension("time", 100)
+
+        _scalar(ds, "version_", 9.0)
+        _char(ds, "input_extension", "nemec2vmec", "dim_00100")
+        _char(ds, "mgrid_file", "", "dim_00200")
+        _char(ds, "pcurr_type", "", "dim_00020")
+        _char(ds, "pmass_type", "", "dim_00020")
+        _char(ds, "piota_type", "", "dim_00020")
+        _char(ds, "mgrid_mode", "", "dim_00001")
+
+        for name, value in _scalar_values(data).items():
+            _scalar(ds, name, value)
+
+        _array(ds, "xm", ("mn_mode",), data.xm)
+        _array(ds, "xn", ("mn_mode",), data.xn)
+        _array(ds, "xm_nyq", ("mn_mode_nyq",), data.xm)
+        _array(ds, "xn_nyq", ("mn_mode_nyq",), data.xn)
+
+        axis_modes = data.ntor + 1
+        _array(ds, "raxis_cc", ("n_tor",), data.rmnc[0, :axis_modes])
+        _array(ds, "zaxis_cs", ("n_tor",), data.zmns[0, :axis_modes])
+        _array(ds, "raxis_cs", ("n_tor",), data.rmns[0, :axis_modes])
+        _array(ds, "zaxis_cc", ("n_tor",), data.zmnc[0, :axis_modes])
+
+        for name, values in _profile_arrays(data).items():
+            _array(ds, name, ("radius",), values)
+        _array(ds, "fsqt", ("time",), np.zeros(100, dtype=float))
+        _array(ds, "wdot", ("time",), np.zeros(100, dtype=float))
+
+        _array(ds, "rmnc", ("radius", "mn_mode"), data.rmnc)
+        _array(ds, "zmns", ("radius", "mn_mode"), data.zmns)
+        _array(ds, "lmns", ("radius", "mn_mode"), data.lmns)
+        _array(ds, "rmns", ("radius", "mn_mode"), data.rmns)
+        _array(ds, "zmnc", ("radius", "mn_mode"), data.zmnc)
+        _array(ds, "lmnc", ("radius", "mn_mode"), data.lmnc)
+
+        zeros = np.zeros_like(data.rmnc)
+        _array(ds, "gmnc", ("radius", "mn_mode_nyq"), zeros)
+        _array(ds, "gmns", ("radius", "mn_mode_nyq"), zeros)
+        _array(ds, "bmnc", ("radius", "mn_mode_nyq"), zeros)
+        _array(ds, "bmns", ("radius", "mn_mode_nyq"), zeros)
+        _array(ds, "bsubumnc", ("radius", "mn_mode_nyq"), data.bsubumnc)
+        _array(ds, "bsubvmnc", ("radius", "mn_mode_nyq"), data.bsubvmnc)
+        _array(ds, "bsubsmns", ("radius", "mn_mode_nyq"), data.bsubsmns)
+        _array(ds, "bsubumns", ("radius", "mn_mode_nyq"), data.bsubumns)
+        _array(ds, "bsubvmns", ("radius", "mn_mode_nyq"), data.bsubvmns)
+        _array(ds, "bsubsmnc", ("radius", "mn_mode_nyq"), data.bsubsmnc)
+        _array(ds, "bsupumnc", ("radius", "mn_mode_nyq"), data.bsupumnc)
+        _array(ds, "bsupvmnc", ("radius", "mn_mode_nyq"), data.bsupvmnc)
+        _array(ds, "bsupumns", ("radius", "mn_mode_nyq"), data.bsupumns)
+        _array(ds, "bsupvmns", ("radius", "mn_mode_nyq"), data.bsupvmns)
+
+
+def _mode_numbers(nfp: int, mpol: int, ntor: int) -> np.ndarray:
+    modes = []
+    for m in range(mpol):
+        n_min = 0 if m == 0 else -ntor
+        for n in range(n_min, ntor + 1):
+            modes.append((m, n * nfp))
+    return np.asarray(modes, dtype=int)
+
+
+def _with_axis(values: np.ndarray, first_value: float = 0.0) -> np.ndarray:
+    return np.concatenate(([float(first_value)], np.asarray(values, dtype=float)))
+
+
+def _scalar(ds: Dataset, name: str, value: float | int) -> None:
+    dtype = "i4" if isinstance(value, int) else "f8"
+    var = ds.createVariable(name, dtype)
+    var[...] = value
+
+
+def _char(ds: Dataset, name: str, value: str, dim: str) -> None:
+    var = ds.createVariable(name, "S1", (dim,))
+    encoded = value.encode("ascii")[: ds.dimensions[dim].size]
+    arr = np.full(ds.dimensions[dim].size, b" ", dtype="S1")
+    arr[:len(encoded)] = np.frombuffer(encoded, dtype="S1")
+    var[:] = arr
+
+
+def _array(ds: Dataset, name: str, dims: tuple[str, ...], values: np.ndarray) -> None:
+    var = ds.createVariable(name, "f8", dims)
+    var[:] = np.asarray(values, dtype=float)
+
+
+def _scalar_values(data: NemecData) -> dict[str, float | int]:
+    r_boundary, z_boundary = _boundary_extrema_samples(data)
+    return {
+        "wb": 0.0,
+        "wp": 0.0,
+        "gamma": 0.0,
+        "rmax_surf": float(np.max(r_boundary)),
+        "rmin_surf": float(np.min(r_boundary)),
+        "zmax_surf": float(np.max(z_boundary)),
+        "nfp": data.nfp,
+        "ns": data.ns,
+        "mpol": data.mpol,
+        "ntor": data.ntor,
+        "mnmax": data.xm.size,
+        "mnmax_nyq": data.xm.size,
+        "niter": 0,
+        "itfsq": 0,
+        "lasym__logical__": 1 if data.iasym else 0,
+        "lrecon__logical__": 0,
+        "lfreeb__logical__": 1,
+        "lrfp__logical__": 0,
+        "ier_flag": 0,
+        "aspect": 0.0,
+        "betatotal": 0.0,
+        "betapol": 0.0,
+        "betator": 0.0,
+        "betaxis": 0.0,
+        "b0": 0.0,
+        "rbtor0": 0.0,
+        "rbtor": 0.0,
+        "signgs": -1,
+        "IonLarmor": 0.0,
+        "volavgB": 0.0,
+        "ctor": 0.0,
+        "Aminor_p": 0.0,
+        "Rmajor_p": 0.0,
+        "volume_p": 0.0,
+        "ftolv": 0.0,
+        "fsql": 0.0,
+        "fsqr": 0.0,
+        "fsqz": 0.0,
+        "nextcur": 0,
+    }
+
+
+def _boundary_extrema_samples(data: NemecData) -> tuple[np.ndarray, np.ndarray]:
+    theta = np.linspace(0.0, TWOPI, 257, endpoint=False)
+    zeta = np.linspace(0.0, TWOPI / max(data.nfp, 1), 257, endpoint=False)
+    angle = (
+        data.xm[:, None, None] * theta[None, :, None]
+        - data.xn[:, None, None] * zeta[None, None, :]
+    )
+    r = np.tensordot(data.rmnc[-1], np.cos(angle), axes=(0, 0))
+    z = np.tensordot(data.zmns[-1], np.sin(angle), axes=(0, 0))
+    if data.iasym:
+        r += np.tensordot(data.rmns[-1], np.sin(angle), axes=(0, 0))
+        z += np.tensordot(data.zmnc[-1], np.cos(angle), axes=(0, 0))
+    return r, z
+
+
+def _profile_arrays(data: NemecData) -> dict[str, np.ndarray]:
+    zeros = np.zeros(data.ns, dtype=float)
+    q_factor = np.zeros(data.ns, dtype=float)
+    np.divide(1.0, data.iotaf, out=q_factor, where=data.iotaf != 0.0)
+    return {
+        "iotaf": data.iotaf,
+        "q_factor": q_factor,
+        "presf": data.pres,
+        "phi": data.phi,
+        "phipf": data.phipf,
+        "chi": zeros,
+        "chipf": data.iotaf * data.phipf,
+        "jcuru": data.jcuru,
+        "jcurv": data.jcurv,
+        "iotas": data.iotas,
+        "mass": data.mass,
+        "pres": data.pres,
+        "beta_vol": zeros,
+        "buco": data.buco,
+        "bvco": data.bvco,
+        "vp": data.vp,
+        "specw": data.specw,
+        "phips": data.phips,
+        "over_r": data.over_r,
+        "jdotb": zeros,
+        "bdotb": zeros,
+        "bdotgradv": zeros,
+        "DMerc": zeros,
+        "DShear": zeros,
+        "DWell": zeros,
+        "DCurr": zeros,
+        "DGeod": zeros,
+        "equif": zeros,
+    }

--- a/python/libneo/nemec2vmec.py
+++ b/python/libneo/nemec2vmec.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .nemec import read_nemec, write_vmec_wout
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="nemec2vmec")
+    parser.add_argument("input", type=Path, help="NEMEC text wout file")
+    parser.add_argument("output", type=Path, help="Output VMEC wout NetCDF file")
+    parser.add_argument("--force", action="store_true", help="Overwrite output file")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.output.exists() and not args.force:
+        raise SystemExit(f"{args.output} exists; pass --force to overwrite")
+    data = read_nemec(args.input)
+    write_vmec_wout(data, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/python/test_nemec2vmec.py
+++ b/test/python/test_nemec2vmec.py
@@ -34,13 +34,17 @@ def _write_tiny_nemec(path):
             records[j, k, 1] = 0.1 * base
             records[j, k, 2] = -0.03 * base
             records[j, k, 3] = 0.07 * base
+            records[j, k, 4] = 0.02 * base
+            records[j, k, 5] = 2.0 if (m, n) == (0, 0) else 0.01 * base
+            records[j, k, 6] = -0.01 * base
+            records[j, k, 7] = 0.005 * base
             records[j, k, 8] = -0.02 * base
             records[j, k, 9] = 0.04 * base
             records[j, k, 10] = 0.2 * base
-            records[j, k, 11] = -0.3 * base
+            records[j, k, 11] = 0.3 * base
             records[j, k, 12] = 0.4 * base
             records[j, k, 13] = -0.5 * base
-            records[j, k, 14] = 0.6 * base
+            records[j, k, 14] = 0.06 * base
             records[j, k, 15] = -0.7 * base
 
     profiles = np.array(
@@ -70,6 +74,14 @@ def _evaluate_z(parsed, surface, theta, zeta):
     for mode, coeff in enumerate(parsed.zmns[surface]):
         angle = parsed.xm[mode] * theta - parsed.xn[mode] * zeta
         out += coeff * np.sin(angle) + parsed.zmnc[surface, mode] * np.cos(angle)
+    return out
+
+
+def _evaluate_pair(cos_coeff, sin_coeff, xm, xn, theta, zeta):
+    out = np.zeros_like(theta, dtype=float)
+    for mode, coeff in enumerate(cos_coeff):
+        angle = xm[mode] * theta - xn[mode] * zeta
+        out += coeff * np.cos(angle) + sin_coeff[mode] * np.sin(angle)
     return out
 
 
@@ -121,9 +133,14 @@ def test_write_vmec_wout_preserves_geometry_signs(tmp_path):
         raxis_cc = np.array(ds.variables["raxis_cc"][:])
         zaxis_cs = np.array(ds.variables["zaxis_cs"][:])
         zaxis_cc = np.array(ds.variables["zaxis_cc"][:])
+        bmnc = np.array(ds.variables["bmnc"][:])
+        bmns = np.array(ds.variables["bmns"][:])
+        gmnc = np.array(ds.variables["gmnc"][:])
+        gmns = np.array(ds.variables["gmns"][:])
         rmax_surf = float(ds.variables["rmax_surf"][...])
         rmin_surf = float(ds.variables["rmin_surf"][...])
         zmax_surf = float(ds.variables["zmax_surf"][...])
+        assert "m*theta - n*zeta*nfp" in ds.source_conventions
     np.testing.assert_allclose(raxis_cc, parsed.rmnc[0, :2])
     np.testing.assert_allclose(zaxis_cs, parsed.zmns[0, :2])
 
@@ -142,6 +159,40 @@ def test_write_vmec_wout_preserves_geometry_signs(tmp_path):
         + parsed.zmnc[0, :2] * np.cos(-axis_xn * zeta)
     )
     assert stored_axis_z == pytest.approx(expected_axis_z)
+
+    theta_grid = np.linspace(0.1, 1.4, 4)
+    zeta_grid = np.linspace(0.2, 0.9, 4)
+    bsupu = _evaluate_pair(
+        parsed.bsupumnc[surface], parsed.bsupumns[surface], parsed.xm, parsed.xn, theta_grid, zeta_grid
+    )
+    bsupv = _evaluate_pair(
+        parsed.bsupvmnc[surface], parsed.bsupvmns[surface], parsed.xm, parsed.xn, theta_grid, zeta_grid
+    )
+    bsubu = _evaluate_pair(
+        parsed.bsubumnc[surface], parsed.bsubumns[surface], parsed.xm, parsed.xn, theta_grid, zeta_grid
+    )
+    bsubv = _evaluate_pair(
+        parsed.bsubvmnc[surface], parsed.bsubvmns[surface], parsed.xm, parsed.xn, theta_grid, zeta_grid
+    )
+    bmod_expected = np.sqrt(np.maximum(bsupu * bsubu + bsupv * bsubv, 0.0))
+    bmod_stored = _evaluate_pair(
+        bmnc[surface], bmns[surface], parsed.xm, parsed.xn, theta_grid, zeta_grid
+    )
+    np.testing.assert_allclose(bmod_stored, bmod_expected, atol=0.8)
+
+    lam_theta = _evaluate_pair(
+        parsed.xm * parsed.lmns[surface],
+        -parsed.xm * parsed.lmnc[surface],
+        parsed.xm,
+        parsed.xn,
+        theta_grid,
+        zeta_grid,
+    )
+    sqrtg_expected = (1.0 + lam_theta) * parsed.phipf[surface] / bsupv
+    sqrtg_stored = _evaluate_pair(
+        gmnc[surface], gmns[surface], parsed.xm, parsed.xn, theta_grid, zeta_grid
+    )
+    np.testing.assert_allclose(sqrtg_stored, sqrtg_expected, atol=0.4)
 
 
 def test_nemec2vmec_cli_refuses_overwrite(tmp_path):

--- a/test/python/test_nemec2vmec.py
+++ b/test/python/test_nemec2vmec.py
@@ -1,0 +1,161 @@
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+from netCDF4 import Dataset
+
+from libneo.nemec import read_nemec, write_vmec_wout
+from libneo.vmec import VMECGeometry
+
+
+def _mode_order(mpol, ntor):
+    modes = []
+    for m in range(mpol):
+        n_min = 0 if m == 0 else -ntor
+        for n in range(n_min, ntor + 1):
+            modes.append((m, n))
+    return modes
+
+
+def _write_tiny_nemec(path):
+    nfp = 2
+    nrho = 3
+    mpol = 2
+    ntor = 1
+    modes = _mode_order(mpol, ntor)
+    records = np.zeros((nrho, len(modes), 16), dtype=float)
+
+    for j in range(nrho):
+        s_scale = 1.0 + 0.2 * j
+        for k, (m, n) in enumerate(modes):
+            base = s_scale * (10.0 + 2.0 * m + 0.5 * n)
+            records[j, k, 0] = base
+            records[j, k, 1] = 0.1 * base
+            records[j, k, 2] = -0.03 * base
+            records[j, k, 3] = 0.07 * base
+            records[j, k, 8] = -0.02 * base
+            records[j, k, 9] = 0.04 * base
+            records[j, k, 10] = 0.2 * base
+            records[j, k, 11] = -0.3 * base
+            records[j, k, 12] = 0.4 * base
+            records[j, k, 13] = -0.5 * base
+            records[j, k, 14] = 0.6 * base
+            records[j, k, 15] = -0.7 * base
+
+    profiles = np.array(
+        [
+            [0.31, 1.0, 2.0, 0.5, -3.0, 4.0, -0.25, 9.0, 0.1, 0.2, 0.3, 0.4],
+            [0.41, 1.1, 2.1, 0.5, -3.1, 4.1, -0.50, 9.1, 0.2, 0.3, 0.4, 0.5],
+        ],
+        dtype=float,
+    )
+
+    values = [0.0, nfp, nrho, mpol, ntor, len(modes), 1, -0.5]
+    values.extend(records.ravel())
+    values.extend(profiles.ravel())
+    path.write_text("\n".join(f"{value:.17e}" for value in values) + "\n")
+
+
+def _evaluate(parsed, surface, theta, zeta):
+    out = np.zeros_like(theta, dtype=float)
+    for mode, coeff in enumerate(parsed.rmnc[surface]):
+        angle = parsed.xm[mode] * theta - parsed.xn[mode] * zeta
+        out += coeff * np.cos(angle) + parsed.rmns[surface, mode] * np.sin(angle)
+    return out
+
+
+def _evaluate_z(parsed, surface, theta, zeta):
+    out = np.zeros_like(theta, dtype=float)
+    for mode, coeff in enumerate(parsed.zmns[surface]):
+        angle = parsed.xm[mode] * theta - parsed.xn[mode] * zeta
+        out += coeff * np.sin(angle) + parsed.zmnc[surface, mode] * np.cos(angle)
+    return out
+
+
+def _boundary_samples(parsed):
+    theta = np.linspace(0.0, 2.0 * np.pi, 21, endpoint=False)
+    zeta = np.linspace(0.0, 2.0 * np.pi / parsed.nfp, 21, endpoint=False)
+    theta_grid, zeta_grid = np.meshgrid(theta, zeta, indexing="ij")
+    r = _evaluate(parsed, -1, theta_grid.ravel(), zeta_grid.ravel())
+    z = _evaluate_z(parsed, -1, theta_grid.ravel(), zeta_grid.ravel())
+    return r, z
+
+
+def test_read_nemec_mode_order_and_profiles(tmp_path):
+    src = tmp_path / "wout.nemec"
+    _write_tiny_nemec(src)
+
+    parsed = read_nemec(src)
+
+    np.testing.assert_array_equal(parsed.xm, np.array([0.0, 0.0, 1.0, 1.0, 1.0]))
+    np.testing.assert_array_equal(parsed.xn, np.array([0.0, 2.0, -2.0, 0.0, 2.0]))
+    assert parsed.nfp == 2
+    assert parsed.ns == 3
+    assert parsed.phiedge == pytest.approx(-0.5)
+    np.testing.assert_allclose(parsed.phi, np.array([0.0, -0.25, -0.50]))
+    np.testing.assert_allclose(parsed.phipf, np.array([-np.pi, -np.pi, -np.pi]))
+
+
+def test_write_vmec_wout_preserves_geometry_signs(tmp_path):
+    src = tmp_path / "wout.nemec"
+    out = tmp_path / "wout.nc"
+    _write_tiny_nemec(src)
+
+    parsed = read_nemec(src)
+    write_vmec_wout(parsed, out)
+
+    geom = VMECGeometry.from_file(str(out))
+    theta = np.array([0.2, 1.3, 2.7])
+    zeta = 0.37
+    surface = 1
+
+    R, Z, zeta_out = geom.coords(surface, theta, zeta)
+    assert zeta_out == pytest.approx(zeta)
+    np.testing.assert_allclose(R, _evaluate(parsed, surface, theta, zeta))
+    np.testing.assert_allclose(Z, _evaluate_z(parsed, surface, theta, zeta))
+
+    with Dataset(out) as ds:
+        assert int(ds.variables["signgs"][...]) == -1
+        assert int(ds.variables["lasym__logical__"][...]) == 1
+        raxis_cc = np.array(ds.variables["raxis_cc"][:])
+        zaxis_cs = np.array(ds.variables["zaxis_cs"][:])
+        zaxis_cc = np.array(ds.variables["zaxis_cc"][:])
+        rmax_surf = float(ds.variables["rmax_surf"][...])
+        rmin_surf = float(ds.variables["rmin_surf"][...])
+        zmax_surf = float(ds.variables["zmax_surf"][...])
+    np.testing.assert_allclose(raxis_cc, parsed.rmnc[0, :2])
+    np.testing.assert_allclose(zaxis_cs, parsed.zmns[0, :2])
+
+    r_boundary, z_boundary = _boundary_samples(parsed)
+    assert rmax_surf >= float(np.max(r_boundary))
+    assert rmin_surf <= float(np.min(r_boundary))
+    assert zmax_surf >= float(np.max(z_boundary))
+
+    axis_xn = np.array([0.0, 2.0])
+    stored_axis_z = np.sum(
+        zaxis_cs * np.sin(-axis_xn * zeta)
+        + zaxis_cc * np.cos(-axis_xn * zeta)
+    )
+    expected_axis_z = np.sum(
+        parsed.zmns[0, :2] * np.sin(-axis_xn * zeta)
+        + parsed.zmnc[0, :2] * np.cos(-axis_xn * zeta)
+    )
+    assert stored_axis_z == pytest.approx(expected_axis_z)
+
+
+def test_nemec2vmec_cli_refuses_overwrite(tmp_path):
+    src = tmp_path / "wout.nemec"
+    out = tmp_path / "wout.nc"
+    _write_tiny_nemec(src)
+    out.write_text("existing")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "libneo.nemec2vmec", str(src), str(out)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "exists" in result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -297,6 +297,7 @@ name = "libneo"
 version = "0.0.3"
 source = { editable = "." }
 dependencies = [
+    { name = "netcdf4" },
     { name = "numpy" },
 ]
 
@@ -332,6 +333,7 @@ requires-dist = [
     { name = "map2disc", marker = "extra == 'dev'", git = "https://github.com/itpplasma/map2disc.git" },
     { name = "matplotlib", marker = "extra == 'chartmap'" },
     { name = "matplotlib", marker = "extra == 'dev'" },
+    { name = "netcdf4" },
     { name = "netcdf4", marker = "extra == 'chartmap'" },
     { name = "netcdf4", marker = "extra == 'dev'" },
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- Add a `nemec2vmec` CLI and Python converter for text NEMEC wout files to VMEC-style NetCDF wout files.
- Preserve VMEC Fourier phase convention `m*theta - xn*zeta`, with `xn = n*nfp`, asymmetric coefficients, `signgs = -1`, and `phip = -2*pi*hphip` for AUG-like NEMEC equilibria where `Phi` decreases from axis to edge.
- Project `bmnc/bmns` from NEMEC covariant and contravariant B components, and project `gmnc/gmns` from `sqrt(g) B^zeta = (1 + lambda_theta) dPhi/ds`.
- Document source conventions in README and write a `source_conventions` NetCDF attribute.
- Avoid recursive uv sync during scikit-build editable builds.

## Sign Convention Sources
- NEMEC output manual distributed with Strumberger/Tichmann data: NEMEC uses left-handed flux coordinates and geometric phase `m*theta - n*zeta*nfp`; `hphip = (1 / (2*pi)) dPhi/ds`.
- NEMEC `readnemec.f90` distributed with the same data: output column order is `rmnc, zmns, rmns, zmnc, bsupumnc, bsupvmnc, bsupumns, bsupvmns, lmns, lmnc, bsubumnc, bsubvmnc, bsubsmns, bsubumns, bsubvmns, bsubsmnc`.
- STELLOPT [`read_wout_mod.f90`](https://github.com/PrincetonUniversity/STELLOPT/blob/develop/LIBSTELL/Sources/Modules/read_wout_mod.f90): VMEC wout stores `xn` with the `nfp` factor and labels `rmnc/zmns/rmns/zmnc` as the corresponding cos/sin components.
- DESC [`vmec.py`](https://github.com/PlasmaControl/DESC/blob/master/desc/vmec.py): VMEC interpolation evaluates `xm*theta - xn*phi` and writes `signgs = -1`.

## Verification
### Test fails on main
```text
$ python -m pytest test/python/test_nemec2vmec.py -q
ERROR collecting test/python/test_nemec2vmec.py
ModuleNotFoundError: No module named 'libneo.nemec'
1 error in 0.74s
```

### Test passes after fix
```text
$ python -m pytest test/python/test_nemec2vmec.py -q
...                                                                      [100%]
3 passed in 1.27s
```

```text
$ python -m pytest test/python -q
....s.ssssssss.......................................s.................. [100%]
62 passed, 11 skipped in 4.22s
```

```text
$ make test
100% tests passed, 0 tests failed out of 84
Total Test time (real) =  39.77 sec
```

```text
$ PYTHONPATH=.venv/lib/python3.14/site-packages:python python -m pytest python/tests -vv -s
=================== 43 passed, 1 skipped in 70.47s (0:01:10) ===================
```

```text
$ python -m libneo.nemec2vmec <nemec-wout> /tmp/wout.3d_rip_n16.nc --force
nfp () 16
ns () 1001
mpol () 24
ntor () 2
mnmax () 118
lasym__logical__ () 1
signgs () -1
phi (1001,) -2.255276 0.0
phipf (1001,) -2.255275999999891 -2.255275999999891
xn (118,) -32.0 32.0
rmnc (1001, 118) -0.00179494425918 1.716050046603
zmns (1001, 118) -0.02791440245881 0.8356130621226
rmns (1001, 118) -0.009476494000382 0.04657109971587
zmnc (1001, 118) -0.05066592827247 0.04657109971587
bmnc (1001, 118) -0.5498097495770645 1.9304959861013602
gmnc (1001, 118) -0.9758607357192915 2.2661414736866874
source note True
```

```text
$ $HOME/code/prompts/scripts/check-writing-slop.py README.md --threshold soft
PASS: no writing-slop candidates at threshold soft
```
