### PR TITLE
Add JOREK model 303 vector potential

### DIFF
--- a/src/field/jorek_model303_field.f90
+++ b/src/field/jorek_model303_field.f90
@@ -1,15 +1,45 @@
 module jorek_model303_field
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use jorek_bezier, only: evaluate_jorek_geometry
+    use jorek_bezier, only: evaluate_jorek_geometry, locate_jorek_element
     use jorek_field_values, only: evaluate_jorek_variable
     use jorek_restart, only: jorek_restart_t
 
     implicit none
     private
 
-    public :: evaluate_jorek_model303_b
+    public :: evaluate_jorek_model303_a, evaluate_jorek_model303_b, &
+        evaluate_jorek_model303_at
 
 contains
+
+    pure subroutine evaluate_jorek_model303_a(data, element, s, t, phi, &
+            a_r_phi_z, ierr)
+        type(jorek_restart_t), intent(in) :: data
+        integer, intent(in) :: element
+        real(dp), intent(in) :: s, t, phi
+        real(dp), intent(out) :: a_r_phi_z(3)
+        integer, intent(out) :: ierr
+
+        real(dp) :: rz(2), rz_st(2, 2), psi, psi_st_phi(3)
+
+        a_r_phi_z = 0.0_dp
+        ierr = 0
+        if (data%jorek_model /= 303) then
+            ierr = 7
+            return
+        end if
+        call evaluate_jorek_geometry(data, element, s, t, rz, rz_st, ierr)
+        if (ierr /= 0) return
+        call evaluate_jorek_variable(data, element, 1, s, t, phi, psi, &
+            psi_st_phi, ierr)
+        if (ierr /= 0) return
+        if (rz(1) <= 0.0_dp) then
+            ierr = 8
+            return
+        end if
+
+        a_r_phi_z = [0.0_dp, -psi, -data%F0*log(rz(1))]
+    end subroutine evaluate_jorek_model303_a
 
     pure subroutine evaluate_jorek_model303_b(data, element, s, t, phi, &
             b_r_z_phi, ierr)
@@ -49,5 +79,27 @@ contains
             + psi_st_phi(2)*rz_st(1, 1))/jacobian
         b_r_z_phi = [psi_z, -psi_r, data%F0]/rz(1)
     end subroutine evaluate_jorek_model303_b
+
+    pure subroutine evaluate_jorek_model303_at(data, target_rz, phi, &
+            a_r_phi_z, b_r_z_phi, element, st, ierr)
+        type(jorek_restart_t), intent(in) :: data
+        real(dp), intent(in) :: target_rz(2), phi
+        real(dp), intent(out) :: a_r_phi_z(3), b_r_z_phi(3)
+        integer, intent(out) :: element
+        real(dp), intent(out) :: st(2)
+        integer, intent(out) :: ierr
+
+        a_r_phi_z = 0.0_dp
+        b_r_z_phi = 0.0_dp
+        element = 0
+        st = 0.0_dp
+        call locate_jorek_element(data, target_rz, element, st(1), st(2), ierr)
+        if (ierr /= 0) return
+        call evaluate_jorek_model303_a(data, element, st(1), st(2), phi, &
+            a_r_phi_z, ierr)
+        if (ierr /= 0) return
+        call evaluate_jorek_model303_b(data, element, st(1), st(2), phi, &
+            b_r_z_phi, ierr)
+    end subroutine evaluate_jorek_model303_at
 
 end module jorek_model303_field

--- a/test/jorek/test_jorek_model303_field.f90
+++ b/test/jorek/test_jorek_model303_field.f90
@@ -1,6 +1,7 @@
 program test_jorek_model303_field
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use jorek_model303_field, only: evaluate_jorek_model303_b
+    use jorek_model303_field, only: evaluate_jorek_model303_a, &
+        evaluate_jorek_model303_b, evaluate_jorek_model303_at
     use jorek_restart, only: jorek_restart_t
     use util_for_test, only: print_test, print_ok, print_fail
 
@@ -11,6 +12,8 @@ program test_jorek_model303_field
 
     nfail = 0
     call test_reduced_mhd_field
+    call test_reduced_mhd_potential
+    call test_global_field_query
     call test_rejected_model
     call test_rejected_singular_geometry
     if (nfail > 0) error stop
@@ -35,6 +38,48 @@ contains
         call check_real('B_phi', b_r_z_phi(3), data%F0/r)
         call report(nfail_before)
     end subroutine test_reduced_mhd_field
