### PR TITLE
field_mesh: name the default mesh resolution constant

### DIFF
--- a/src/field/field_mesh.f90
+++ b/src/field/field_mesh.f90
@@ -70,6 +70,7 @@ subroutine field_mesh_init_with_field(self, limits, field, n_points, is_periodic
     integer, dimension(3), intent(in), optional :: n_points
     logical, intent(in), optional :: is_periodic(3)
 
+    integer, parameter :: n_points_default = 10
     integer :: i, j, k
     real(dp), dimension(:), allocatable :: x1, x2, x3
     real(dp), dimension(3) :: x, A, B
@@ -80,10 +81,10 @@ subroutine field_mesh_init_with_field(self, limits, field, n_points, is_periodic
         x2 = linspace(limits(2,1), limits(2,2), n_points(2))
         x3 = linspace(limits(3,1), limits(3,2), n_points(3))
     else
-        allocate(x1(10), x2(10), x3(10))
-        x1 = linspace(limits(1,1), limits(1,2), 10)
-        x2 = linspace(limits(2,1), limits(2,2), 10)
-        x3 = linspace(limits(3,1), limits(3,2), 10)
+        allocate(x1(n_points_default), x2(n_points_default), x3(n_points_default))
+        x1 = linspace(limits(1,1), limits(1,2), n_points_default)
+        x2 = linspace(limits(2,1), limits(2,2), n_points_default)
+        x3 = linspace(limits(3,1), limits(3,2), n_points_default)
     end if
 
     call self%A1%mesh_init(x1, x2, x3, is_periodic=is_periodic)


### PR DESCRIPTION
## What

Follow-up to the review afterthoughts on #349.

- **`field_mesh_init_with_field`**: the no-`n_points` branch hardcoded `10` in
  four places. Replace with a named `n_points_default` parameter so the default
  mesh resolution reads as an intentional default, not a magic number. Pure
  rename, no behavior change.

The second afterthought (setting the axis `s`-derivatives in `splint_vmec_data`
to `NaN` instead of `0.0`) is **deliberately not applied**. `vmec_from_cyl`'s
Newton solver reads `dR_ds`/`dZ_ds` into a Jacobian and guards on
`abs(det) < tol`. For an on-axis query `s` clamps to `0`, so:

- With `0.0`: `det = 0`, the existing singular-Jacobian guard fires cleanly
  (`ierr = 2`).
- With `NaN`: `abs(det) < tol` is an IEEE *ordered* comparison, which signals
  `INVALID` on a quiet `NaN` and re-arms the Debug `-ffpe-trap` SIGFPE that #349
  removed (and poisons the Release solve).

So `0.0` is load-bearing here. A proper fail-loud signal would need an explicit
"axis / derivative-undefined" status out-arg rather than smuggling `NaN` through
a numeric out-argument. Reasoning recorded on #349.

## Verification

Release build (existing `build/`), affected field tests.

Before (this branch, no functional change to verify a regression against — this
is a readability rename of a constant with identical numeric value `10`):

After:
```
    Start 68: test_field_mesh
1/2 Test #68: test_field_mesh ..................   Passed    0.05 sec
    Start 70: test_spline_field
2/2 Test #70: test_spline_field ................   Passed    0.39 sec

100% tests passed, 0 tests failed out of 2
```

`n_points_default = 10` reproduces the prior literal exactly, so numerical
output is unchanged.
