### PR TITLE
Add shared boozmn (booz_xform) reader feeding Boozer splines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,8 +290,11 @@ add_library(boozer STATIC
     src/boozer_converter.F90
     src/boozer_chartmap.f90
     src/field/boozer_chartmap_io.f90
+    src/field/boozmn_file.f90
+    src/field/boozmn_reader.f90
 )
 target_link_libraries(boozer PUBLIC vmec_support interpolate neo_util)
+target_link_libraries(boozer PRIVATE nctools)
 if(TARGET netcdf::netcdff)
     target_link_libraries(boozer PRIVATE netcdf::netcdff)
 elseif(TARGET netcdf::netcdf)

--- a/src/field/boozmn_file.f90
+++ b/src/field/boozmn_file.f90
@@ -1,0 +1,83 @@
+module boozmn_file
+!> Raw reader for booz_xform boozmn NetCDF output.
+!>
+!> Layout follows the booz_xform convention: Fourier harmonics live on the
+!> half-grid surfaces listed in jlist, the profiles iota, buco, bvco, phi on
+!> the full grid of ns surfaces, and ixn already contains the nfp factor.
+!> Angles enter as cos(m*theta - n*zeta) for the *mnc and
+!> sin(m*theta - n*zeta) for the *mns coefficients. All values keep the file
+!> units (SI: T, m, Wb).
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+
+    implicit none
+    private
+
+    public :: boozmn_data_t, read_boozmn
+
+    type :: boozmn_data_t
+        integer :: ns = 0
+        integer :: nfp = 0
+        integer :: nmodes = 0
+        integer :: nsurf = 0
+        logical :: asym = .false.
+        integer, allocatable :: jlist(:)
+        integer, allocatable :: ixm(:), ixn(:)
+        real(dp), allocatable :: iota(:), buco(:), bvco(:), phi(:)
+        real(dp), allocatable :: bmnc(:, :), rmnc(:, :), zmns(:, :), pmns(:, :)
+        real(dp), allocatable :: bmns(:, :), rmns(:, :), zmnc(:, :), pmnc(:, :)
+    end type boozmn_data_t
+
+contains
+
+    subroutine read_boozmn(filename, d)
+        use nctools_module, only: nc_open, nc_close, nc_inq_dim, nc_get
+        use netcdf, only: nf90_inq_varid, nf90_noerr
+
+        character(len=*), intent(in) :: filename
+        type(boozmn_data_t), intent(out) :: d
+
+        integer :: ncid, varid, lasym
+
+        call nc_open(trim(filename), ncid)
+        call nc_get(ncid, 'ns_b', d%ns)
+        call nc_get(ncid, 'nfp_b', d%nfp)
+        call nc_inq_dim(ncid, 'ixm_b', d%nmodes)
+        call nc_inq_dim(ncid, 'jlist', d%nsurf)
+
+        lasym = 0
+        if (nf90_inq_varid(ncid, 'lasym__logical__', varid) == nf90_noerr) then
+            call nc_get(ncid, 'lasym__logical__', lasym)
+        end if
+        d%asym = lasym /= 0
+
+        allocate (d%jlist(d%nsurf), d%ixm(d%nmodes), d%ixn(d%nmodes))
+        allocate (d%iota(d%ns), d%buco(d%ns), d%bvco(d%ns), d%phi(d%ns))
+        allocate (d%bmnc(d%nmodes, d%nsurf), d%rmnc(d%nmodes, d%nsurf), &
+                  d%zmns(d%nmodes, d%nsurf), d%pmns(d%nmodes, d%nsurf))
+
+        call nc_get(ncid, 'jlist', d%jlist)
+        call nc_get(ncid, 'ixm_b', d%ixm)
+        call nc_get(ncid, 'ixn_b', d%ixn)
+        call nc_get(ncid, 'iota_b', d%iota)
+        call nc_get(ncid, 'buco_b', d%buco)
+        call nc_get(ncid, 'bvco_b', d%bvco)
+        call nc_get(ncid, 'phi_b', d%phi)
+        call nc_get(ncid, 'bmnc_b', d%bmnc)
+        call nc_get(ncid, 'rmnc_b', d%rmnc)
+        call nc_get(ncid, 'zmns_b', d%zmns)
+        call nc_get(ncid, 'pmns_b', d%pmns)
+
+        if (d%asym) then
+            allocate (d%bmns(d%nmodes, d%nsurf), d%rmns(d%nmodes, d%nsurf), &
+                      d%zmnc(d%nmodes, d%nsurf), d%pmnc(d%nmodes, d%nsurf))
+            call nc_get(ncid, 'bmns_b', d%bmns)
+            call nc_get(ncid, 'rmns_b', d%rmns)
+            call nc_get(ncid, 'zmnc_b', d%zmnc)
+            call nc_get(ncid, 'pmnc_b', d%pmnc)
+        end if
+
+        call nc_close(ncid)
+    end subroutine read_boozmn
+
+end module boozmn_file

