### PR TITLE
Expose JOREK as a light CMake component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 # Consumers that only link the light targets (interpolate, vmec_support, boozer,
 # field, nctools, util, ...) set this OFF to skip those dependencies entirely.
 option(LIBNEO_BUILD_NUMERICS "Build numerics-heavy components requiring BLAS/LAPACK and fortnum" ON)
+option(LIBNEO_BUILD_JOREK "Build the HDF5-backed JOREK restart component" ${LIBNEO_BUILD_NUMERICS})
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/Modules/")
@@ -247,7 +248,7 @@ endif()
 # Tier 0: no internal libneo dependencies
 add_subdirectory(src/util)
 add_subdirectory(src/nctools)
-if(LIBNEO_BUILD_NUMERICS)
+if(LIBNEO_BUILD_NUMERICS OR LIBNEO_BUILD_JOREK)
     add_subdirectory(src/hdf5_tools)
 endif()
 add_subdirectory(src/polylag)
@@ -258,17 +259,7 @@ add_subdirectory(src/field)
 # Tier 1: depends on Tier 0
 add_subdirectory(src/vmec_support)
 
-if(LIBNEO_BUILD_NUMERICS)
-    # Tier 1: SPECTRE equilibrium HDF5 reader (depends on hdf5_tools only).
-    add_library(spectre_support STATIC
-        src/spectre/spectre_reader.f90
-        src/spectre/spectre_basis.f90
-    )
-    target_link_libraries(spectre_support PUBLIC LIBNEO::hdf5_tools)
-    set_property(TARGET spectre_support PROPERTY
-        INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Fortran_MODULE_DIRECTORY})
-    add_library(LIBNEO::spectre ALIAS spectre_support)
-
+if(LIBNEO_BUILD_JOREK)
     # Tier 1: JOREK restart HDF5 reader (depends on hdf5_tools only).
     add_library(jorek_support STATIC
         src/field/jorek_restart.f90
@@ -280,6 +271,18 @@ if(LIBNEO_BUILD_NUMERICS)
     set_property(TARGET jorek_support PROPERTY
         INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Fortran_MODULE_DIRECTORY})
     add_library(LIBNEO::jorek ALIAS jorek_support)
+endif()
+
+if(LIBNEO_BUILD_NUMERICS)
+    # Tier 1: SPECTRE equilibrium HDF5 reader (depends on hdf5_tools only).
+    add_library(spectre_support STATIC
+        src/spectre/spectre_reader.f90
+        src/spectre/spectre_basis.f90
+    )
+    target_link_libraries(spectre_support PUBLIC LIBNEO::hdf5_tools)
+    set_property(TARGET spectre_support PROPERTY
+        INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Fortran_MODULE_DIRECTORY})
+    add_library(LIBNEO::spectre ALIAS spectre_support)
 
     add_subdirectory(src/coordinates)
 

--- a/cmake/DetectDependencies.cmake
+++ b/cmake/DetectDependencies.cmake
@@ -131,13 +131,14 @@ message(STATUS "")
 message(STATUS "=== Detecting External Dependencies ===")
 message(STATUS "")
 
-# Light consumers (LIBNEO_BUILD_NUMERICS=OFF) link no HDF5-backed target and get
-# NetCDF via a pkg-config imported target (set up in the top-level CMakeLists),
-# so skip the nf-config detection here: it never triggers the HDF5/NetCDF
-# from-source superbuild and never injects nf-config's full static --flibs
-# (-lhdf5 -lz -lcurl, no -L) globally onto consumer executables.
-if(NOT DEFINED LIBNEO_BUILD_NUMERICS OR LIBNEO_BUILD_NUMERICS)
+# Light consumers get NetCDF through pkg-config and skip nf-config detection.
+# An explicitly enabled JOREK component still detects HDF5 without enabling the
+# numerical targets or the NetCDF/HDF5 source superbuild for those targets.
+if((NOT DEFINED LIBNEO_BUILD_NUMERICS OR LIBNEO_BUILD_NUMERICS) OR
+        (DEFINED LIBNEO_BUILD_JOREK AND LIBNEO_BUILD_JOREK))
     detect_hdf5()
+endif()
+if(NOT DEFINED LIBNEO_BUILD_NUMERICS OR LIBNEO_BUILD_NUMERICS)
     detect_netcdf()
 endif()
 


### PR DESCRIPTION
Makes `LIBNEO::jorek` independently selectable with `LIBNEO_BUILD_JOREK`. The option follows `LIBNEO_BUILD_NUMERICS` by default, preserving existing builds; consumers can now enable the HDF5-backed JOREK reader while disabling the unrelated numerical applications and Python interfaces.

This is stacked on #384.

No Fortran source, numerical algorithm, memory layout, normalization, ABI, or field convention changes. The change only narrows CMake target selection and dependency detection.

## Verification

Failing before implementation:
```text
ninja: error: unknown target 'jorek_support'
```

Passing after implementation:
```text
-- Found system HDF5: 2.1.1
-- Smoke test for HDF5-Fortran: PASSED
[16/16] Linking Fortran static library libjorek_support.a
Static: OK (227 modules, 227 changed, 227 affected)
```

Commands:
```sh
cmake -S . -B /tmp/libneo-jorek-light -G Ninja -DSKBUILD=ON -DLIBNEO_BUILD_NUMERICS=OFF -DLIBNEO_BUILD_JOREK=ON -DLIBNEO_BUILD_TESTING=OFF
cmake --build /tmp/libneo-jorek-light --target jorek_support -j$(nproc)
fo
fo test --all
```