### PR TITLE
Add indexed JOREK point location

### DIFF
--- a/src/field/jorek_bezier.f90
+++ b/src/field/jorek_bezier.f90
@@ -5,7 +5,14 @@ module jorek_bezier
     implicit none
     private
 
-    public :: cubic_jorek_basis, evaluate_jorek_geometry, locate_jorek_element
+    type :: jorek_locator_t
+        integer :: n_elements = 0
+        real(dp), allocatable :: bounds(:, :, :)
+    end type jorek_locator_t
+
+    public :: jorek_locator_t, cubic_jorek_basis, evaluate_jorek_geometry
+    public :: build_jorek_locator, locate_jorek_element
+    public :: locate_jorek_element_indexed
 
 contains
 
@@ -103,15 +110,7 @@ contains
         real(dp), intent(out) :: s, t
         integer, intent(out) :: ierr
 
-        real(dp), parameter :: seeds(2, 9) = reshape([ &
-            0.5_dp, 0.5_dp, 0.0_dp, 0.0_dp, 1.0_dp, 0.0_dp, &
-            1.0_dp, 1.0_dp, 0.0_dp, 1.0_dp, 0.5_dp, 0.0_dp, &
-            1.0_dp, 0.5_dp, 0.5_dp, 1.0_dp, 0.0_dp, 0.5_dp], [2, 9])
-        integer, parameter :: max_iterations = 30
-
-        real(dp) :: delta(2), determinant, determinant_scale, residual(2)
-        real(dp) :: rz(2), rz_st(2, 2), scale, tolerance, trial_s, trial_t
-        integer :: candidate, iteration, seed, geometry_ierr
+        integer :: candidate, candidate_ierr
 
         element = 0
         s = 0.0_dp
@@ -121,47 +120,193 @@ contains
             ierr = 2
             return
         end if
-        call evaluate_jorek_geometry(data, 1, 0.5_dp, 0.5_dp, rz, rz_st, &
-            geometry_ierr)
-        if (geometry_ierr /= 0) then
+        do candidate = 1, data%n_elements
+            call invert_jorek_element(data, candidate, target_rz, s, t, &
+                candidate_ierr)
+            if (candidate_ierr == 0) then
+                element = candidate
+                ierr = 0
+                return
+            end if
+            if (candidate_ierr == 2) then
+                ierr = 2
+                return
+            end if
+        end do
+    end subroutine locate_jorek_element
+
+    subroutine build_jorek_locator(data, locator, ierr)
+        type(jorek_restart_t), intent(in) :: data
+        type(jorek_locator_t), intent(out) :: locator
+        integer, intent(out) :: ierr
+
+        real(dp) :: coefficient, lower, upper
+        integer :: coordinate, degree, element, node, vertex
+
+        ierr = 0
+        if (.not. supported_geometry_layout(data)) then
             ierr = 2
             return
         end if
-
-        do candidate = 1, data%n_elements
-            do seed = 1, size(seeds, 2)
-                trial_s = seeds(1, seed)
-                trial_t = seeds(2, seed)
-                do iteration = 1, max_iterations
-                    call evaluate_jorek_geometry(data, candidate, trial_s, &
-                        trial_t, rz, rz_st, geometry_ierr)
-                    if (geometry_ierr /= 0) exit
-                    residual = target_rz - rz
-                    scale = max(1.0_dp, maxval(abs(target_rz)), maxval(abs(rz)))
-                    tolerance = 1024.0_dp*epsilon(1.0_dp)**0.75_dp*scale
-                    if (maxval(abs(residual)) <= tolerance) then
-                        element = candidate
-                        s = trial_s
-                        t = trial_t
-                        ierr = 0
-                        return
-                    end if
-                    determinant = rz_st(1, 1)*rz_st(2, 2) &
-                        - rz_st(1, 2)*rz_st(2, 1)
-                    determinant_scale = maxval(abs(rz_st(:, 1))) &
-                        *maxval(abs(rz_st(:, 2)))
-                    if (abs(determinant) <= 64.0_dp*epsilon(1.0_dp) &
-                        *determinant_scale) exit
-                    delta(1) = (residual(1)*rz_st(2, 2) &
-                        - residual(2)*rz_st(1, 2))/determinant
-                    delta(2) = (-residual(1)*rz_st(2, 1) &
-                        + residual(2)*rz_st(1, 1))/determinant
-                    trial_s = min(1.0_dp, max(0.0_dp, trial_s + delta(1)))
-                    trial_t = min(1.0_dp, max(0.0_dp, trial_t + delta(2)))
+        locator%n_elements = data%n_elements
+        allocate (locator%bounds(2, 2, data%n_elements))
+        locator%bounds(:, 1, :) = 0.0_dp
+        locator%bounds(:, 2, :) = 0.0_dp
+        do element = 1, data%n_elements
+            do vertex = 1, 4
+                node = data%vertex(element, vertex)
+                if (node < 1 .or. node > data%n_nodes) then
+                    ierr = 2
+                    return
+                end if
+                do degree = 1, 4
+                    call jorek_basis_interval(vertex, degree, lower, upper)
+                    do coordinate = 1, 2
+                        coefficient = data%x(node, 1, degree, coordinate) &
+                            *data%size(element, vertex, degree)
+                        locator%bounds(coordinate, 1, element) = &
+                            locator%bounds(coordinate, 1, element) &
+                            + min(coefficient*lower, coefficient*upper)
+                        locator%bounds(coordinate, 2, element) = &
+                            locator%bounds(coordinate, 2, element) &
+                            + max(coefficient*lower, coefficient*upper)
+                    end do
                 end do
             end do
         end do
