### PR TITLE
Add shared bc_file reader for Boozer .bc files

### DIFF
--- a/.github/workflows/downstream-gate.yml
+++ b/.github/workflows/downstream-gate.yml
@@ -63,10 +63,12 @@ jobs:
           # so a watch or query glitch is never mistaken for a failed run.
           # Returns 0 success, 2 cancelled (retryable by the caller), 1 any
           # other terminal state or timeout.
+          # Polls with plain run-view reads: gh run watch re-queries every few
+          # seconds and five sequential downstream waits can exhaust the shared
+          # hourly API quota of the token, which then kills the gate itself.
           await_run() {
             local repo=$1 run_id=$2 deadline=$((SECONDS + 5400)) misses=0 state
             while [ "$SECONDS" -lt "$deadline" ]; do
-              gh run watch "$run_id" -R "itpplasma/$repo" >/dev/null 2>&1 || true
               state=$(gh run view "$run_id" -R "itpplasma/$repo" \
                         --json status,conclusion \
                         -q '"\(.status) \(.conclusion)"' 2>/dev/null)
@@ -76,7 +78,7 @@ jobs:
                   echo "::error::$repo run $run_id: cannot read status after retries"
                   return 1
                 }
-                sleep 15; continue
+                sleep 30; continue
               fi
               misses=0
               case "$state" in
@@ -88,7 +90,7 @@ jobs:
                   echo "::error::$repo run $run_id concluded ${state#completed }"
                   return 1 ;;
               esac
-              sleep 15
+              sleep 30
             done
             echo "::error::$repo run $run_id did not finish within timeout"
             return 1
@@ -109,8 +111,19 @@ jobs:
             local before run_id="" attempt rc
             for attempt in 1 2 3; do
               before=$(latest_dispatch_id "$repo" "$wf")
-              if ! gh workflow run "$wf" -R "itpplasma/$repo" -f "libneo_ref=$REF" "$@"; then
-                echo "::error::failed to dispatch $repo ($wf) — workflow may lack workflow_dispatch trigger"
+              # --ref main skips gh's GraphQL default-branch lookup, which fails
+              # hard when the token's hourly API quota is drained. Dispatch
+              # errors are retried with backoff for the same reason.
+              dispatched=0
+              for _ in 1 2 3; do
+                if gh workflow run "$wf" -R "itpplasma/$repo" --ref main \
+                     -f "libneo_ref=$REF" "$@"; then
+                  dispatched=1; break
+                fi
+                sleep 30
+              done
+              if [ "$dispatched" -ne 1 ]; then
+                echo "::error::failed to dispatch $repo ($wf) — missing workflow_dispatch trigger or persistent API error"
                 return 1
               fi
               run_id=""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,7 @@ add_library(boozer STATIC
     src/boozer_converter.F90
     src/boozer_chartmap.f90
     src/field/boozer_chartmap_io.f90
+    src/field/bc_file.f90
 )
 target_link_libraries(boozer PUBLIC vmec_support interpolate neo_util)
 if(TARGET netcdf::netcdff)

