### PR TITLE
Bump fortnum pin to CQUAD revision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ if(LIBNEO_BUILD_NUMERICS AND NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
         GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-        GIT_TAG 92de6e949a772cfffc73bb5295fe5e2b056b9c18
+        GIT_TAG 62a559c0b8e1b28bd63550164a09ed9644e659b1
     )
     FetchContent_MakeAvailable(fortnum)
 endif()


### PR DESCRIPTION
Bumps the fortnum FetchContent pin `92de6e9` -> `62a559c` (lazy-fortran/fortnum main).

fortnum 62a559c adds `fortnum_cquad`/`integrate_cquad`, a genuine doubly-adaptive Clenshaw-Curtis integrator (verified against scipy/QUADPACK to full double precision). NEO-2 pulls fortnum transitively through libneo, so this pin is what its collision-operator CQUAD path actually builds against; without it NEO-2's fint1d_cquad routing to integrate_cquad cannot resolve the module.