-    end subroutine locate_jorek_element
+    end subroutine build_jorek_locator
+
+    pure subroutine locate_jorek_element_indexed(data, locator, target_rz, &
+            element, s, t, ierr)
+        type(jorek_restart_t), intent(in) :: data
+        type(jorek_locator_t), intent(in) :: locator
+        real(dp), intent(in) :: target_rz(2)
+        integer, intent(out) :: element
+        real(dp), intent(out) :: s, t
+        integer, intent(out) :: ierr
+
+        real(dp) :: scale, tolerance
+        integer :: candidate, candidate_ierr
+
+        element = 0
+        s = 0.0_dp
+        t = 0.0_dp
+        ierr = 1
+        if (.not. allocated(locator%bounds) &
+            .or. locator%n_elements /= data%n_elements &
+            .or. any(shape(locator%bounds) /= [2, 2, data%n_elements])) then
+            ierr = 2
+            return
+        end if
+        do candidate = 1, data%n_elements
+            scale = max(1.0_dp, maxval(abs(target_rz)), &
+                maxval(abs(locator%bounds(:, :, candidate))))
+            tolerance = 64.0_dp*epsilon(1.0_dp)*scale
+            if (any(target_rz < locator%bounds(:, 1, candidate) - tolerance) &
+                .or. any(target_rz > locator%bounds(:, 2, candidate) &
+                + tolerance)) cycle
+            call invert_jorek_element(data, candidate, target_rz, s, t, &
+                candidate_ierr)
+            if (candidate_ierr == 0) then
+                element = candidate
+                ierr = 0
+                return
+            end if
+            if (candidate_ierr == 2) then
+                ierr = 2
+                return
+            end if
+        end do
+    end subroutine locate_jorek_element_indexed
+
+    pure subroutine invert_jorek_element(data, element, target_rz, s, t, ierr)
+        type(jorek_restart_t), intent(in) :: data
+        integer, intent(in) :: element
+        real(dp), intent(in) :: target_rz(2)
+        real(dp), intent(out) :: s, t
+        integer, intent(out) :: ierr
+
+        real(dp), parameter :: seeds(2, 9) = reshape([ &
+            0.5_dp, 0.5_dp, 0.0_dp, 0.0_dp, 1.0_dp, 0.0_dp, &
+            1.0_dp, 1.0_dp, 0.0_dp, 1.0_dp, 0.5_dp, 0.0_dp, &
+            1.0_dp, 0.5_dp, 0.5_dp, 1.0_dp, 0.0_dp, 0.5_dp], [2, 9])
+        integer, parameter :: max_iterations = 30
+
+        real(dp) :: delta(2), determinant, determinant_scale, residual(2)
+        real(dp) :: rz(2), rz_st(2, 2), scale, tolerance
+        integer :: geometry_ierr, iteration, seed
+
+        s = 0.0_dp
+        t = 0.0_dp
+        ierr = 1
+        do seed = 1, size(seeds, 2)
+            s = seeds(1, seed)
+            t = seeds(2, seed)
+            do iteration = 1, max_iterations
+                call evaluate_jorek_geometry(data, element, s, t, rz, rz_st, &
+                    geometry_ierr)
+                if (geometry_ierr /= 0) then
+                    ierr = 2
+                    return
+                end if
+                residual = target_rz - rz
+                scale = max(1.0_dp, maxval(abs(target_rz)), maxval(abs(rz)))
+                tolerance = 1024.0_dp*epsilon(1.0_dp)**0.75_dp*scale
+                if (maxval(abs(residual)) <= tolerance) then
+                    ierr = 0
+                    return
+                end if
+                determinant = rz_st(1, 1)*rz_st(2, 2) &
+                    - rz_st(1, 2)*rz_st(2, 1)
+                determinant_scale = maxval(abs(rz_st(:, 1))) &
+                    *maxval(abs(rz_st(:, 2)))
+                if (abs(determinant) <= 64.0_dp*epsilon(1.0_dp) &
+                    *determinant_scale) exit
+                delta(1) = (residual(1)*rz_st(2, 2) &
+                    - residual(2)*rz_st(1, 2))/determinant
+                delta(2) = (-residual(1)*rz_st(2, 1) &
+                    + residual(2)*rz_st(1, 1))/determinant
+                s = min(1.0_dp, max(0.0_dp, s + delta(1)))
+                t = min(1.0_dp, max(0.0_dp, t + delta(2)))
+            end do
+        end do
+    end subroutine invert_jorek_element
+
+    pure subroutine jorek_basis_interval(vertex, degree, lower, upper)
+        integer, intent(in) :: vertex, degree
+        real(dp), intent(out) :: lower, upper
+
+        integer, parameter :: s_end(4) = [1, 2, 2, 1]
+        integer, parameter :: t_end(4) = [1, 1, 2, 2]
+        integer, parameter :: s_kind(4) = [1, 2, 1, 2]
+        integer, parameter :: t_kind(4) = [1, 1, 2, 2]
+        real(dp) :: s_lower, s_upper, t_lower, t_upper, products(4)
+
+        call endpoint_basis_interval(s_end(vertex), s_kind(degree), &
+            s_lower, s_upper)
+        call endpoint_basis_interval(t_end(vertex), t_kind(degree), &
+            t_lower, t_upper)
+        products = [s_lower*t_lower, s_lower*t_upper, &
+            s_upper*t_lower, s_upper*t_upper]
+        lower = minval(products)
+        upper = maxval(products)
+    end subroutine jorek_basis_interval
+
+    pure subroutine endpoint_basis_interval(endpoint, kind, lower, upper)
+        integer, intent(in) :: endpoint, kind
+        real(dp), intent(out) :: lower, upper
+
+        if (kind == 1) then
+            lower = 0.0_dp
+            upper = 1.0_dp
+        else if (endpoint == 1) then
+            lower = 0.0_dp
+            upper = 4.0_dp/9.0_dp
+        else
+            lower = -4.0_dp/9.0_dp
+            upper = 0.0_dp
+        end if
+    end subroutine endpoint_basis_interval
 
     pure subroutine cubic_endpoint_basis(u, basis, derivative)
         real(dp), intent(in) :: u

