### PR TITLE
Add JOREK element point location

### DIFF
--- a/src/field/jorek_bezier.f90
+++ b/src/field/jorek_bezier.f90
@@ -5,7 +5,7 @@ module jorek_bezier
     implicit none
     private
 
-    public :: cubic_jorek_basis, evaluate_jorek_geometry
+    public :: cubic_jorek_basis, evaluate_jorek_geometry, locate_jorek_element
 
 contains
 
@@ -95,6 +95,73 @@ contains
             end do
         end do
     end subroutine evaluate_jorek_geometry
+
+    pure subroutine locate_jorek_element(data, target_rz, element, s, t, ierr)
+        type(jorek_restart_t), intent(in) :: data
+        real(dp), intent(in) :: target_rz(2)
+        integer, intent(out) :: element
+        real(dp), intent(out) :: s, t
+        integer, intent(out) :: ierr
+
+        real(dp), parameter :: seeds(2, 9) = reshape([ &
+            0.5_dp, 0.5_dp, 0.0_dp, 0.0_dp, 1.0_dp, 0.0_dp, &
+            1.0_dp, 1.0_dp, 0.0_dp, 1.0_dp, 0.5_dp, 0.0_dp, &
+            1.0_dp, 0.5_dp, 0.5_dp, 1.0_dp, 0.0_dp, 0.5_dp], [2, 9])
+        integer, parameter :: max_iterations = 30
+
+        real(dp) :: delta(2), determinant, determinant_scale, residual(2)
+        real(dp) :: rz(2), rz_st(2, 2), scale, tolerance, trial_s, trial_t
+        integer :: candidate, iteration, seed, geometry_ierr
+
+        element = 0
+        s = 0.0_dp
+        t = 0.0_dp
+        ierr = 1
+        if (data%n_elements < 1) then
+            ierr = 2
+            return
+        end if
+        call evaluate_jorek_geometry(data, 1, 0.5_dp, 0.5_dp, rz, rz_st, &
+            geometry_ierr)
+        if (geometry_ierr /= 0) then
+            ierr = 2
+            return
+        end if
+
+        do candidate = 1, data%n_elements
+            do seed = 1, size(seeds, 2)
+                trial_s = seeds(1, seed)
+                trial_t = seeds(2, seed)
+                do iteration = 1, max_iterations
+                    call evaluate_jorek_geometry(data, candidate, trial_s, &
+                        trial_t, rz, rz_st, geometry_ierr)
+                    if (geometry_ierr /= 0) exit
+                    residual = target_rz - rz
+                    scale = max(1.0_dp, maxval(abs(target_rz)), maxval(abs(rz)))
+                    tolerance = 1024.0_dp*epsilon(1.0_dp)**0.75_dp*scale
+                    if (maxval(abs(residual)) <= tolerance) then
+                        element = candidate
+                        s = trial_s
+                        t = trial_t
+                        ierr = 0
+                        return
+                    end if
+                    determinant = rz_st(1, 1)*rz_st(2, 2) &
+                        - rz_st(1, 2)*rz_st(2, 1)
+                    determinant_scale = maxval(abs(rz_st(:, 1))) &
+                        *maxval(abs(rz_st(:, 2)))
+                    if (abs(determinant) <= 64.0_dp*epsilon(1.0_dp) &
+                        *determinant_scale) exit
+                    delta(1) = (residual(1)*rz_st(2, 2) &
+                        - residual(2)*rz_st(1, 2))/determinant
+                    delta(2) = (-residual(1)*rz_st(2, 1) &
+                        + residual(2)*rz_st(1, 1))/determinant
+                    trial_s = min(1.0_dp, max(0.0_dp, trial_s + delta(1)))
+                    trial_t = min(1.0_dp, max(0.0_dp, trial_t + delta(2)))
+                end do
+            end do
+        end do
+    end subroutine locate_jorek_element
 
     pure subroutine cubic_endpoint_basis(u, basis, derivative)
         real(dp), intent(in) :: u

--- a/test/jorek/test_jorek_bezier_geometry.f90
+++ b/test/jorek/test_jorek_bezier_geometry.f90
@@ -1,6 +1,7 @@
 program test_jorek_bezier_geometry
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use jorek_bezier, only: cubic_jorek_basis, evaluate_jorek_geometry
+    use jorek_bezier, only: cubic_jorek_basis, evaluate_jorek_geometry, &
+        locate_jorek_element
     use jorek_restart, only: jorek_restart_t
     use util_for_test, only: print_test, print_ok, print_fail
 
