### PR TITLE
Add JOREK Bezier geometry evaluation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,7 @@ if(LIBNEO_BUILD_NUMERICS)
     # Tier 1: JOREK restart HDF5 reader (depends on hdf5_tools only).
     add_library(jorek_support STATIC
         src/field/jorek_restart.f90
+        src/field/jorek_bezier.f90
     )
     target_link_libraries(jorek_support PUBLIC LIBNEO::hdf5_tools)
     set_property(TARGET jorek_support PROPERTY

--- a/src/field/jorek_bezier.f90
+++ b/src/field/jorek_bezier.f90
@@ -1,0 +1,132 @@
+module jorek_bezier
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use jorek_restart, only: jorek_restart_t
+
+    implicit none
+    private
+
+    public :: cubic_jorek_basis, evaluate_jorek_geometry
+
+contains
+
+    pure subroutine cubic_jorek_basis(s, t, basis, basis_s, basis_t, ierr)
+        real(dp), intent(in) :: s, t
+        real(dp), intent(out) :: basis(4, 4), basis_s(4, 4), basis_t(4, 4)
+        integer, intent(out) :: ierr
+
+        integer, parameter :: s_end(4) = [1, 2, 2, 1]
+        integer, parameter :: t_end(4) = [1, 1, 2, 2]
+        real(dp) :: bs(2, 2), bt(2, 2), dbs(2, 2), dbt(2, 2)
+        integer :: vertex
+
+        basis = 0.0_dp
+        basis_s = 0.0_dp
+        basis_t = 0.0_dp
+        ierr = 0
+        if (s < 0.0_dp .or. s > 1.0_dp .or. &
+            t < 0.0_dp .or. t > 1.0_dp) then
+            ierr = 2
+            return
+        end if
+
+        call cubic_endpoint_basis(s, bs, dbs)
+        call cubic_endpoint_basis(t, bt, dbt)
+        do vertex = 1, 4
+            basis(vertex, 1) = bs(s_end(vertex), 1)*bt(t_end(vertex), 1)
+            basis(vertex, 2) = bs(s_end(vertex), 2)*bt(t_end(vertex), 1)
+            basis(vertex, 3) = bs(s_end(vertex), 1)*bt(t_end(vertex), 2)
+            basis(vertex, 4) = bs(s_end(vertex), 2)*bt(t_end(vertex), 2)
+
+            basis_s(vertex, 1) = dbs(s_end(vertex), 1)*bt(t_end(vertex), 1)
+            basis_s(vertex, 2) = dbs(s_end(vertex), 2)*bt(t_end(vertex), 1)
+            basis_s(vertex, 3) = dbs(s_end(vertex), 1)*bt(t_end(vertex), 2)
+            basis_s(vertex, 4) = dbs(s_end(vertex), 2)*bt(t_end(vertex), 2)
+
+            basis_t(vertex, 1) = bs(s_end(vertex), 1)*dbt(t_end(vertex), 1)
+            basis_t(vertex, 2) = bs(s_end(vertex), 2)*dbt(t_end(vertex), 1)
+            basis_t(vertex, 3) = bs(s_end(vertex), 1)*dbt(t_end(vertex), 2)
+            basis_t(vertex, 4) = bs(s_end(vertex), 2)*dbt(t_end(vertex), 2)
+        end do
+    end subroutine cubic_jorek_basis
+
+    pure subroutine evaluate_jorek_geometry(data, element, s, t, rz, rz_st, ierr)
+        type(jorek_restart_t), intent(in) :: data
+        integer, intent(in) :: element
+        real(dp), intent(in) :: s, t
+        real(dp), intent(out) :: rz(2), rz_st(2, 2)
+        integer, intent(out) :: ierr
+
+        real(dp) :: basis(4, 4), basis_s(4, 4), basis_t(4, 4), coefficient
+        integer :: coordinate, degree, node, vertex
+
+        rz = 0.0_dp
+        rz_st = 0.0_dp
+        ierr = 0
+        if (element < 1 .or. element > data%n_elements) then
+            ierr = 1
+            return
+        end if
+        call cubic_jorek_basis(s, t, basis, basis_s, basis_t, ierr)
+        if (ierr /= 0) return
+        if (.not. supported_geometry_layout(data)) then
+            ierr = 3
+            return
+        end if
+
+        do vertex = 1, 4
+            node = data%vertex(element, vertex)
+            if (node < 1 .or. node > data%n_nodes) then
+                ierr = 4
+                rz = 0.0_dp
+                rz_st = 0.0_dp
+                return
+            end if
+            do coordinate = 1, 2
+                do degree = 1, 4
+                    coefficient = data%x(node, 1, degree, coordinate) &
+                        *data%size(element, vertex, degree)
+                    rz(coordinate) = rz(coordinate) &
+                        + coefficient*basis(vertex, degree)
+                    rz_st(coordinate, 1) = rz_st(coordinate, 1) &
+                        + coefficient*basis_s(vertex, degree)
+                    rz_st(coordinate, 2) = rz_st(coordinate, 2) &
+                        + coefficient*basis_t(vertex, degree)
+                end do
+            end do
+        end do
+    end subroutine evaluate_jorek_geometry
+
+    pure subroutine cubic_endpoint_basis(u, basis, derivative)
+        real(dp), intent(in) :: u
+        real(dp), intent(out) :: basis(2, 2), derivative(2, 2)
+
+        basis(1, 1) = 2.0_dp*u**3 - 3.0_dp*u**2 + 1.0_dp
+        basis(1, 2) = 3.0_dp*(u**3 - 2.0_dp*u**2 + u)
+        basis(2, 1) = -2.0_dp*u**3 + 3.0_dp*u**2
+        basis(2, 2) = 3.0_dp*(u**3 - u**2)
+
+        derivative(1, 1) = 6.0_dp*u**2 - 6.0_dp*u
+        derivative(1, 2) = 9.0_dp*u**2 - 12.0_dp*u + 3.0_dp
+        derivative(2, 1) = -6.0_dp*u**2 + 6.0_dp*u
+        derivative(2, 2) = 9.0_dp*u**2 - 6.0_dp*u
+    end subroutine cubic_endpoint_basis
+
+    pure logical function supported_geometry_layout(data)
+        type(jorek_restart_t), intent(in) :: data
+
+        supported_geometry_layout = .false.
+        if (data%n_order /= 3) return
+        if (data%n_degrees /= 4) return
+        if (data%n_vertex_max /= 4) return
+        if (data%n_coord_tor < 1) return
+        if (data%n_dim < 2) return
+        if (.not. allocated(data%x)) return
+        if (.not. allocated(data%vertex)) return
+        if (.not. allocated(data%size)) return
+        if (any(shape(data%x) < [data%n_nodes, 1, 4, 2])) return
+        if (any(shape(data%vertex) < [data%n_elements, 4])) return
+        if (any(shape(data%size) < [data%n_elements, 4, 4])) return
+        supported_geometry_layout = .true.
+    end function supported_geometry_layout
+
+end module jorek_bezier

--- a/test/jorek/CMakeLists.txt
+++ b/test/jorek/CMakeLists.txt
@@ -11,3 +11,8 @@ target_link_libraries(test_jorek_restart_fixture.x PRIVATE jorek_support
                                                            hdf5_tools
                                                            util_for_test)
 add_test(NAME test_jorek_restart_fixture COMMAND test_jorek_restart_fixture.x)
+
+add_executable(test_jorek_bezier_geometry.x test_jorek_bezier_geometry.f90)
+target_link_libraries(test_jorek_bezier_geometry.x PRIVATE jorek_support
+                                                           util_for_test)
+add_test(NAME test_jorek_bezier_geometry COMMAND test_jorek_bezier_geometry.x)

--- a/test/jorek/test_jorek_bezier_geometry.f90
+++ b/test/jorek/test_jorek_bezier_geometry.f90
@@ -1,0 +1,182 @@
+program test_jorek_bezier_geometry
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use jorek_bezier, only: cubic_jorek_basis, evaluate_jorek_geometry
+    use jorek_restart, only: jorek_restart_t
+    use util_for_test, only: print_test, print_ok, print_fail
+
+    implicit none
+
+    real(dp), parameter :: tol = 2.0e-14_dp
+    integer :: nfail
+
+    nfail = 0
+    call test_jorek_basis_oracle
+    call test_affine_geometry
+    call test_shared_edge
+    call test_rejected_inputs
+    if (nfail > 0) error stop
+
+contains
+
+    subroutine test_jorek_basis_oracle
+        real(dp), parameter :: basis_ref(4, 4) = reshape([ &
+            0.193536_dp, 0.022464_dp, 0.081536_dp, 0.702464_dp, &
+            0.082944_dp, -0.020736_dp, -0.075264_dp, 0.301056_dp, &
+            0.169344_dp, 0.019656_dp, -0.045864_dp, -0.395136_dp, &
+            0.072576_dp, -0.018144_dp, 0.042336_dp, -0.169344_dp], [4, 4])
+        real(dp), parameter :: basis_s_ref(4, 4) = reshape([ &
+            -0.20736_dp, 0.20736_dp, 0.75264_dp, -0.75264_dp, &
+            0.20736_dp, -0.18144_dp, -0.65856_dp, 0.75264_dp, &
+            -0.18144_dp, 0.18144_dp, -0.42336_dp, 0.42336_dp, &
+            0.18144_dp, -0.15876_dp, 0.37044_dp, -0.42336_dp], [4, 4])
+        real(dp), parameter :: basis_t_ref(4, 4) = reshape([ &
+            -1.12896_dp, -0.13104_dp, 0.13104_dp, 1.12896_dp, &
+            -0.48384_dp, 0.12096_dp, -0.12096_dp, 0.48384_dp, &
+            -0.88704_dp, -0.10296_dp, 0.02184_dp, 0.18816_dp, &
+            -0.38016_dp, 0.09504_dp, -0.02016_dp, 0.08064_dp], [4, 4])
+
+        real(dp) :: basis(4, 4), basis_s(4, 4), basis_t(4, 4)
+        integer :: ierr, nfail_before
+
+        call print_test('cubic basis matches JOREK oracle at s=0.2, t=0.7')
+        nfail_before = nfail
+        call cubic_jorek_basis(0.2_dp, 0.7_dp, basis, basis_s, basis_t, ierr)
+        call check_int('ierr', ierr, 0)
+        call check_array('basis', basis, basis_ref)
+        call check_array('basis_s', basis_s, basis_s_ref)
+        call check_array('basis_t', basis_t, basis_t_ref)
+        call report(nfail_before)
+    end subroutine test_jorek_basis_oracle
+
+    subroutine test_affine_geometry
+        type(jorek_restart_t) :: data
+        real(dp) :: rz(2), rz_st(2, 2)
+        integer :: ierr, nfail_before
+
+        call print_test('geometry reproduces an affine element and Jacobian')
+        nfail_before = nfail
+        call make_two_element_strip(data)
+        call evaluate_jorek_geometry(data, 1, 0.25_dp, 0.6_dp, rz, rz_st, ierr)
+        call check_int('ierr', ierr, 0)
+        call check_real('R', rz(1), 10.25_dp)
+        call check_real('Z', rz(2), 0.6_dp)
+        call check_real('R_s', rz_st(1, 1), 1.0_dp)
+        call check_real('Z_s', rz_st(2, 1), 0.0_dp)
+        call check_real('R_t', rz_st(1, 2), 0.0_dp)
+        call check_real('Z_t', rz_st(2, 2), 1.0_dp)
+        call report(nfail_before)
+    end subroutine test_affine_geometry
+
+    subroutine test_shared_edge
+        type(jorek_restart_t) :: data
+        real(dp) :: left(2), right(2), left_st(2, 2), right_st(2, 2)
+        integer :: ierr, nfail_before
+
+        call print_test('adjacent elements agree on their shared edge')
+        nfail_before = nfail
+        call make_two_element_strip(data)
+        call evaluate_jorek_geometry(data, 1, 1.0_dp, 0.37_dp, &
+            left, left_st, ierr)
+        call check_int('left ierr', ierr, 0)
+        call evaluate_jorek_geometry(data, 2, 0.0_dp, 0.37_dp, &
+            right, right_st, ierr)
+        call check_int('right ierr', ierr, 0)
+        call check_vector('position', left, right)
+        call check_vector('s tangent', left_st(:, 1), right_st(:, 1))
+        call check_vector('t tangent', left_st(:, 2), right_st(:, 2))
+        call report(nfail_before)
+    end subroutine test_shared_edge
+
+    subroutine test_rejected_inputs
+        type(jorek_restart_t) :: data
+        real(dp) :: rz(2), rz_st(2, 2)
+        integer :: ierr, nfail_before
+
+        call print_test('geometry rejects invalid element, coordinates, and order')
+        nfail_before = nfail
+        call make_two_element_strip(data)
+        call evaluate_jorek_geometry(data, 0, 0.5_dp, 0.5_dp, rz, rz_st, ierr)
+        call check_int('element ierr', ierr, 1)
+        call evaluate_jorek_geometry(data, 1, -0.1_dp, 0.5_dp, rz, rz_st, ierr)
+        call check_int('coordinate ierr', ierr, 2)
+        data%n_order = 5
+        call evaluate_jorek_geometry(data, 1, 0.5_dp, 0.5_dp, rz, rz_st, ierr)
+        call check_int('order ierr', ierr, 3)
+        call report(nfail_before)
+    end subroutine test_rejected_inputs
+
+    subroutine make_two_element_strip(data)
+        type(jorek_restart_t), intent(out) :: data
+
+        real(dp), parameter :: r_node(6) = [10.0_dp, 11.0_dp, 11.0_dp, &
+            10.0_dp, 12.0_dp, 12.0_dp]
+        real(dp), parameter :: z_node(6) = [0.0_dp, 0.0_dp, 1.0_dp, &
+            1.0_dp, 0.0_dp, 1.0_dp]
+        integer :: i
+
+        data%n_order = 3
+        data%n_degrees = 4
+        data%n_coord_tor = 1
+        data%n_dim = 2
+        data%n_nodes = 6
+        data%n_elements = 2
+        data%n_vertex_max = 4
+        allocate (data%x(6, 1, 4, 2), data%vertex(2, 4), data%size(2, 4, 4))
+        data%x = 0.0_dp
+        data%size = 1.0_dp
+        data%vertex(1, :) = [1, 2, 3, 4]
+        data%vertex(2, :) = [2, 5, 6, 3]
+        do i = 1, 6
+            data%x(i, 1, 1, 1) = r_node(i)
+            data%x(i, 1, 1, 2) = z_node(i)
+            data%x(i, 1, 2, 1) = 1.0_dp/3.0_dp
+            data%x(i, 1, 3, 2) = 1.0_dp/3.0_dp
+        end do
+    end subroutine make_two_element_strip
+
+    subroutine check_array(name, actual, expected)
+        character(len=*), intent(in) :: name
+        real(dp), intent(in) :: actual(:, :), expected(:, :)
+
+        if (maxval(abs(actual - expected)) > tol) call fail(name//' mismatch')
+    end subroutine check_array
+
+    subroutine check_vector(name, actual, expected)
+        character(len=*), intent(in) :: name
+        real(dp), intent(in) :: actual(:), expected(:)
+
+        if (maxval(abs(actual - expected)) > tol) call fail(name//' mismatch')
+    end subroutine check_vector
+
+    subroutine check_real(name, actual, expected)
+        character(len=*), intent(in) :: name
+        real(dp), intent(in) :: actual, expected
+
+        if (abs(actual - expected) > tol) call fail(name//' mismatch')
+    end subroutine check_real
+
+    subroutine check_int(name, actual, expected)
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: actual, expected
+
+        if (actual /= expected) call fail(name//' mismatch')
+    end subroutine check_int
+
+    subroutine fail(message)
+        character(len=*), intent(in) :: message
+
+        print *, '    ', message
+        nfail = nfail + 1
+    end subroutine fail
+
+    subroutine report(nfail_before)
+        integer, intent(in) :: nfail_before
+
+        if (nfail > nfail_before) then
+            call print_fail
+        else
+            call print_ok
+        end if
+    end subroutine report
+
+end program test_jorek_bezier_geometry

--- a/test/jorek/test_jorek_restart_fixture.f90
+++ b/test/jorek/test_jorek_restart_fixture.f90
@@ -1,5 +1,6 @@
 program test_jorek_restart_fixture
     use, intrinsic :: iso_fortran_env, only: dp => real64
+    use jorek_bezier, only: evaluate_jorek_geometry
     use jorek_restart, only: jorek_restart_t, load_jorek_restart, &
         free_jorek_restart
     use util_for_test, only: print_test, print_ok, print_fail
@@ -7,6 +8,7 @@ program test_jorek_restart_fixture
     implicit none
 
     character(len=*), parameter :: fixture_env = 'LIBNEO_JOREK_RESTART_FIXTURE'
+    real(dp), parameter :: tol = 2.0e-13_dp
     character(len=1024) :: fixture
     integer :: env_status, nfail
 
@@ -37,6 +39,8 @@ contains
         end if
 
         call check_int('rst_hdf5_version', data%rst_hdf5_version, 2)
+        call check_int('n_nodes', data%n_nodes, 1561)
+        call check_int('n_elements', data%n_elements, 1485)
         call check_int('n_degrees', data%n_degrees, 4)
         call check_int('n_dim', data%n_dim, 2)
         call check_int('n_vertex_max', data%n_vertex_max, 4)
@@ -46,6 +50,7 @@ contains
         call check_nodal_r_range(data)
         call check_vertex_bounds(data)
         call check_neighbour_bounds(data)
+        call check_geometry_oracle(data)
 
         call free_jorek_restart(data)
 
@@ -102,6 +107,22 @@ contains
         end if
     end subroutine check_neighbour_bounds
 
+    subroutine check_geometry_oracle(data)
+        type(jorek_restart_t), intent(in) :: data
+
+        real(dp) :: rz(2), rz_st(2, 2)
+        integer :: ierr
+
+        call evaluate_jorek_geometry(data, 1, 0.2_dp, 0.7_dp, rz, rz_st, ierr)
+        call check_int('geometry ierr', ierr, 0)
+        call check_dp('R', rz(1), 1.7020710470004476_dp)
+        call check_dp('Z', rz(2), 0.03437336518385514_dp)
+        call check_dp('R_s', rz_st(1, 1), -0.02304197881763608_dp)
+        call check_dp('Z_s', rz_st(2, 1), -0.10438992315046813_dp)
+        call check_dp('R_t', rz_st(1, 2), 0.0006138917527668017_dp)
+        call check_dp('Z_t', rz_st(2, 2), -0.00017457983954904943_dp)
+    end subroutine check_geometry_oracle
+
     subroutine check_int(name, actual, expected)
         character(len=*), intent(in) :: name
         integer, intent(in) :: actual, expected
@@ -114,6 +135,15 @@ contains
             call fail(trim(message))
         end if
     end subroutine check_int
+
+    subroutine check_dp(name, actual, expected)
+        character(len=*), intent(in) :: name
+        real(dp), intent(in) :: actual, expected
+
+        if (abs(actual - expected) > tol*max(1.0_dp, abs(expected))) then
+            call fail(name//' mismatch')
+        end if
+    end subroutine check_dp
 
     subroutine check_shape(name, actual, expected)
         character(len=*), intent(in) :: name


### PR DESCRIPTION
Evaluate the cubic JOREK poloidal finite-element geometry directly from restart `x`, `vertex`, and `size` data. The API returns `(R,Z)` and derivatives with respect to the local `(s,t)` element coordinates.

This PR is stacked on PR 379 at `b0d7dcd`; its slice is commit `bf97918`. It preserves JOREK normalized units, vertex ordering, local-coordinate orientation, stored DOFs, ABI, and memory layout. It supports the cubic four-vertex/four-DOF layout and rejects other orders explicitly.

## Verification
### Test fails on main
```text
$ fo test test_jorek_bezier_geometry
fo: test failed: Fatal Error: Cannot open module file ‘jorek_bezier.mod’ for reading at
```

### Test passes after fix
```text
$ fo test test_jorek_bezier_geometry
test_jorek_bezier_geometry                 PASS       0.06s
Summary: 1 passed, 0 failed, 0 skipped (  0.06s)

$ LIBNEO_JOREK_RESTART_FIXTURE=<fixed-boundary-restart.h5> fo test test_jorek_restart_fixture
test_jorek_restart_fixture                 PASS       0.06s
Summary: 1 passed, 0 failed, 0 skipped (  0.06s)

$ fo test --all
exit 0
```

The focused test covers a JOREK basis oracle, affine reproduction, the local Jacobian, shared-edge continuity, and rejected inputs. The restart integration test checks one real element against fixed JOREK-side reference values for `R`, `Z`, and first derivatives.