### PR TITLE
Preserve asymmetric phase coefficients in boozmn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ chartmap = [
     "matplotlib",
 ]
 dev = [
+  "booz-xform",
   "scipy",
   "shapely",
   "matplotlib",

--- a/python/libneo/bc_to_booz_xform.py
+++ b/python/libneo/bc_to_booz_xform.py
@@ -14,7 +14,8 @@ Radial staggering convention (matches booz_xform output):
 Unit conversions:
   .bc curr_pol/nper [A] -> bvco_b [T*m] = curr_pol/nper * nfp * mu_0 / (2*pi)
   .bc curr_tor [A]      -> buco_b [T*m] = curr_tor * mu_0 / (2*pi)
-  .bc vmns (phase) = (phib-phi)*nper/(2*pi) -> pmns_b [rad] = vmns * 2*pi/nfp
+  .bc vmnc/vmns (phase) = (phib-phi)*nper/(2*pi)
+                     -> pmnc_b/pmns_b [rad] = vmnc/vmns * 2*pi/nfp
   .bc bmnc [T]          -> bmnc_b [T]  (no conversion needed)
   .bc rmnc, zmns [m]    -> rmnc_b, zmns_b [m] (no conversion needed)
 """
@@ -45,6 +46,7 @@ def _bc_to_mode_arrays(bc):
     zmns = np.zeros((nsurf, nmn))
     pmns = np.zeros((nsurf, nmn))
     bmnc = np.zeros((nsurf, nmn))
+    pmnc = np.zeros((nsurf, nmn))
     lasym = False
     rmns = np.zeros((nsurf, nmn)) if lasym else None
     zmnc = np.zeros((nsurf, nmn)) if lasym else None
@@ -59,8 +61,11 @@ def _bc_to_mode_arrays(bc):
 
         r_s = np.array(bc.rmns[k], dtype=float)
         z_c = np.array(bc.zmnc[k], dtype=float)
+        p_c = np.array(bc.vmnc[k], dtype=float) * TWOPI / bc.nper
         b_s = np.array(bc.bmns[k], dtype=float)
-        if np.any(r_s != 0.0) or np.any(z_c != 0.0) or np.any(b_s != 0.0):
+        pmnc[k] = p_c
+        if (np.any(r_s != 0.0) or np.any(z_c != 0.0)
+                or np.any(p_c != 0.0) or np.any(b_s != 0.0)):
             lasym = True
 
     if lasym:
@@ -72,7 +77,7 @@ def _bc_to_mode_arrays(bc):
             zmnc[k] = np.array(bc.zmnc[k], dtype=float)
             bmns[k] = np.array(bc.bmns[k], dtype=float)
 
-    return m0, n0, rmnc, zmns, pmns, bmnc, rmns, zmnc, bmns, lasym
+    return m0, n0, rmnc, zmns, pmns, bmnc, rmns, zmnc, pmnc, bmns, lasym
 
 
 def write_boozmn(bc, output, source=None):
@@ -118,7 +123,7 @@ def write_boozmn(bc, output, source=None):
         )
 
     # Build mode arrays from .bc.
-    m0, n0, rmnc_h, zmns_h, pmns_h, bmnc_h, rmns_h, zmnc_h, bmns_h, lasym = (
+    m0, n0, rmnc_h, zmns_h, pmns_h, bmnc_h, rmns_h, zmnc_h, pmnc_h, bmns_h, lasym = (
         _bc_to_mode_arrays(bc)
     )
     ixm = m0.astype(np.int32)
@@ -185,6 +190,7 @@ def write_boozmn(bc, output, source=None):
             _var("bmns_b", "f8", ("comput_surfs", "mn_mode"), bmns_h)
             _var("rmns_b", "f8", ("comput_surfs", "mn_mode"), rmns_h)
             _var("zmnc_b", "f8", ("comput_surfs", "mn_mode"), zmnc_h)
+            _var("pmnc_b", "f8", ("comput_surfs", "mn_mode"), pmnc_h)
 
         ds.bc2boozmn_source = str(source if source is not None else output)
 

--- a/python/tests/test_bc_to_booz_xform.py
+++ b/python/tests/test_bc_to_booz_xform.py
@@ -80,6 +80,7 @@ def _read_boozmn(path):
         d["zmns"] = np.asarray(ds.variables["zmns_b"][:])
         d["pmns"] = np.asarray(ds.variables["pmns_b"][:])
         if d["lasym"]:
+            d["bmns"] = np.asarray(ds.variables["bmns_b"][:])
             d["pmnc"] = np.asarray(ds.variables["pmnc_b"][:])
     return d
 
@@ -163,13 +164,91 @@ def test_boozmn_R0_from_rmnc(boozmn_path):
     )
 
 
-def test_asymmetric_bc_writes_pmnc_b(tmp_path):
-    """Asymmetric .bc phase cosine coefficients are preserved as pmnc_b."""
+def test_symmetric_bc_writes_modes_with_booz_xform_signs(tmp_path):
+    """Symmetric .bc coefficients keep booz_xform cos(m theta - n zeta)."""
     pytest.importorskip("netCDF4")
     from libneo.bc_to_booz_xform import write_boozmn
 
-    modes = [np.array([0, 1], dtype=int), np.array([0, 1], dtype=int)]
-    zeros = [np.zeros(2), np.zeros(2)]
+    mode_m = np.array([0, 1, 1, 2], dtype=int)
+    mode_n = np.array([0, 1, -1, -2], dtype=int)
+    zeros = [np.zeros(4), np.zeros(4)]
+    bmnc = [
+        np.array([1.5, 0.12, -0.19, 0.08]),
+        np.array([1.6, -0.21, 0.15, -0.11]),
+    ]
+    vmns = [
+        np.array([0.0, -0.14, 0.22, 0.07]),
+        np.array([0.0, 0.18, -0.25, 0.09]),
+    ]
+    bc = SimpleNamespace(
+        nsurf=2,
+        nper=4,
+        s=np.array([0.25, 0.75]),
+        flux=1.0,
+        iota=np.array([0.4, 0.5]),
+        Jpol_divided_by_nper=np.array([1.0, 2.0]),
+        Itor=np.array([3.0, 4.0]),
+        m=[mode_m, mode_m],
+        n=[mode_n, mode_n],
+        rmnc=[np.ones(4), np.ones(4)],
+        zmns=zeros,
+        vmns=vmns,
+        bmnc=bmnc,
+        rmns=zeros,
+        zmnc=zeros,
+        vmnc=zeros,
+        bmns=zeros,
+    )
+
+    out = tmp_path / "sym.nc"
+    write_boozmn(bc, out)
+
+    d = _read_boozmn(out)
+    assert d["lasym"] == 0
+    assert d["mboz"] == 2
+    assert d["nboz"] == 2
+    np.testing.assert_array_equal(d["ixm"], mode_m)
+    np.testing.assert_array_equal(d["ixn"], mode_n * bc.nper)
+
+    surface = 1
+    theta = 0.37
+    zeta = 0.21
+    scale = 2.0 * np.pi / bc.nper
+    angle = mode_m * theta - d["ixn"] * zeta
+    np.testing.assert_allclose(
+        np.sum(d["bmnc"][surface] * np.cos(angle)),
+        np.sum(bmnc[surface] * np.cos(angle)),
+    )
+    np.testing.assert_allclose(
+        np.sum(d["pmns"][surface] * np.sin(angle)),
+        np.sum(vmns[surface] * scale * np.sin(angle)),
+    )
+
+
+def test_asymmetric_bc_writes_phase_coefficients_with_booz_xform_signs(tmp_path):
+    """Asymmetric .bc phase coefficients keep booz_xform cos(m theta - n zeta)."""
+    pytest.importorskip("netCDF4")
+    from libneo.bc_to_booz_xform import write_boozmn
+
+    mode_m = np.array([0, 0, 1, 1, 2], dtype=int)
+    mode_n = np.array([0, 1, -1, 1, -2], dtype=int)
+    zeros = [np.zeros(5), np.zeros(5)]
+    bmnc = [
+        np.array([1.5, 0.21, -0.13, 0.34, -0.08]),
+        np.array([1.6, -0.17, 0.22, 0.41, 0.19]),
+    ]
+    bmns = [
+        np.array([0.0, -0.12, 0.07, 0.18, -0.03]),
+        np.array([0.0, 0.09, -0.16, 0.25, 0.11]),
+    ]
+    vmns = [
+        np.array([0.0, 0.31, -0.23, 0.14, -0.05]),
+        np.array([0.0, -0.27, 0.19, 0.33, 0.08]),
+    ]
+    vmnc = [
+        np.array([0.0, -0.18, 0.26, -0.07, 0.16]),
+        np.array([0.0, 0.24, -0.11, 0.29, -0.21]),
+    ]
     bc = SimpleNamespace(
         nsurf=2,
         nper=3,
@@ -178,30 +257,56 @@ def test_asymmetric_bc_writes_pmnc_b(tmp_path):
         iota=np.array([0.4, 0.5]),
         Jpol_divided_by_nper=np.array([1.0, 2.0]),
         Itor=np.array([3.0, 4.0]),
-        m=modes,
-        n=modes,
-        rmnc=[np.array([1.0, 0.1]), np.array([1.1, 0.2])],
+        m=[mode_m, mode_m],
+        n=[mode_n, mode_n],
+        rmnc=[
+            np.array([1.0, 0.1, 0.2, 0.3, 0.4]),
+            np.array([1.1, 0.2, 0.3, 0.4, 0.5]),
+        ],
         zmns=zeros,
-        vmns=zeros,
-        bmnc=[np.array([1.5, 0.3]), np.array([1.6, 0.4])],
+        vmns=vmns,
+        bmnc=bmnc,
         rmns=zeros,
         zmnc=zeros,
-        vmnc=[np.array([0.0, 0.6]), np.array([0.0, 0.9])],
-        bmns=zeros,
+        vmnc=vmnc,
+        bmns=bmns,
     )
 
     out = tmp_path / "asym.nc"
     write_boozmn(bc, out)
 
-    import netCDF4
+    d = _read_boozmn(out)
+    assert d["lasym"] == 1
+    assert d["mboz"] == 2
+    assert d["nboz"] == 2
+    np.testing.assert_array_equal(d["ixm"], mode_m)
+    np.testing.assert_array_equal(d["ixn"], mode_n * bc.nper)
 
-    with netCDF4.Dataset(out) as ds:
-        assert int(np.asarray(ds.variables["lasym__logical__"][:])) == 1
-        assert "pmnc_b" in ds.variables
-        np.testing.assert_allclose(
-            ds.variables["pmnc_b"][:, 1],
-            np.array([0.6, 0.9]) * 2.0 * np.pi / bc.nper,
-        )
+    scale = 2.0 * np.pi / bc.nper
+    np.testing.assert_allclose(d["pmns"], np.asarray(vmns) * scale)
+    np.testing.assert_allclose(d["pmnc"], np.asarray(vmnc) * scale)
+
+    surface = 1
+    theta = 0.37
+    zeta = 0.21
+    angle = mode_m * theta - d["ixn"] * zeta
+    np.testing.assert_allclose(
+        np.sum(
+            d["bmnc"][surface] * np.cos(angle)
+            + d["bmns"][surface] * np.sin(angle)
+        ),
+        np.sum(bmnc[surface] * np.cos(angle) + bmns[surface] * np.sin(angle)),
+    )
+    np.testing.assert_allclose(
+        np.sum(
+            d["pmnc"][surface] * np.cos(angle)
+            + d["pmns"][surface] * np.sin(angle)
+        ),
+        np.sum(
+            vmnc[surface] * scale * np.cos(angle)
+            + vmns[surface] * scale * np.sin(angle)
+        ),
+    )
 
 
 def test_asymmetric_vmec_bc_to_boozmn_matches_booz_xform_mode_signs(tmp_path):

--- a/python/tests/test_bc_to_booz_xform.py
+++ b/python/tests/test_bc_to_booz_xform.py
@@ -1,15 +1,27 @@
 """Tests for bc_to_booz_xform: .bc -> boozmn -> chartmap conversion."""
 
+from contextlib import redirect_stdout
+import io
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.request import urlopen
 import numpy as np
 import pytest
 
 TESTS_DIR = Path(__file__).parent
 CIRC_BC = Path(__file__).resolve().parent / "circ.bc"
+LSP_WOUT_URL = (
+    "https://raw.githubusercontent.com/hiddenSymmetries/simsopt/master/"
+    "tests/test_files/wout_LandremanSenguptaPlunk_section5p3_reference.nc"
+)
 
 R0_expected = 1.64377  # m, from circ.bc header
 A_expected = 0.46      # m
+
+
+def _download(url: str, out_path: Path) -> None:
+    with urlopen(url, timeout=60) as resp, open(out_path, "wb") as f:
+        f.write(resp.read())
 
 
 @pytest.fixture(scope="module")
@@ -56,6 +68,9 @@ def _read_boozmn(path):
         d["jlist"] = np.asarray(ds.variables["jlist"][:])
         d["ixm"] = np.asarray(ds.variables["ixm_b"][:])
         d["ixn"] = np.asarray(ds.variables["ixn_b"][:])
+        d["lasym"] = int(np.asarray(ds.variables["lasym__logical__"][:]))
+        d["mboz"] = int(np.asarray(ds.variables["mboz_b"][:]))
+        d["nboz"] = int(np.asarray(ds.variables["nboz_b"][:]))
         d["iota"] = np.asarray(ds.variables["iota_b"][:])
         d["bvco"] = np.asarray(ds.variables["bvco_b"][:])
         d["buco"] = np.asarray(ds.variables["buco_b"][:])
@@ -64,6 +79,8 @@ def _read_boozmn(path):
         d["rmnc"] = np.asarray(ds.variables["rmnc_b"][:])
         d["zmns"] = np.asarray(ds.variables["zmns_b"][:])
         d["pmns"] = np.asarray(ds.variables["pmns_b"][:])
+        if d["lasym"]:
+            d["pmnc"] = np.asarray(ds.variables["pmnc_b"][:])
     return d
 
 
@@ -185,6 +202,59 @@ def test_asymmetric_bc_writes_pmnc_b(tmp_path):
             ds.variables["pmnc_b"][:, 1],
             np.array([0.6, 0.9]) * 2.0 * np.pi / bc.nper,
         )
+
+
+def test_asymmetric_vmec_bc_to_boozmn_matches_booz_xform_mode_signs(tmp_path):
+    pytest.importorskip("booz_xform")
+    pytest.importorskip("scipy")
+    pytest.importorskip("netCDF4")
+
+    from booz_xform import Booz_xform
+    from libneo.bc_to_booz_xform import convert_bc_to_boozmn
+    from libneo.boozer import BoozerFile
+
+    wout = tmp_path / "wout_lsp_section5p3.nc"
+    booz_xform_path = tmp_path / "boozmn_booz_xform.nc"
+    bc_path = tmp_path / "libneo.bc"
+    libneo_path = tmp_path / "boozmn_libneo.nc"
+
+    _download(LSP_WOUT_URL, wout)
+
+    with redirect_stdout(io.StringIO()):
+        bx = Booz_xform()
+        bx.read_wout(str(wout), True)
+        bx.mboz = 6
+        bx.nboz = 8
+        bx.run()
+        bx.write_boozmn(str(booz_xform_path))
+
+        bc = BoozerFile(filename="")
+        bc.convert_vmec_to_boozer(str(wout), uv_grid_multiplicator=1)
+        bc.write(str(bc_path))
+        convert_bc_to_boozmn(bc_path, libneo_path)
+
+    booz_xform_boozmn = _read_boozmn(booz_xform_path)
+    libneo_boozmn = _read_boozmn(libneo_path)
+
+    assert booz_xform_boozmn["lasym"] == 1
+    assert libneo_boozmn["lasym"] == 1
+    assert "pmnc" in libneo_boozmn
+    assert booz_xform_boozmn["nfp"] == libneo_boozmn["nfp"] == 3
+
+    booz_xform_modes = set(zip(booz_xform_boozmn["ixm"], booz_xform_boozmn["ixn"]))
+    libneo_modes = set(zip(libneo_boozmn["ixm"], libneo_boozmn["ixn"]))
+    missing_modes = sorted(booz_xform_modes - libneo_modes)
+    sign_flipped_modes = [
+        (m, n) for (m, n) in missing_modes if n != 0 and (m, -n) in libneo_modes
+    ]
+
+    assert not sign_flipped_modes
+    assert not missing_modes
+
+    booz_xform_m0_n = sorted(n for m, n in booz_xform_modes if m == 0 and n > 0)
+    assert booz_xform_m0_n
+    assert all((0, n) in libneo_modes for n in booz_xform_m0_n)
+    assert not any((0, -n) in libneo_modes for n in booz_xform_m0_n)
 
 
 def test_chartmap_from_bc_structure(chartmap_path):

--- a/python/tests/test_bc_to_booz_xform.py
+++ b/python/tests/test_bc_to_booz_xform.py
@@ -1,6 +1,7 @@
 """Tests for bc_to_booz_xform: .bc -> boozmn -> chartmap conversion."""
 
 from pathlib import Path
+from types import SimpleNamespace
 import numpy as np
 import pytest
 
@@ -143,6 +144,47 @@ def test_boozmn_R0_from_rmnc(boozmn_path):
     assert abs(R0_computed - R0_expected) < 0.1, (
         f"R0={R0_computed:.4f} m, expected {R0_expected:.4f} m"
     )
+
+
+def test_asymmetric_bc_writes_pmnc_b(tmp_path):
+    """Asymmetric .bc phase cosine coefficients are preserved as pmnc_b."""
+    pytest.importorskip("netCDF4")
+    from libneo.bc_to_booz_xform import write_boozmn
+
+    modes = [np.array([0, 1], dtype=int), np.array([0, 1], dtype=int)]
+    zeros = [np.zeros(2), np.zeros(2)]
+    bc = SimpleNamespace(
+        nsurf=2,
+        nper=3,
+        s=np.array([0.25, 0.75]),
+        flux=1.0,
+        iota=np.array([0.4, 0.5]),
+        Jpol_divided_by_nper=np.array([1.0, 2.0]),
+        Itor=np.array([3.0, 4.0]),
+        m=modes,
+        n=modes,
+        rmnc=[np.array([1.0, 0.1]), np.array([1.1, 0.2])],
+        zmns=zeros,
+        vmns=zeros,
+        bmnc=[np.array([1.5, 0.3]), np.array([1.6, 0.4])],
+        rmns=zeros,
+        zmnc=zeros,
+        vmnc=[np.array([0.0, 0.6]), np.array([0.0, 0.9])],
+        bmns=zeros,
+    )
+
+    out = tmp_path / "asym.nc"
+    write_boozmn(bc, out)
+
+    import netCDF4
+
+    with netCDF4.Dataset(out) as ds:
+        assert int(np.asarray(ds.variables["lasym__logical__"][:])) == 1
+        assert "pmnc_b" in ds.variables
+        np.testing.assert_allclose(
+            ds.variables["pmnc_b"][:, 1],
+            np.array([0.6, 0.9]) * 2.0 * np.pi / bc.nper,
+        )
 
 
 def test_chartmap_from_bc_structure(chartmap_path):

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,15 @@ wheels = [
 ]
 
 [[package]]
+name = "booz-xform"
+version = "0.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/c5/8551d16ce47bde9087d4f8fd7794e0f42c196da58ccd4c1039966ba669f5/booz_xform-0.0.9.tar.gz", hash = "sha256:d650c5fcbd668cbccea50fbfd6e5c507225eb07218acd4991875804aaeb574d7", size = 1075083, upload-time = "2025-07-29T13:15:02.503Z" }
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -311,6 +320,7 @@ chartmap = [
     { name = "trimesh" },
 ]
 dev = [
+    { name = "booz-xform" },
     { name = "h5py" },
     { name = "map2disc" },
     { name = "matplotlib" },
@@ -328,6 +338,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "booz-xform", marker = "extra == 'dev'" },
     { name = "h5py", marker = "extra == 'dev'" },
     { name = "map2disc", marker = "extra == 'chartmap'", git = "https://github.com/itpplasma/map2disc.git" },
     { name = "map2disc", marker = "extra == 'dev'", git = "https://github.com/itpplasma/map2disc.git" },


### PR DESCRIPTION
## Summary
- carry `.bc` `vmnc` through `.bc -> boozmn` as `pmnc_b`
- treat nonzero `vmnc` as asymmetric input
- test synthetic stellarator-symmetric and asymmetric `.bc` inputs with positive and negative `n`
- check `ixn_b = n*nfp`, `bmns_b`, `pmns_b`, and `pmnc_b` by evaluating the written coefficients with booz_xform phase `m*theta - n*zeta`
- compare a public asymmetric Simsopt VMEC file against booz_xform's own `ixn_b` mode-sign convention

## Verification
### Test fails on main
```text
$ python check_asymmetric_bc_to_boozmn.py
has_pmnc_b False
Traceback (most recent call last):
  File "<stdin>", line 16, in <module>
AssertionError: missing pmnc_b
```

### Test passes after fix
```text
$ uv run --python /usr/bin/python3.14 --extra dev python -m pytest python/tests/test_bc_to_booz_xform.py -q
..........                                                               [100%]
10 passed, 2330 warnings in 1.94s
```