--- a/src/field/jorek_model303_field.f90
+++ b/src/field/jorek_model303_field.f90
@@ -1,6 +1,7 @@
 module jorek_model303_field
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use jorek_bezier, only: evaluate_jorek_geometry, locate_jorek_element
+    use jorek_bezier, only: jorek_locator_t, evaluate_jorek_geometry, &
+        locate_jorek_element, locate_jorek_element_indexed
     use jorek_field_values, only: evaluate_jorek_variable
     use jorek_restart, only: jorek_restart_t
 
@@ -81,19 +82,26 @@ contains
     end subroutine evaluate_jorek_model303_b
 
     pure subroutine evaluate_jorek_model303_at(data, target_rz, phi, &
-            a_r_phi_z, b_r_z_phi, element, st, ierr)
+            a_r_phi_z, b_r_z_phi, element, st, ierr, locator)
         type(jorek_restart_t), intent(in) :: data
         real(dp), intent(in) :: target_rz(2), phi
         real(dp), intent(out) :: a_r_phi_z(3), b_r_z_phi(3)
         integer, intent(out) :: element
         real(dp), intent(out) :: st(2)
         integer, intent(out) :: ierr
+        type(jorek_locator_t), intent(in), optional :: locator
 
         a_r_phi_z = 0.0_dp
         b_r_z_phi = 0.0_dp
         element = 0
         st = 0.0_dp