+
+    subroutine test_reduced_mhd_potential
+        type(jorek_restart_t) :: data
+        real(dp) :: a_r_phi_z(3), r, z
+        integer :: ierr, nfail_before
+
+        call print_test('model 303 potential has the reduced-MHD curl')
+        nfail_before = nfail
+        call make_model303_element(data)
+        call evaluate_jorek_model303_a(data, 1, 0.25_dp, 0.6_dp, 0.4_dp, &
+            a_r_phi_z, ierr)
+        r = 10.25_dp
+        z = 0.6_dp
+        call check_int('ierr', ierr, 0)
+        call check_real('A_R', a_r_phi_z(1), 0.0_dp)
+        call check_real('A_phi', a_r_phi_z(2), -r*z)
+        call check_real('A_Z', a_r_phi_z(3), -data%F0*log(r))
+        call report(nfail_before)
+    end subroutine test_reduced_mhd_potential
+
+    subroutine test_global_field_query
+        type(jorek_restart_t) :: data
+        real(dp) :: a_r_phi_z(3), b_r_z_phi(3), st(2), r, z
+        integer :: element, ierr, nfail_before
+
+        call print_test('global model 303 query returns compatible A and B')
+        nfail_before = nfail
+        call make_model303_element(data)
+        r = 10.25_dp
+        z = 0.6_dp
+        call evaluate_jorek_model303_at(data, [r, z], 0.4_dp, a_r_phi_z, &
+            b_r_z_phi, element, st, ierr)
+        call check_int('ierr', ierr, 0)
+        call check_int('element', element, 1)
+        call check_real('s', st(1), 0.25_dp)
+        call check_real('t', st(2), 0.6_dp)
+        call check_real('A_phi', a_r_phi_z(2), -r*z)
+        call check_real('B_R', b_r_z_phi(1), 1.0_dp)
+        call check_real('B_Z', b_r_z_phi(2), -z/r)
+        call check_real('B_phi', b_r_z_phi(3), data%F0/r)
+        call report(nfail_before)
+    end subroutine test_global_field_query
 
     subroutine test_rejected_model
         type(jorek_restart_t) :: data

--- a/test/jorek/test_jorek_restart_fixture.f90
+++ b/test/jorek/test_jorek_restart_fixture.f90
@@ -2,7 +2,8 @@ program test_jorek_restart_fixture
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use jorek_bezier, only: evaluate_jorek_geometry, locate_jorek_element
     use jorek_field_values, only: evaluate_jorek_variable
-    use jorek_model303_field, only: evaluate_jorek_model303_b
+    use jorek_model303_field, only: evaluate_jorek_model303_a, &
+        evaluate_jorek_model303_b
     use jorek_restart, only: jorek_restart_t, load_jorek_restart, &
         free_jorek_restart
     use util_for_test, only: print_test, print_ok, print_fail
@@ -54,6 +55,7 @@ contains
         call check_neighbour_bounds(data)
         call check_geometry_oracle(data)
         call check_value_oracle(data)
+        call check_model303_potential_oracle(data)
         call check_model303_field_oracle(data)
 
         call free_jorek_restart(data)
@@ -146,6 +148,21 @@ contains
         call check_dp('value_t', derivative(2), -4.6960480732495265e-8_dp)
         call check_dp('value_phi', derivative(3), 0.0_dp)
     end subroutine check_value_oracle
+
+    subroutine check_model303_potential_oracle(data)
+        type(jorek_restart_t), intent(in) :: data
+
+        real(dp) :: a_r_phi_z(3)
+        integer :: ierr
+
+        call evaluate_jorek_model303_a(data, 1, 0.2_dp, 0.7_dp, 0.4_dp, &
+            a_r_phi_z, ierr)
+        call check_int('potential ierr', ierr, 0)
+        call check_dp('A_R', a_r_phi_z(1), 0.0_dp)
+        call check_dp('A_phi', a_r_phi_z(2), 0.29533650641295134_dp)
+        call check_dp('A_Z', a_r_phi_z(3), &
+            -data%F0*log(1.7020710470004476_dp))
+    end subroutine check_model303_potential_oracle
 
     subroutine check_model303_field_oracle(data)
         type(jorek_restart_t), intent(in) :: data


### PR DESCRIPTION
Adds the covariant cylindrical vector potential for JOREK model 303 and a global query returning compatible vector-potential and magnetic-field values.

This is stacked on #383.

The gauge is `A_R=0`, `A_phi=-psi`, `A_Z=-F0 log(R)`. Its cylindrical curl gives the existing physical field convention `B_R=(partial_Z psi)/R`, `B_Z=-(partial_R psi)/R`, and `B_phi=F0/R`. JOREK normalization, Fourier modes, geometry, memory layout, and stored values are unchanged.

## Verification

Failing before implementation:
```text
fo: test failed: Error: Symbol ‘evaluate_jorek_model303_a’ referenced at (1) not found in
```

Passing after implementation:
```text
==> model 303 potential has the reduced-MHD curl
    .................................................... OK
==> global model 303 query returns compatible A and B
    .................................................... OK
Static: OK (227 modules, 227 changed, 227 affected)
Build: OK
```

Commands:
```sh
fo test test/jorek/test_jorek_model303_field.f90
fo
fo test --all
```