--- a/src/field/bc_file.f90
+++ b/src/field/bc_file.f90
@@ -1,0 +1,212 @@
+module bc_file
+    !> Reader for Boozer-coordinate .bc ASCII files (Strumberger/NEO-2 format).
+    !>
+    !> Returns the raw file quantities without unit conversion: currents stay
+    !> in the file's [A] columns and no derived major radius is computed.
+    !> Consumers apply their own conventions (e.g. -mu0/(2 pi) factors).
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+
+    implicit none
+
+    private
+    public :: bc_data_t, read_bc_file
+
+    integer, parameter :: max_header_lines = 100
+
+    type :: bc_data_t
+        integer :: m0b, n0b, nsurf, nper, nmode
+        real(dp) :: flux !< toroidal flux [Tm^2] from global header
+        real(dp) :: a, R !< minor/major radius [m] from global header
+        integer, allocatable :: m(:), n(:) !< mode numbers, n without nper
+        real(dp), allocatable :: s(:) !< per-surface normalized toroidal flux
+        real(dp), allocatable :: iota(:)
+        real(dp), allocatable :: Jpol_over_nper(:), Itor(:) !< [A]
+        real(dp), allocatable :: rmnc(:, :), zmns(:, :) !< (nsurf, nmode) [m]
+        real(dp), allocatable :: vmns(:, :) !< (nsurf, nmode) [ ]
+        real(dp), allocatable :: bmnc(:, :) !< (nsurf, nmode) [T]
+    end type bc_data_t
+
+contains
+
+    subroutine read_bc_file(filename, d)
+        character(len=*), intent(in) :: filename
+        type(bc_data_t), intent(out) :: d
+
+        integer :: iunit, ios, isurf, imode, m_int, n_int
+        real(dp) :: surf_vals(6), row(4)
+        character(len=512) :: line
+
+        open (newunit=iunit, file=trim(filename), status='old', &
+              action='read', iostat=ios)
+        if (ios /= 0) then
+            print *, "bc_file: cannot open file: ", trim(filename)
+            error stop
+        end if
+
+        call next_matching_line(iunit, line, is_global_header, &
+                                "global header (m0b n0b nsurf nper flux a R)")
+        read (line, *) d%m0b, d%n0b, d%nsurf, d%nper, d%flux, d%a, d%R
+
+        do isurf = 1, d%nsurf
+            call next_matching_line(iunit, line, is_real_row_6, &
+                                    "surface parameter line")
+            read (line, *) surf_vals
+            if (isurf == 1) call first_surface_pass(d, iunit, line)
+            call store_surface_params(d, isurf, surf_vals)
+            if (isurf == 1) cycle
+            call next_matching_line(iunit, line, is_mode_row, "mode table row")
+            do imode = 1, d%nmode
+                if (imode > 1) then
+                    read (iunit, '(A)', iostat=ios) line
+                    if (ios /= 0) error stop "bc_file: truncated mode table"
+                end if
+                read (line, *, iostat=ios) m_int, n_int, row(1:4)
+                if (ios /= 0) error stop "bc_file: malformed mode table row"
+                if (d%m(imode) /= m_int .or. d%n(imode) /= n_int) then
+                    error stop "bc_file: mode table differs between surfaces"
+                end if
+                d%rmnc(isurf, imode) = row(1)
+                d%zmns(isurf, imode) = row(2)
+                d%vmns(isurf, imode) = row(3)
+                d%bmnc(isurf, imode) = row(4)
+            end do
+        end do
+        close (iunit)
+    end subroutine read_bc_file
+
+    !> Read the first surface block to discover the mode table size, detect
+    !! non-stellarator-symmetric files, and allocate all storage.
+    subroutine first_surface_pass(d, iunit, line)
+        type(bc_data_t), intent(inout) :: d
+        integer, intent(in) :: iunit
+        character(len=512), intent(inout) :: line
+
+        integer :: ios, m_int, n_int, nmode
+        integer, parameter :: max_modes = 100000
+        real(dp) :: probe(10), row(4)
+        real(dp), allocatable :: m_tmp(:), n_tmp(:), table(:, :)
+
+        allocate (m_tmp(1024), n_tmp(1024), table(1024, 4))
+
+        call next_matching_line(iunit, line, is_mode_row, "first mode table row")
+        read (line, *, iostat=ios) probe
+        if (ios == 0) then
+            error stop "bc_file: non-stellarator-symmetric .bc files "// &
+                "(10 columns) are not supported"
+        end if
+
+        nmode = 0
+        do
+            read (line, *, iostat=ios) m_int, n_int, row
+            if (ios /= 0) exit
+            nmode = nmode + 1
+            if (nmode > max_modes) error stop "bc_file: mode table too large"
+            if (nmode > size(m_tmp)) call grow(m_tmp, n_tmp, table)
+            m_tmp(nmode) = real(m_int, dp)
+            n_tmp(nmode) = real(n_int, dp)
+            table(nmode, :) = row
+            read (iunit, '(A)', iostat=ios) line
+            if (ios /= 0) exit
+        end do
+        if (nmode == 0) error stop "bc_file: empty mode table"
+
+        d%nmode = nmode
+        allocate (d%m(nmode), d%n(nmode))
+        allocate (d%s(d%nsurf), d%iota(d%nsurf))
+        allocate (d%Jpol_over_nper(d%nsurf), d%Itor(d%nsurf))
+        allocate (d%rmnc(d%nsurf, nmode), d%zmns(d%nsurf, nmode))
+        allocate (d%vmns(d%nsurf, nmode), d%bmnc(d%nsurf, nmode))
+        d%m = nint(m_tmp(1:nmode))
+        d%n = nint(n_tmp(1:nmode))
+        d%rmnc(1, :) = table(1:nmode, 1)
+        d%zmns(1, :) = table(1:nmode, 2)
+        d%vmns(1, :) = table(1:nmode, 3)
+        d%bmnc(1, :) = table(1:nmode, 4)
+    end subroutine first_surface_pass
+
+    subroutine store_surface_params(d, isurf, surf_vals)
+        type(bc_data_t), intent(inout) :: d
+        integer, intent(in) :: isurf
+        real(dp), intent(in) :: surf_vals(6)
+
+        d%s(isurf) = surf_vals(1)
+        d%iota(isurf) = surf_vals(2)
+        d%Jpol_over_nper(isurf) = surf_vals(3)
+        d%Itor(isurf) = surf_vals(4)
+    end subroutine store_surface_params
+
+    !> Advance to the next line for which matches() is true, skipping headers
+    !! and comments. Aborts with what_expected in the message on EOF.
+    subroutine next_matching_line(iunit, line, matches, what_expected)
+        integer, intent(in) :: iunit
+        character(len=512), intent(out) :: line
+        interface
+            logical function matches(line)
+                character(len=512), intent(in) :: line
+            end function matches
+        end interface
+        character(len=*), intent(in) :: what_expected
+
+        integer :: ios, tries
+
+        do tries = 1, max_header_lines
+            read (iunit, '(A)', iostat=ios) line
+            if (ios /= 0) then
+                print *, "bc_file: unexpected end of file, expected ", &
+                    what_expected
+                error stop
+            end if
+            if (matches(line)) return
+        end do
+        print *, "bc_file: could not find ", what_expected
+        error stop
+    end subroutine next_matching_line
+
+    logical function is_global_header(line)
+        character(len=512), intent(in) :: line
+
+        integer :: ios, ints(4)
+        real(dp) :: reals(3)
+
+        read (line, *, iostat=ios) ints, reals
+        is_global_header = (ios == 0)
+    end function is_global_header
+
+    logical function is_real_row_6(line)
+        character(len=512), intent(in) :: line
+
+        integer :: ios
+        real(dp) :: vals(6)
+
+        read (line, *, iostat=ios) vals
+        is_real_row_6 = (ios == 0)
+    end function is_real_row_6
+
+    logical function is_mode_row(line)
+        character(len=512), intent(in) :: line
+
+        integer :: ios, ints(2)
+        real(dp) :: vals(4)
+
+        read (line, *, iostat=ios) ints, vals
+        is_mode_row = (ios == 0)
+    end function is_mode_row
+
+    subroutine grow(m_tmp, n_tmp, table)
+        real(dp), allocatable, intent(inout) :: m_tmp(:), n_tmp(:), table(:, :)
+
+        real(dp), allocatable :: m_new(:), n_new(:), table_new(:, :)
+        integer :: n_old
+
+        n_old = size(m_tmp)
+        allocate (m_new(2*n_old), n_new(2*n_old), table_new(2*n_old, 4))
+        m_new(1:n_old) = m_tmp
+        n_new(1:n_old) = n_tmp
+        table_new(1:n_old, :) = table
+        call move_alloc(m_new, m_tmp)
+        call move_alloc(n_new, n_tmp)
+        call move_alloc(table_new, table)
+    end subroutine grow
+
+end module bc_file

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -572,6 +572,14 @@ set_tests_properties(test_boozer_chartmap_roundtrip PROPERTIES
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS setup_vmec_wout)
 