-        call locate_jorek_element(data, target_rz, element, st(1), st(2), ierr)
+        if (present(locator)) then
+            call locate_jorek_element_indexed(data, locator, target_rz, &
+                element, st(1), st(2), ierr)
+        else
+            call locate_jorek_element(data, target_rz, element, st(1), st(2), &
+                ierr)
+        end if
         if (ierr /= 0) return
         call evaluate_jorek_model303_a(data, element, st(1), st(2), phi, &
             a_r_phi_z, ierr)

--- a/test/jorek/test_jorek_bezier_geometry.f90
+++ b/test/jorek/test_jorek_bezier_geometry.f90
@@ -1,7 +1,8 @@
 program test_jorek_bezier_geometry
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use jorek_bezier, only: cubic_jorek_basis, evaluate_jorek_geometry, &
-        locate_jorek_element
+        jorek_locator_t, build_jorek_locator, locate_jorek_element, &
+        locate_jorek_element_indexed
     use jorek_restart, only: jorek_restart_t
     use util_for_test, only: print_test, print_ok, print_fail
 
@@ -15,6 +16,8 @@ program test_jorek_bezier_geometry
     call test_affine_geometry
     call test_shared_edge
     call test_point_location
+    call test_indexed_point_location
+    call test_locator_bounds
     call test_rejected_inputs
     if (nfail > 0) error stop
 
@@ -111,6 +114,62 @@ contains
         call check_int('outside ierr', ierr, 1)
         call report(nfail_before)
     end subroutine test_point_location
+
+    subroutine test_indexed_point_location
+        type(jorek_restart_t) :: data
+        type(jorek_locator_t) :: locator
+        integer :: element, ierr, nfail_before
+        real(dp) :: s, t
+
+        call print_test('indexed point location preserves element ownership')
+        nfail_before = nfail
+        call make_two_element_strip(data)
+        call build_jorek_locator(data, locator, ierr)
+        call check_int('build ierr', ierr, 0)
+        call locate_jorek_element_indexed(data, locator, [11.25_dp, 0.6_dp], &
+            element, s, t, ierr)
+        call check_int('interior ierr', ierr, 0)
+        call check_int('interior element', element, 2)
+        call check_real('interior s', s, 0.25_dp)
+        call check_real('interior t', t, 0.6_dp)
+        call locate_jorek_element_indexed(data, locator, [11.0_dp, 0.37_dp], &
+            element, s, t, ierr)
+        call check_int('edge ierr', ierr, 0)
+        call check_int('edge element', element, 1)
+        call locate_jorek_element_indexed(data, locator, [13.0_dp, 0.5_dp], &
+            element, s, t, ierr)
+        call check_int('outside ierr', ierr, 1)
+        call report(nfail_before)
+    end subroutine test_indexed_point_location
+
+    subroutine test_locator_bounds
+        type(jorek_restart_t) :: data
+        type(jorek_locator_t) :: locator
+        real(dp) :: rz(2), rz_st(2, 2), s, t
+        integer :: ierr, i, j, nfail_before
+
+        call print_test('locator bounds contain curved Hermite geometry')
+        nfail_before = nfail
+        call make_two_element_strip(data)
+        data%x(:, 1, 2, 1) = [2.0_dp, -1.0_dp, 0.7_dp, -1.3_dp, &
+            1.1_dp, -0.4_dp]
+        data%x(:, 1, 3, 2) = [0.8_dp, -0.5_dp, 1.4_dp, -0.9_dp, &
+            0.6_dp, -1.2_dp]
+        call build_jorek_locator(data, locator, ierr)
+        call check_int('build ierr', ierr, 0)
+        do i = 0, 10
+            s = real(i, dp)/10.0_dp
+            do j = 0, 10
+                t = real(j, dp)/10.0_dp
+                call evaluate_jorek_geometry(data, 1, s, t, rz, rz_st, ierr)
+                call check_int('geometry ierr', ierr, 0)
+                if (any(rz < locator%bounds(:, 1, 1)) &
+                    .or. any(rz > locator%bounds(:, 2, 1))) &
+                    call fail('curved point outside locator bounds')
+            end do
+        end do
+        call report(nfail_before)
+    end subroutine test_locator_bounds
 
     subroutine test_rejected_inputs
         type(jorek_restart_t) :: data

