### PR TITLE
hdf5_tools: export the Fortran module directory to consumers

### DIFF
--- a/src/hdf5_tools/CMakeLists.txt
+++ b/src/hdf5_tools/CMakeLists.txt
@@ -36,4 +36,7 @@ elseif (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
   install (DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/ifort/include)
 endif ()
 
+set_property(TARGET hdf5_tools PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Fortran_MODULE_DIRECTORY})
+
 add_library(LIBNEO::hdf5_tools ALIAS hdf5_tools)


### PR DESCRIPTION
## Summary

Every other libneo sub-target sets `INTERFACE_INCLUDE_DIRECTORIES` to the shared Fortran module directory; `hdf5_tools` did not. A consumer linking only `LIBNEO::hdf5_tools` fails with `Cannot open module file 'hdf5_tools.mod'` and compiled before only because another linked sub-target (boozer, magfie, ...) leaked the path transitively.

Found while reducing NEO-2's MULTI-SPEC-TOOLS link list to the targets it actually uses (itpplasma/NEO-2#107): the tool uses only `hdf5_tools`, and with the reduced list the module path disappeared.

## Verification

NEO-2 build with MULTI-SPEC-TOOLS linking only `LIBNEO::hdf5_tools`:

Before (libneo main):
```
Fatal Error: Cannot open module file 'hdf5_tools.mod' for reading at (1): No such file or directory
```

After (this patch applied to the fetched libneo): full NEO-2 QL+PAR+tools build links clean (verification in itpplasma/NEO-2#107).