--- a/src/field/boozmn_reader.f90
+++ b/src/field/boozmn_reader.f90
@@ -1,0 +1,271 @@
+module boozmn_reader
+!> Load Boozer splines from a booz_xform boozmn NetCDF.
+!>
+!> Reads the harmonics via boozmn_file, evaluates Bmod on a uniform grid by
+!> Fourier summation, and hands the result to build_boozer_from_chartmap so
+!> the boozmn and chartmap paths share one spline backend.
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+
+    implicit none
+
+    private
+    public :: load_boozer_from_boozmn
+
+    real(dp), parameter :: TWOPI = 8.0_dp*atan(1.0_dp)
+    real(dp), parameter :: GAUSS_CM2_PER_TM2 = 1.0e8_dp
+    real(dp), parameter :: GAUSS_CM_PER_TM = 1.0e6_dp
+    real(dp), parameter :: GAUSS_PER_T = 1.0e4_dp
+
+contains
+
+    subroutine load_boozer_from_boozmn(boozmn_filename, nrho_in, ntheta_in, nzeta_in)
+        use boozmn_file, only: boozmn_data_t, read_boozmn
+        use boozer_chartmap_types, only: boozer_chartmap_data_t
+        use boozer_sub, only: build_boozer_from_chartmap
+
+        character(len=*), intent(in) :: boozmn_filename
+        integer, intent(in), optional :: nrho_in, ntheta_in, nzeta_in
+
+        type(boozmn_data_t) :: b
+        type(boozer_chartmap_data_t) :: d
+        integer :: nrho, ntheta, nzeta
+        integer :: ir, it, iz, mn, mn00
+        integer :: k
+        real(dp), allocatable :: rho_half(:), s_half(:)
+        real(dp), allocatable :: theta(:), zeta(:), bmnc_out(:, :)
+        real(dp), allocatable :: bmod_geom(:, :, :)
+        real(dp) :: torflux_si, angle
+        real(dp) :: rho_min, rho_max, s_min, s_max
+
+        nrho = 30
+        ntheta = 48
+        nzeta = 96
+        if (present(nrho_in)) nrho = nrho_in
+        if (present(ntheta_in)) ntheta = ntheta_in
+        if (present(nzeta_in)) nzeta = nzeta_in
+
+        call read_boozmn(boozmn_filename, b)
+        if (b%asym) then
+            error stop "asymmetric (lasym=1) boozmn not yet supported"
+        end if
+
+        allocate (s_half(b%nsurf), rho_half(b%nsurf))
+        do k = 1, b%nsurf
+            s_half(k) = (real(b%jlist(k), dp) - 1.5_dp)/real(b%ns - 1, dp)
+        end do
+        rho_half = sqrt(s_half)
+
+        torflux_si = -b%phi(b%ns)/TWOPI
+
+        rho_min = 1.0e-3_dp
+        rho_max = 1.0_dp
+        s_min = rho_min**2
+        s_max = rho_max**2
+
+        d%n_rho = nrho
+        d%n_s = nrho
+        d%nfp = b%nfp
+        d%torflux = torflux_si*GAUSS_CM2_PER_TM2
+        d%rho_min = rho_min
+        d%rho_max = rho_max
+        d%h_rho = (rho_max - rho_min)/real(nrho - 1, dp)
+        d%h_s = (s_max - s_min)/real(nrho - 1, dp)
+
+        allocate (d%rho(nrho), d%s(nrho))
+        allocate (d%A_phi(nrho), d%B_theta(nrho), d%B_phi(nrho))
+        do ir = 1, nrho
+            d%rho(ir) = rho_min + d%h_rho*real(ir - 1, dp)
+            d%s(ir) = s_min + d%h_s*real(ir - 1, dp)
+        end do
+
+        call interp_1d(b%buco(b%jlist), rho_half, d%rho, b%nsurf, nrho, d%B_theta)
+        call interp_1d(b%bvco(b%jlist), rho_half, d%rho, b%nsurf, nrho, d%B_phi)
+        call iota_integral(b%iota(b%jlist), rho_half, d%s, b%nsurf, nrho, &
+                           torflux_si, d%A_phi)
+        d%B_theta = d%B_theta*GAUSS_CM_PER_TM
+        d%B_phi = d%B_phi*GAUSS_CM_PER_TM
+        d%A_phi = d%A_phi*GAUSS_CM2_PER_TM2
+
+        allocate (theta(ntheta), zeta(nzeta), bmnc_out(nrho, b%nmodes))
+        do it = 1, ntheta
+            theta(it) = TWOPI*real(it - 1, dp)/real(ntheta, dp)
+        end do
+        do iz = 1, nzeta
+            zeta(iz) = TWOPI/real(b%nfp, dp)*real(iz - 1, dp)/real(nzeta, dp)
+        end do
+
+        call interp_modes(b%bmnc, rho_half, d%rho, b%ixm, b%nmodes, b%nsurf, &
+                          nrho, bmnc_out)
+
+        allocate (bmod_geom(nrho, ntheta, nzeta))
+        do ir = 1, nrho
+            do it = 1, ntheta
+                do iz = 1, nzeta
+                    bmod_geom(ir, it, iz) = 0.0_dp
+                    do mn = 1, b%nmodes
+                        angle = real(b%ixm(mn), dp)*theta(it) &
+                                - real(b%ixn(mn), dp)*zeta(iz)
+                        bmod_geom(ir, it, iz) = bmod_geom(ir, it, iz) &
+                                                + bmnc_out(ir, mn)*cos(angle)
+                    end do
+                    bmod_geom(ir, it, iz) = bmod_geom(ir, it, iz)*GAUSS_PER_T
+                end do
+            end do
+        end do
+
+        d%n_theta = ntheta + 1
+        d%n_phi = nzeta + 1
+        d%h_theta = theta(2) - theta(1)
+        d%h_phi = zeta(2) - zeta(1)
+        allocate (d%Bmod(nrho, d%n_theta, d%n_phi))
+        d%Bmod(:, 1:ntheta, 1:nzeta) = bmod_geom
+        d%Bmod(:, d%n_theta, 1:nzeta) = bmod_geom(:, 1, :)
+        d%Bmod(:, 1:ntheta, d%n_phi) = bmod_geom(:, :, 1)
+        d%Bmod(:, d%n_theta, d%n_phi) = bmod_geom(:, 1, 1)
+
+        mn00 = 0
+        do mn = 1, b%nmodes
+            if (b%ixm(mn) == 0 .and. b%ixn(mn) == 0) then
+                mn00 = mn
+                exit
+            end if
+        end do
+        if (mn00 > 0) then
+            d%rmajor = b%rmnc(mn00, b%nsurf)
+        else
+            d%rmajor = 1.0_dp
+        end if
+
+        call build_boozer_from_chartmap(d)
+    end subroutine load_boozer_from_boozmn
+
+    !> Interpolate boozmn Fourier coefficients from the half grid to rho_out.
+    !> bmnc_h is shaped (nmn, nsurf): Fortran order from NetCDF (comput_surfs, mn_mode).
+    subroutine interp_modes(bmnc_h, rho_half, rho_out, ixm, nmn, nsurf, nrho_out, &
+                            bmnc_out)
+        integer, intent(in) :: nmn, nsurf, nrho_out
+        real(dp), intent(in) :: bmnc_h(nmn, nsurf)
+        real(dp), intent(in) :: rho_half(nsurf)
+        real(dp), intent(in) :: rho_out(nrho_out)
+        integer, intent(in) :: ixm(nmn)
+        real(dp), intent(out) :: bmnc_out(nrho_out, nmn)
+
+        integer :: ir, mn, k
+        real(dp) :: rho, frac, ratio
+
+        do ir = 1, nrho_out
+            rho = rho_out(ir)
+            if (rho <= rho_half(1)) then
+                do mn = 1, nmn
+                    if (rho_half(1) > 0.0_dp) then
+                        ratio = rho/rho_half(1)
+                        bmnc_out(ir, mn) = bmnc_h(mn, 1)*ratio**min(ixm(mn), 50)
+                    else
+                        bmnc_out(ir, mn) = bmnc_h(mn, 1)
+                    end if
+                end do
+            else if (rho >= rho_half(nsurf)) then
+                do mn = 1, nmn
+                    bmnc_out(ir, mn) = bmnc_h(mn, nsurf)
+                end do
+            else
+                k = 1
+                do while (k < nsurf)
+                    if (rho_half(k + 1) >= rho) exit
+                    k = k + 1
+                end do
+                if (rho_half(k + 1) > rho_half(k)) then
+                    frac = (rho - rho_half(k))/(rho_half(k + 1) - rho_half(k))
+                else
+                    frac = 0.0_dp
+                end if
+                do mn = 1, nmn
+                    bmnc_out(ir, mn) = (1.0_dp - frac)*bmnc_h(mn, k) &
+                                       + frac*bmnc_h(mn, k + 1)
+                end do
+            end if
+        end do
+    end subroutine interp_modes
+
+    !> Interpolate a 1D radial profile from the half grid to rho_out.
+    subroutine interp_1d(vals_h, rho_half, rho_out, nsurf, nrho_out, vals_out)
+        integer, intent(in) :: nsurf, nrho_out
+        real(dp), intent(in) :: vals_h(nsurf)
+        real(dp), intent(in) :: rho_half(nsurf)
+        real(dp), intent(in) :: rho_out(nrho_out)
+        real(dp), intent(out) :: vals_out(nrho_out)
+
+        integer :: ir, k
+        real(dp) :: rho, frac
+
+        do ir = 1, nrho_out
+            rho = rho_out(ir)
+            if (rho <= rho_half(1)) then
+                vals_out(ir) = vals_h(1)
+            else if (rho >= rho_half(nsurf)) then
+                vals_out(ir) = vals_h(nsurf)
+            else
+                k = 1
+                do while (k < nsurf)
+                    if (rho_half(k + 1) >= rho) exit
+                    k = k + 1
+                end do
+                if (rho_half(k + 1) > rho_half(k)) then
+                    frac = (rho - rho_half(k))/(rho_half(k + 1) - rho_half(k))
+                else
+                    frac = 0.0_dp
+                end if
+                vals_out(ir) = (1.0_dp - frac)*vals_h(k) + frac*vals_h(k + 1)
+            end if
+        end do
+    end subroutine interp_1d
+
+    !> A_phi(s) = -torflux_si * integral_0^s iota(s') ds', in T*m^2.
+    subroutine iota_integral(iota_h, rho_half, s_out, nsurf, nrho_out, torflux_si, &
+                             A_phi_out)
+        integer, intent(in) :: nsurf, nrho_out
+        real(dp), intent(in) :: iota_h(nsurf)
+        real(dp), intent(in) :: rho_half(nsurf)
+        real(dp), intent(in) :: s_out(nrho_out)
+        real(dp), intent(in) :: torflux_si
+        real(dp), intent(out) :: A_phi_out(nrho_out)
+
+        integer :: ir, k
+        real(dp) :: iota_at_s, s, s_half_sq(nsurf), cum(nsurf)
+
+        s_half_sq = rho_half**2
+
+        cum(1) = 0.0_dp
+        do k = 2, nsurf
+            cum(k) = cum(k - 1) + 0.5_dp*(iota_h(k - 1) + iota_h(k)) &
+                     *(s_half_sq(k) - s_half_sq(k - 1))
+        end do
+
+        do ir = 1, nrho_out
+            s = s_out(ir)
+            if (s <= s_half_sq(1)) then
+                iota_at_s = iota_h(1)
+                A_phi_out(ir) = -torflux_si*iota_at_s*s
+            else if (s >= s_half_sq(nsurf)) then
+                A_phi_out(ir) = -torflux_si*(cum(nsurf) + &
+                                             iota_h(nsurf)*(s - s_half_sq(nsurf)))
+            else
+                k = 1
+                do while (k < nsurf)
+                    if (s_half_sq(k + 1) >= s) exit
+                    k = k + 1
+                end do
+                if (s_half_sq(k + 1) > s_half_sq(k)) then
+                    iota_at_s = iota_h(k) + (iota_h(k + 1) - iota_h(k))* &
+                                (s - s_half_sq(k))/(s_half_sq(k + 1) - s_half_sq(k))
+                else
+                    iota_at_s = iota_h(k)
+                end if
+                A_phi_out(ir) = -torflux_si*(cum(k) + 0.5_dp*(iota_h(k) + iota_at_s)* &
+                                             (s - s_half_sq(k)))
+            end if
+        end do
+    end subroutine iota_integral
+
+end module boozmn_reader

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -572,6 +572,14 @@ set_tests_properties(test_boozer_chartmap_roundtrip PROPERTIES
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS setup_vmec_wout)
 
+add_executable(test_boozmn_reader.x source/test_boozmn_reader.f90)
+target_link_libraries(test_boozmn_reader.x neo)
+add_test(NAME test_boozmn_reader
+  COMMAND test_boozmn_reader.x)
+set_tests_properties(test_boozmn_reader PROPERTIES
+  FAIL_REGULAR_EXPRESSION "STOP"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 add_executable(test_delthe_delphi_bv_d2.x source/test_delthe_delphi_bv_d2.f90)
 target_link_libraries(test_delthe_delphi_bv_d2.x neo)
 add_test(NAME test_delthe_delphi_bv_d2

--- a/test/source/test_boozmn_reader.f90
+++ b/test/source/test_boozmn_reader.f90
@@ -1,0 +1,236 @@
+!> Pin the boozmn NetCDF reader and the boozmn -> Boozer-spline loader.
+!>
+!> Writes synthetic booz_xform boozmn files (symmetric and asymmetric),
+!> checks the raw fields read_boozmn returns, then loads the symmetric file
+!> via load_boozer_from_boozmn and compares |B| from splint_boozer_coord
+!> against the analytic Fourier sum of the fixture modes.
+program test_boozmn_reader
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use netcdf
+    use boozmn_file, only: boozmn_data_t, read_boozmn
+    use boozmn_reader, only: load_boozer_from_boozmn
+    use boozer_sub, only: splint_boozer_coord
+
+    implicit none
+
+    character(len=*), parameter :: sym_file = 'boozmn_reader_sym.nc'
+    character(len=*), parameter :: asym_file = 'boozmn_reader_asym.nc'
+    integer, parameter :: ns_full = 5
+    integer, parameter :: nsurf = 3
+    integer, parameter :: nmode = 4
+    integer, dimension(nmode), parameter :: ixm = [0, 1, 1, 2]
+    integer, dimension(nmode), parameter :: ixn = [0, 1, -1, 0]
+    real(dp), dimension(nmode), parameter :: bmn = &
+        [2.0_dp, 0.1_dp, -0.07_dp, 0.02_dp]
+    integer, dimension(nsurf), parameter :: jlist = [2, 3, 4]
+    real(dp), dimension(ns_full), parameter :: iota_full = &
+        [0.5_dp, 0.55_dp, 0.6_dp, 0.65_dp, 0.7_dp]
+    real(dp), dimension(ns_full), parameter :: phi_full = &
+        [0.0_dp, 0.2_dp, 0.5_dp, 0.9_dp, 1.3_dp]
+
+    real(dp), parameter :: TWOPI = 8.0_dp*atan(1.0_dp)
+    real(dp), parameter :: GAUSS_PER_T = 1.0e4_dp
+    real(dp), parameter :: stor = 0.5_dp
+    real(dp), parameter :: theta = TWOPI*7.0_dp/48.0_dp
+    real(dp), parameter :: zeta = TWOPI*11.0_dp/96.0_dp
+    real(dp), parameter :: reltol = 1.0e-6_dp
+
+    type(boozmn_data_t) :: d
+    real(dp) :: bmod, expected
+
+    call write_boozmn_fixture(sym_file, asym=.false.)
+    call write_boozmn_fixture(asym_file, asym=.true.)
+
+    call read_boozmn(sym_file, d)
+    call check_raw_symmetric(d)
+
+    call read_boozmn(asym_file, d)
+    if (.not. d%asym) error stop 'asym flag not read'
+    if (.not. allocated(d%bmns)) error stop 'bmns not allocated for asym file'
+    call assert_close(d%bmns(2, 1), 0.5_dp*bmn(2), 'bmns spot value')
+    call assert_close(d%pmnc(3, 2), 0.25_dp*bmn(3), 'pmnc spot value')
+    print *, 'OK raw asymmetric read'
+
+    call load_boozer_from_boozmn(sym_file)
+    call eval_bmod(stor, theta, zeta, bmod)
+    expected = expected_bmod(theta, zeta)*GAUSS_PER_T
+    print *, 'boozmn Bmod:', bmod, ' expected:', expected
+    if (abs(bmod - expected) > reltol*abs(expected)) then
+        error stop 'boozmn Bmod mismatch'
+    end if
+    print *, 'OK boozmn -> Boozer splines'
+
+contains
+
+    subroutine check_raw_symmetric(b)
+        type(boozmn_data_t), intent(in) :: b
+
+        if (b%ns /= ns_full) error stop 'ns mismatch'
+        if (b%nfp /= 1) error stop 'nfp mismatch'
+        if (b%nmodes /= nmode) error stop 'nmodes mismatch'
+        if (b%nsurf /= nsurf) error stop 'nsurf mismatch'
+        if (b%asym) error stop 'asym flag set for symmetric file'
+        if (any(b%jlist /= jlist)) error stop 'jlist mismatch'
+        if (any(b%ixm /= ixm)) error stop 'ixm mismatch'
+        if (any(b%ixn /= ixn)) error stop 'ixn mismatch'
+        call assert_close(b%iota(3), iota_full(3), 'iota spot value')
+        call assert_close(b%phi(ns_full), phi_full(ns_full), 'phi spot value')
+        call assert_close(b%bmnc(2, 1), bmn(2), 'bmnc spot value')
+        call assert_close(b%zmns(4, 2), 0.1_dp*bmn(4), 'zmns spot value')
+        call assert_close(b%pmns(1, 3), 0.2_dp*bmn(1), 'pmns spot value')
+        print *, 'OK raw symmetric read'
+    end subroutine check_raw_symmetric
+
+    subroutine assert_close(actual, ref, what)
+        real(dp), intent(in) :: actual, ref
+        character(len=*), intent(in) :: what
+
+        if (abs(actual - ref) > 1.0e-12_dp*max(1.0_dp, abs(ref))) then
+            print *, 'FAIL: ', what, ' actual:', actual, ' ref:', ref
+            error stop 'raw boozmn value mismatch'
+        end if
+    end subroutine assert_close
+
+    function expected_bmod(theta_in, zeta_in) result(value)
+        real(dp), intent(in) :: theta_in, zeta_in
+        real(dp) :: value
+        integer :: imode
+
+        value = 0.0_dp
+        do imode = 1, nmode
+            value = value + bmn(imode)*cos(real(ixm(imode), dp)*theta_in &
+                                           - real(ixn(imode), dp)*zeta_in)
+        end do
+    end function expected_bmod
+
+    subroutine eval_bmod(s_in, theta_in, zeta_in, bmod_out)
+        real(dp), intent(in) :: s_in, theta_in, zeta_in
+        real(dp), intent(out) :: bmod_out
+
+        real(dp) :: A_theta, A_phi, dA_theta_dr, dA_phi_dr
+        real(dp) :: d2A_phi_dr2, d3A_phi_dr3
+        real(dp) :: Bth, dBth, d2Bth, Bph, dBph, d2Bph
+        real(dp) :: dBmod(3), d2Bmod(6), Br, dBr(3), d2Br(6)
+
+        call splint_boozer_coord(s_in, theta_in, zeta_in, 0, &
+                                 A_theta, A_phi, dA_theta_dr, dA_phi_dr, &
+                                 d2A_phi_dr2, d3A_phi_dr3, Bth, dBth, d2Bth, &
+                                 Bph, dBph, d2Bph, bmod_out, dBmod, d2Bmod, &
+                                 Br, dBr, d2Br)
+    end subroutine eval_bmod
+
+    subroutine write_boozmn_fixture(path, asym)
+        character(len=*), intent(in) :: path
+        logical, intent(in) :: asym
+
+        integer :: ncid, dim_radius, dim_mode, dim_surf
+        integer :: var_ns, var_nfp, var_lasym
+        integer :: var_jlist, var_ixm, var_ixn
+        integer :: var_iota, var_buco, var_bvco, var_phi
+        integer :: var_bmnc, var_rmnc, var_zmns, var_pmns
+        integer :: var_bmns, var_rmns, var_zmnc, var_pmnc
+        integer :: lasym_int
+        real(dp), dimension(ns_full) :: buco, bvco
+        real(dp), dimension(nmode, nsurf) :: coeff
+
+        call check_nc(nf90_create(path, nf90_clobber, ncid), 'create boozmn')
+        call check_nc(nf90_def_dim(ncid, 'radius', ns_full, dim_radius), &
+                      'define radius')
+        call check_nc(nf90_def_dim(ncid, 'mn_mode', nmode, dim_mode), &
+                      'define mn_mode')
+        call check_nc(nf90_def_dim(ncid, 'comput_surfs', nsurf, dim_surf), &
+                      'define comput_surfs')
+
+        call check_nc(nf90_def_var(ncid, 'ns_b', nf90_int, varid=var_ns), &
+                      'define ns_b')
+        call check_nc(nf90_def_var(ncid, 'nfp_b', nf90_int, varid=var_nfp), &
+                      'define nfp_b')
+        call check_nc(nf90_def_var(ncid, 'lasym__logical__', nf90_int, &
+                                   varid=var_lasym), 'define lasym')
+        call check_nc(nf90_def_var(ncid, 'jlist', nf90_int, [dim_surf], &
+                                   var_jlist), 'define jlist')
+        call check_nc(nf90_def_var(ncid, 'ixm_b', nf90_int, [dim_mode], &
+                                   var_ixm), 'define ixm_b')
+        call check_nc(nf90_def_var(ncid, 'ixn_b', nf90_int, [dim_mode], &
+                                   var_ixn), 'define ixn_b')
+        call check_nc(nf90_def_var(ncid, 'iota_b', nf90_double, [dim_radius], &
+                                   var_iota), 'define iota_b')
+        call check_nc(nf90_def_var(ncid, 'buco_b', nf90_double, [dim_radius], &
+                                   var_buco), 'define buco_b')
+        call check_nc(nf90_def_var(ncid, 'bvco_b', nf90_double, [dim_radius], &
+                                   var_bvco), 'define bvco_b')
+        call check_nc(nf90_def_var(ncid, 'phi_b', nf90_double, [dim_radius], &
+                                   var_phi), 'define phi_b')
+        call check_nc(nf90_def_var(ncid, 'bmnc_b', nf90_double, &
+                                   [dim_mode, dim_surf], var_bmnc), 'define bmnc_b')
+        call check_nc(nf90_def_var(ncid, 'rmnc_b', nf90_double, &
+                                   [dim_mode, dim_surf], var_rmnc), 'define rmnc_b')
+        call check_nc(nf90_def_var(ncid, 'zmns_b', nf90_double, &
+                                   [dim_mode, dim_surf], var_zmns), 'define zmns_b')
+        call check_nc(nf90_def_var(ncid, 'pmns_b', nf90_double, &
+                                   [dim_mode, dim_surf], var_pmns), 'define pmns_b')
+        if (asym) then
+            call check_nc(nf90_def_var(ncid, 'bmns_b', nf90_double, &
+                                       [dim_mode, dim_surf], var_bmns), &
+                          'define bmns_b')
+            call check_nc(nf90_def_var(ncid, 'rmns_b', nf90_double, &
+                                       [dim_mode, dim_surf], var_rmns), &
+                          'define rmns_b')
+            call check_nc(nf90_def_var(ncid, 'zmnc_b', nf90_double, &
+                                       [dim_mode, dim_surf], var_zmnc), &
+                          'define zmnc_b')
+            call check_nc(nf90_def_var(ncid, 'pmnc_b', nf90_double, &
+                                       [dim_mode, dim_surf], var_pmnc), &
+                          'define pmnc_b')
+        end if
+        call check_nc(nf90_enddef(ncid), 'end definitions')
+
+        buco = [0.01_dp, 0.02_dp, 0.03_dp, 0.04_dp, 0.05_dp]
+        bvco = [0.2_dp, 0.21_dp, 0.22_dp, 0.23_dp, 0.24_dp]
+        lasym_int = 0
+        if (asym) lasym_int = 1
+
+        call check_nc(nf90_put_var(ncid, var_ns, ns_full), 'write ns_b')
+        call check_nc(nf90_put_var(ncid, var_nfp, 1), 'write nfp_b')
+        call check_nc(nf90_put_var(ncid, var_lasym, lasym_int), 'write lasym')
+        call check_nc(nf90_put_var(ncid, var_jlist, jlist), 'write jlist')
+        call check_nc(nf90_put_var(ncid, var_ixm, ixm), 'write ixm_b')
+        call check_nc(nf90_put_var(ncid, var_ixn, ixn), 'write ixn_b')
+        call check_nc(nf90_put_var(ncid, var_iota, iota_full), 'write iota_b')
+        call check_nc(nf90_put_var(ncid, var_buco, buco), 'write buco_b')
+        call check_nc(nf90_put_var(ncid, var_bvco, bvco), 'write bvco_b')
+        call check_nc(nf90_put_var(ncid, var_phi, phi_full), 'write phi_b')
+
+        coeff = spread(bmn, dim=2, ncopies=nsurf)
+        call check_nc(nf90_put_var(ncid, var_bmnc, coeff), 'write bmnc_b')
+        coeff = 0.0_dp
+        coeff(1, :) = [1.8_dp, 1.9_dp, 2.0_dp]
+        call check_nc(nf90_put_var(ncid, var_rmnc, coeff), 'write rmnc_b')
+        coeff = 0.1_dp*spread(bmn, dim=2, ncopies=nsurf)
+        call check_nc(nf90_put_var(ncid, var_zmns, coeff), 'write zmns_b')
+        coeff = 0.2_dp*spread(bmn, dim=2, ncopies=nsurf)
+        call check_nc(nf90_put_var(ncid, var_pmns, coeff), 'write pmns_b')
+        if (asym) then
+            coeff = 0.5_dp*spread(bmn, dim=2, ncopies=nsurf)
+            call check_nc(nf90_put_var(ncid, var_bmns, coeff), 'write bmns_b')
+            coeff = 0.3_dp*spread(bmn, dim=2, ncopies=nsurf)
+            call check_nc(nf90_put_var(ncid, var_rmns, coeff), 'write rmns_b')
+            coeff = 0.4_dp*spread(bmn, dim=2, ncopies=nsurf)
+            call check_nc(nf90_put_var(ncid, var_zmnc, coeff), 'write zmnc_b')
+            coeff = 0.25_dp*spread(bmn, dim=2, ncopies=nsurf)
+            call check_nc(nf90_put_var(ncid, var_pmnc, coeff), 'write pmnc_b')
+        end if
+        call check_nc(nf90_close(ncid), 'close boozmn')
+    end subroutine write_boozmn_fixture
+
+    subroutine check_nc(status, context)
+        integer, intent(in) :: status
+        character(len=*), intent(in) :: context
+
+        if (status /= nf90_noerr) then
+            print *, trim(context), ': ', trim(nf90_strerror(status))
+            error stop 'boozmn fixture NetCDF error'
+        end if
+    end subroutine check_nc
+
+end program test_boozmn_reader


### PR DESCRIPTION
Adds a shared Fortran reader for booz_xform `boozmn*.nc` output, so downstream codes stop carrying their own copies (requested by @GeorgGrassler in itpplasma/rabe#108 review: the reader is generic and belongs in libneo).

- `boozmn_file`: raw reader returning `boozmn_data_t` with the file-layout conventions (half-grid `jlist` harmonics, full-grid profiles, `ixn` includes the nfp factor, SI units). Reads the asymmetric (`lasym=1`) coefficient set when present, so NEO-2 can consume the same reader later.
- `boozmn_reader`: `load_boozer_from_boozmn` evaluates Bmod by Fourier summation on a uniform grid and hands off to `build_boozer_from_chartmap`, sharing the spline backend with the chartmap path.

Ported from itpplasma/rabe#108 (`src/vmec/boozmn_reader.f90`), split into raw reader + loader. rabe will consume this and drop its local copy; follow-up there.

## Verification
### Test fails on main
`test_boozmn_reader` does not exist on main; the modules `boozmn_file`/`boozmn_reader` are new. On this branch with the test but without the implementation the build fails to resolve `use boozmn_file`.
### Test passes after fix
```
$ ctest --test-dir build -R 'setup_vmec_wout|test_boozer_chartmap_roundtrip|test_boozmn_reader' --output-on-failure
1/3 Test #36: setup_vmec_wout ..................   Passed    1.28 sec
2/3 Test #58: test_boozer_chartmap_roundtrip ...   Passed    1.09 sec
3/3 Test #59: test_boozmn_reader ...............   Passed    0.30 sec
100% tests passed, 0 tests failed out of 3
```
The new test writes synthetic symmetric and asymmetric boozmn fixtures, pins the raw fields `read_boozmn` returns, and checks |B| from `splint_boozer_coord` after `load_boozer_from_boozmn` against the analytic Fourier sum (reltol 1e-6). The chartmap roundtrip test guards the shared spline backend.