--- a/test/jorek/test_jorek_model303_field.f90
+++ b/test/jorek/test_jorek_model303_field.f90
@@ -2,6 +2,7 @@ program test_jorek_model303_field
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use jorek_model303_field, only: evaluate_jorek_model303_a, &
         evaluate_jorek_model303_b, evaluate_jorek_model303_at
+    use jorek_bezier, only: jorek_locator_t, build_jorek_locator
     use jorek_restart, only: jorek_restart_t
     use util_for_test, only: print_test, print_ok, print_fail
 
@@ -60,6 +61,7 @@ contains
 
     subroutine test_global_field_query
         type(jorek_restart_t) :: data
+        type(jorek_locator_t) :: locator
         real(dp) :: a_r_phi_z(3), b_r_z_phi(3), st(2), r, z
         integer :: element, ierr, nfail_before
 
@@ -68,8 +70,10 @@ contains
         call make_model303_element(data)
         r = 10.25_dp
         z = 0.6_dp
+        call build_jorek_locator(data, locator, ierr)
+        call check_int('build ierr', ierr, 0)
         call evaluate_jorek_model303_at(data, [r, z], 0.4_dp, a_r_phi_z, &
-            b_r_z_phi, element, st, ierr)
+            b_r_z_phi, element, st, ierr, locator)
         call check_int('ierr', ierr, 0)
         call check_int('element', element, 1)
         call check_real('s', st(1), 0.25_dp)

--- a/test/jorek/test_jorek_restart_fixture.f90
+++ b/test/jorek/test_jorek_restart_fixture.f90
@@ -1,6 +1,8 @@
 program test_jorek_restart_fixture
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use jorek_bezier, only: evaluate_jorek_geometry, locate_jorek_element
+    use jorek_bezier, only: jorek_locator_t, build_jorek_locator, &
+        evaluate_jorek_geometry, locate_jorek_element, &
+        locate_jorek_element_indexed
     use jorek_field_values, only: evaluate_jorek_variable
     use jorek_model303_field, only: evaluate_jorek_model303_a, &
         evaluate_jorek_model303_b
@@ -117,6 +119,7 @@ contains
         type(jorek_restart_t), intent(in) :: data
 
         real(dp) :: rz(2), rz_st(2, 2), s, t
+        type(jorek_locator_t) :: locator
         integer :: element, ierr
 
         call evaluate_jorek_geometry(data, 1, 0.2_dp, 0.7_dp, rz, rz_st, ierr)
@@ -132,6 +135,14 @@ contains
         call check_int('location element', element, 1)
         call check_dp('location s', s, 0.2_dp)
         call check_dp('location t', t, 0.7_dp)
+        call build_jorek_locator(data, locator, ierr)
+        call check_int('locator build ierr', ierr, 0)
+        call locate_jorek_element_indexed(data, locator, rz, element, s, t, &
+            ierr)
+        call check_int('indexed location ierr', ierr, 0)
+        call check_int('indexed location element', element, 1)
+        call check_dp('indexed location s', s, 0.2_dp)
+        call check_dp('indexed location t', t, 0.7_dp)
     end subroutine check_geometry_oracle
 
     subroutine check_value_oracle(data)


### PR DESCRIPTION
Adds a reusable point locator with conservative cubic-Hermite element bounds. Global model-303 queries can pass the locator to filter elements before projected Newton inversion while retaining lowest-index ownership on shared edges.

This is stacked on #385.

The bounds use the exact ranges of the JOREK endpoint value and derivative basis functions, including derivative extrema +/-4/9. They are conservative for curved elements and do not approximate or modify geometry. Coordinate conventions, normalization, Fourier evaluation, field formulas, memory layout, and existing unindexed calls are unchanged.

## Verification

Failing before implementation:
```text
Build: FAIL
fo: build failed: Error: Symbol ‘jorek_locator_t’ referenced at (1) not found in module
```

Passing after implementation:
```text
==> indexed point location preserves element ownership
    .................................................... OK
==> locator bounds contain curved Hermite geometry
    .................................................... OK
==> global model 303 query returns compatible A and B
    .................................................... OK
Static: OK (228 modules, 228 changed, 228 affected)
```

Commands:
```sh
fo test test/jorek/test_jorek_bezier_geometry.f90
fo test test/jorek/test_jorek_model303_field.f90
fo
fo test --all
```