@@ -13,6 +14,7 @@ program test_jorek_bezier_geometry
     call test_jorek_basis_oracle
     call test_affine_geometry
     call test_shared_edge
+    call test_point_location
     call test_rejected_inputs
     if (nfail > 0) error stop
 
@@ -86,6 +88,29 @@ contains
         call check_vector('t tangent', left_st(:, 2), right_st(:, 2))
         call report(nfail_before)
     end subroutine test_shared_edge
+
+    subroutine test_point_location
+        type(jorek_restart_t) :: data
+        integer :: element, ierr, nfail_before
+        real(dp) :: s, t
+
+        call print_test('point location finds interiors and resolves shared edges')
+        nfail_before = nfail
+        call make_two_element_strip(data)
+        call locate_jorek_element(data, [11.25_dp, 0.6_dp], element, s, t, ierr)
+        call check_int('interior ierr', ierr, 0)
+        call check_int('interior element', element, 2)
+        call check_real('interior s', s, 0.25_dp)
+        call check_real('interior t', t, 0.6_dp)
+        call locate_jorek_element(data, [11.0_dp, 0.37_dp], element, s, t, ierr)
+        call check_int('edge ierr', ierr, 0)
+        call check_int('edge element', element, 1)
+        call check_real('edge s', s, 1.0_dp)
+        call check_real('edge t', t, 0.37_dp)
+        call locate_jorek_element(data, [13.0_dp, 0.5_dp], element, s, t, ierr)
+        call check_int('outside ierr', ierr, 1)
+        call report(nfail_before)
+    end subroutine test_point_location
 
     subroutine test_rejected_inputs
         type(jorek_restart_t) :: data

--- a/test/jorek/test_jorek_restart_fixture.f90
+++ b/test/jorek/test_jorek_restart_fixture.f90
@@ -1,6 +1,6 @@
 program test_jorek_restart_fixture
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use jorek_bezier, only: evaluate_jorek_geometry
+    use jorek_bezier, only: evaluate_jorek_geometry, locate_jorek_element
     use jorek_field_values, only: evaluate_jorek_variable
     use jorek_model303_field, only: evaluate_jorek_model303_b
     use jorek_restart, only: jorek_restart_t, load_jorek_restart, &
@@ -114,8 +114,8 @@ contains
     subroutine check_geometry_oracle(data)
         type(jorek_restart_t), intent(in) :: data
 
-        real(dp) :: rz(2), rz_st(2, 2)
-        integer :: ierr
+        real(dp) :: rz(2), rz_st(2, 2), s, t
+        integer :: element, ierr
 
         call evaluate_jorek_geometry(data, 1, 0.2_dp, 0.7_dp, rz, rz_st, ierr)
         call check_int('geometry ierr', ierr, 0)
@@ -125,6 +125,11 @@ contains
         call check_dp('Z_s', rz_st(2, 1), -0.10438992315046813_dp)
         call check_dp('R_t', rz_st(1, 2), 0.0006138917527668017_dp)
         call check_dp('Z_t', rz_st(2, 2), -0.00017457983954904943_dp)
+        call locate_jorek_element(data, rz, element, s, t, ierr)
+        call check_int('location ierr', ierr, 0)
+        call check_int('location element', element, 1)
+        call check_dp('location s', s, 0.2_dp)
+        call check_dp('location t', t, 0.7_dp)
     end subroutine check_geometry_oracle
 
     subroutine check_value_oracle(data)


### PR DESCRIPTION
Adds global cylindrical point location for cubic JOREK Bezier elements. The locator uses projected Newton iterations from deterministic seeds, returns the lowest-index element on shared edges, and rejects points outside the mesh or unsupported geometry layouts.

This is stacked on #382.

The coordinate convention remains `(R,Z)` externally and `(s,t)` locally. Geometry coefficients, element connectivity, and normalized JOREK field values are unchanged.

## Verification

Failing before implementation:
```text
fo: test failed: Error: Symbol ‘locate_jorek_element’ referenced at (1) not found in
```

Passing after implementation:
```text
==> point location finds interiors and resolves shared edges
    .................................................... OK
Static: OK (227 modules, 227 changed, 227 affected)
Build: OK
```

Commands:
```sh
fo test test/jorek/test_jorek_bezier_geometry.f90
fo
fo test --all
```