+add_executable(test_bc_file.x source/test_bc_file.f90)
+target_link_libraries(test_bc_file.x neo)
+add_test(NAME test_bc_file
+  COMMAND test_bc_file.x)
+set_tests_properties(test_bc_file PROPERTIES
+  FAIL_REGULAR_EXPRESSION "STOP"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 add_executable(test_delthe_delphi_bv_d2.x source/test_delthe_delphi_bv_d2.f90)
 target_link_libraries(test_delthe_delphi_bv_d2.x neo)
 add_test(NAME test_delthe_delphi_bv_d2

--- a/test/source/test_bc_file.f90
+++ b/test/source/test_bc_file.f90
@@ -1,0 +1,154 @@
+!> Round trip a small synthetic Boozer .bc file through read_bc_file and
+!> check every field of bc_data_t against the values used to write it.
+program test_bc_file
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use bc_file, only: bc_data_t, read_bc_file
+
+    implicit none
+
+    character(len=*), parameter :: bc_filename = "test_bc_file_synthetic.bc"
+    real(dp), parameter :: tol = 1.0e-10_dp
+
+    integer, parameter :: nsurf = 3, nmode = 4
+    integer, parameter :: m0b = 2, n0b = 1, nper = 5
+    real(dp), parameter :: flux = 1.5_dp, a = 0.5_dp, R = 6.0_dp
+
+    integer, parameter :: m(nmode) = [0, 1, 0, 2]
+    integer, parameter :: n(nmode) = [0, 0, 1, 1]
+
+    real(dp) :: s(nsurf), iota(nsurf), Jpol_over_nper(nsurf), Itor(nsurf)
+    real(dp) :: rmnc(nsurf, nmode), zmns(nsurf, nmode)
+    real(dp) :: vmns(nsurf, nmode), bmnc(nsurf, nmode)
+
+    type(bc_data_t) :: d
+    logical :: failed
+    integer :: isurf, imode
+
+    failed = .false.
+
+    do isurf = 1, nsurf
+        s(isurf) = 0.25_dp*real(isurf, dp)
+        iota(isurf) = 0.25_dp + 0.0625_dp*real(isurf, dp)
+        Jpol_over_nper(isurf) = 99.5_dp + 1.0_dp*real(isurf, dp)
+        Itor(isurf) = 0.25_dp + 10.0_dp*real(isurf, dp)
+        do imode = 1, nmode
+            rmnc(isurf, imode) = 1.0_dp + 0.25_dp*real(isurf, dp) &
+                                  + 0.0625_dp*real(imode, dp)
+            zmns(isurf, imode) = -0.5_dp + 0.125_dp*real(isurf, dp) &
+                                  + 0.03125_dp*real(imode, dp)
+            vmns(isurf, imode) = 0.0625_dp*real(isurf, dp) &
+                                  - 0.015625_dp*real(imode, dp)
+            bmnc(isurf, imode) = 2.0_dp + 0.5_dp*real(isurf, dp) &
+                                  + 0.125_dp*real(imode, dp)
+        end do
+    end do
+
+    call write_synthetic_bc_file(bc_filename)
+    call read_bc_file(bc_filename, d)
+
+    call check_int(d%m0b, m0b, "m0b", failed)
+    call check_int(d%n0b, n0b, "n0b", failed)
+    call check_int(d%nsurf, nsurf, "nsurf", failed)
+    call check_int(d%nper, nper, "nper", failed)
+    call check_int(d%nmode, nmode, "nmode", failed)
+    call check_real(d%flux, flux, "flux", failed)
+    call check_real(d%a, a, "a", failed)
+    call check_real(d%R, R, "R", failed)
+
+    if (.not. allocated(d%m) .or. .not. allocated(d%n)) then
+        print *, "FAIL: mode arrays not allocated"
+        failed = .true.
+    else if (size(d%m) /= nmode .or. size(d%n) /= nmode) then
+        print *, "FAIL: mode array size mismatch"
+        failed = .true.
+    else
+        do imode = 1, nmode
+            call check_int(d%m(imode), m(imode), "m(imode)", failed)
+            call check_int(d%n(imode), n(imode), "n(imode)", failed)
+        end do
+    end if
+
+    do isurf = 1, nsurf
+        call check_real(d%s(isurf), s(isurf), "s(isurf)", failed)
+        call check_real(d%iota(isurf), iota(isurf), "iota(isurf)", failed)
+        call check_real(d%Jpol_over_nper(isurf), Jpol_over_nper(isurf), &
+                        "Jpol_over_nper(isurf)", failed)
+        call check_real(d%Itor(isurf), Itor(isurf), "Itor(isurf)", failed)
+        do imode = 1, nmode
+            call check_real(d%rmnc(isurf, imode), rmnc(isurf, imode), &
+                            "rmnc(isurf,imode)", failed)
+            call check_real(d%zmns(isurf, imode), zmns(isurf, imode), &
+                            "zmns(isurf,imode)", failed)
+            call check_real(d%vmns(isurf, imode), vmns(isurf, imode), &
+                            "vmns(isurf,imode)", failed)
+            call check_real(d%bmnc(isurf, imode), bmnc(isurf, imode), &
+                            "bmnc(isurf,imode)", failed)
+        end do
+    end do
+
+    if (failed) then
+        error stop "test_bc_file failed"
+    end if
+    print *, "test_bc_file passed"
+
+contains
+
+    subroutine write_synthetic_bc_file(filename)
+        character(len=*), intent(in) :: filename
+
+        integer :: iunit, is, k
+
+        open (newunit=iunit, file=trim(filename), status='replace', &
+              action='write')
+
+        write (iunit, '(A)') 'CC Boozer-coordinate data file'
+        write (iunit, '(A)') 'CC Version:'
+        write (iunit, '(A)') 'CC Author:'
+        write (iunit, '(A)') 'CC shot:    0'
+        write (iunit, '(A)') ' m0b   n0b  nsurf  nper    flux [Tm^2]'// &
+            '        a [m]          R [m]'
+        write (iunit, '(2I6, 2I6, 3ES16.8)') m0b, n0b, nsurf, nper, flux, a, R
+
+        do is = 1, nsurf
+            write (iunit, '(A)') '        s               iota'// &
+                '           Jpol/nper          Itor            pprime'// &
+                '         sqrt g(0,0)'
+            write (iunit, '(A)') '                                          [A]'// &
+                '           [A]             [Pa]         (dV/ds)/nper'
+            write (iunit, '(6ES16.8)') s(is), iota(is), Jpol_over_nper(is), &
+                Itor(is), 0.0_dp, 0.0_dp
+
+            write (iunit, '(A)') '    m    n      rmnc [m]'// &
+                '         zmns [m]         vmns [ ]         bmnc [T]'
+            do k = 1, nmode
+                write (iunit, '(2I6, 4ES16.8)') m(k), n(k), rmnc(is, k), &
+                    zmns(is, k), vmns(is, k), bmnc(is, k)
+            end do
+        end do
+
+        close (iunit)
+    end subroutine write_synthetic_bc_file
+
+    subroutine check_int(actual, expected, label, failed)
+        integer, intent(in) :: actual, expected
+        character(len=*), intent(in) :: label
+        logical, intent(inout) :: failed
+
+        if (actual /= expected) then
+            print *, "FAIL: ", label, " = ", actual, " expected ", expected
+            failed = .true.
+        end if
+    end subroutine check_int
+
+    subroutine check_real(actual, expected, label, failed)
+        real(dp), intent(in) :: actual, expected
+        character(len=*), intent(in) :: label
+        logical, intent(inout) :: failed
+
+        if (abs(actual - expected) > tol*max(1.0_dp, abs(expected))) then
+            print *, "FAIL: ", label, " = ", actual, " expected ", expected
+            failed = .true.
+        end if
+    end subroutine check_real
+
+end program test_bc_file


### PR DESCRIPTION
Adds a shared reader for Boozer `.bc` ASCII files (Strumberger/NEO-2 format), so rabe and NEO-2 can share one parser (requested by @GeorgGrassler on itpplasma/rabe#99: move the .bc reading to its own little library in libneo so NEO-2 can use the same routines, e.g. for benchmarking).

- `bc_file`: `read_bc_file(filename, d)` returning `bc_data_t` with raw file quantities (header scalars, per-surface s/iota/currents, mode table with rmnc/zmns/vmns/bmnc). No unit conversions: consumers apply their own conventions (rabe applies -mu0/(2 pi) factors, NEO-2 uses raw currents).
- Parser behavior ported from itpplasma/rabe#99 (`src/field/bc_field.f90`): comment/header skipping, first-surface mode-table discovery, identical-mode-table enforcement across surfaces, rejection of non-stellarator-symmetric 10-column files.

rabe#99 will consume this and keep only the `bc_field_t` field wrapper; follow-up there.

## Verification
### Test fails on main
`test_bc_file` and module `bc_file` do not exist on main; with the test but no implementation the build fails to resolve `use bc_file`.
### Test passes after fix
```
$ ctest --test-dir build -R test_bc_file --output-on-failure
1/1 Test #59: test_bc_file .....................   Passed    0.05 sec
100% tests passed, 0 tests failed out of 1
```
The test writes a synthetic 3-surface, 4-mode .bc file with the exact header/comment layout NEO-2 writes and asserts every field of `bc_data_t`.
