### PR TITLE
Regularize JOREK axis field evaluation

### DIFF
--- a/src/field/jorek_bezier.f90
+++ b/src/field/jorek_bezier.f90
@@ -10,15 +10,20 @@ module jorek_bezier
         integer :: n_bins(2) = 0
         real(dp) :: grid_lower(2) = 0.0_dp
         real(dp) :: bin_width(2) = 0.0_dp
+        logical :: has_axis = .false.
+        real(dp) :: axis_rz(2) = 0.0_dp
         real(dp), allocatable :: bounds(:, :, :)
         integer, allocatable :: bin_offsets(:)
         integer, allocatable :: bin_elements(:)
+        integer, allocatable :: axis_elements(:)
+        integer, allocatable :: axis_sides(:)
     end type jorek_locator_t
 
     public :: jorek_locator_t, cubic_jorek_basis, evaluate_jorek_geometry
     public :: build_jorek_locator, locate_jorek_element
     public :: locate_jorek_element_indexed
     public :: jorek_locator_candidate_count
+    public :: is_jorek_axis_target
 
 contains
 
@@ -162,8 +167,105 @@ contains
                 locator%bounds(:, :, element), ierr)
             if (ierr /= 0) return
         end do
+        call build_axis_metadata(data, locator, ierr)
+        if (ierr /= 0) return
         call build_locator_bins(locator, ierr)
     end subroutine build_jorek_locator
+
+    subroutine build_axis_metadata(data, locator, ierr)
+        type(jorek_restart_t), intent(in) :: data
+        type(jorek_locator_t), intent(inout) :: locator
+        integer, intent(out) :: ierr
+
+        integer, allocatable :: elements(:), sides(:)
+        real(dp) :: edge_rz(2), reference_rz(2), scale, tolerance
+        integer :: count, element, side, edge_ierr
+
+        ierr = 0
+        count = 0
+        allocate (elements(data%n_elements), sides(data%n_elements))
+        do element = 1, data%n_elements
+            call collapsed_element_side(data, element, side, edge_rz, edge_ierr)
+            if (edge_ierr /= 0) then
+                ierr = 2
+                return
+            end if
+            if (side == 0) cycle
+            if (count == 0) then
+                reference_rz = edge_rz
+            else
+                scale = max(1.0_dp, maxval(abs(reference_rz)), &
+                    maxval(abs(edge_rz)))
+                tolerance = 64.0_dp*epsilon(1.0_dp)*scale
+                if (maxval(abs(edge_rz - reference_rz)) > tolerance) then
+                    ierr = 2
+                    return
+                end if
+            end if
+            count = count + 1
+            elements(count) = element
+            sides(count) = side
+        end do
+        if (count == 0) return
+        locator%has_axis = .true.
+        locator%axis_rz = reference_rz
+        allocate (locator%axis_elements(count), locator%axis_sides(count))
+        locator%axis_elements = elements(:count)
+        locator%axis_sides = sides(:count)
+    end subroutine build_axis_metadata
+
+    pure subroutine collapsed_element_side(data, element, side, edge_rz, ierr)
+        type(jorek_restart_t), intent(in) :: data
+        integer, intent(in) :: element
+        integer, intent(out) :: side
+        real(dp), intent(out) :: edge_rz(2)
+        integer, intent(out) :: ierr
+
+        real(dp), parameter :: corners(2, 4) = reshape([ &
+            0.0_dp, 0.0_dp, 1.0_dp, 0.0_dp, &
+            1.0_dp, 1.0_dp, 0.0_dp, 1.0_dp], [2, 4])
+        integer, parameter :: edge_vertices(2, 4) = reshape([ &
+            1, 4, 2, 3, 1, 2, 4, 3], [2, 4])
+        real(dp) :: corner_rz(2, 4), rz_st(2, 2), scale, tolerance
+        integer :: corner, vertex_1, vertex_2
+
+        side = 0
+        edge_rz = 0.0_dp
+        ierr = 0
+        do corner = 1, 4
+            call evaluate_jorek_geometry(data, element, corners(1, corner), &
+                corners(2, corner), corner_rz(:, corner), rz_st, ierr)
+            if (ierr /= 0) return
+        end do
+        scale = max(1.0_dp, maxval(abs(corner_rz)))
+        tolerance = 64.0_dp*epsilon(1.0_dp)*scale
+        do side = 1, 4
+            vertex_1 = edge_vertices(1, side)
+            vertex_2 = edge_vertices(2, side)
+            if (maxval(abs(corner_rz(:, vertex_1) &
+                    - corner_rz(:, vertex_2))) <= tolerance) then
+                edge_rz = 0.5_dp*(corner_rz(:, vertex_1) &
+                    + corner_rz(:, vertex_2))
+                return
+            end if
+        end do
+        side = 0
+    end subroutine collapsed_element_side
+
+    pure logical function is_jorek_axis_target(locator, target_rz)
+        type(jorek_locator_t), intent(in) :: locator
+        real(dp), intent(in) :: target_rz(2)
+
+        real(dp) :: scale, tolerance
+
+        is_jorek_axis_target = .false.
+        if (.not. locator%has_axis) return
+        if (.not. allocated(locator%axis_elements)) return
+        scale = max(1.0_dp, maxval(abs(locator%axis_rz)))
+        tolerance = 64.0_dp*epsilon(1.0_dp)*scale
+        is_jorek_axis_target = &
+            maxval(abs(target_rz - locator%axis_rz)) <= tolerance
+    end function is_jorek_axis_target
 
     pure subroutine build_element_bounds(data, element, bounds, ierr)
         type(jorek_restart_t), intent(in) :: data
@@ -461,6 +563,13 @@ contains
         if (size(locator%bin_offsets) /= n_total + 1) return
         if (size(locator%bin_elements) &
             /= locator%bin_offsets(n_total + 1) - 1) return
+        if (locator%has_axis) then
+            if (.not. allocated(locator%axis_elements) &
+                .or. .not. allocated(locator%axis_sides)) return
+            if (size(locator%axis_elements) < 1 &
+                .or. size(locator%axis_sides) &
+                /= size(locator%axis_elements)) return
+        end if
         valid_locator = .true.
     end function valid_locator
 

--- a/src/field/jorek_model303_field.f90
+++ b/src/field/jorek_model303_field.f90
@@ -1,7 +1,8 @@
 module jorek_model303_field
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use jorek_bezier, only: jorek_locator_t, evaluate_jorek_geometry, &
-        locate_jorek_element, locate_jorek_element_indexed
+        locate_jorek_element, locate_jorek_element_indexed, &
+        is_jorek_axis_target
     use jorek_field_values, only: evaluate_jorek_variable
     use jorek_restart, only: jorek_restart_t
 
@@ -96,6 +97,11 @@ contains
         element = 0
         st = 0.0_dp
         if (present(locator)) then
+            if (is_jorek_axis_target(locator, target_rz)) then
+                call evaluate_jorek_model303_axis(data, locator, phi, &
+                    a_r_phi_z, b_r_z_phi, element, st, ierr)
+                return
+            end if
             call locate_jorek_element_indexed(data, locator, target_rz, &
                 element, st(1), st(2), ierr)
         else
@@ -109,5 +115,127 @@ contains
         call evaluate_jorek_model303_b(data, element, st(1), st(2), phi, &
             b_r_z_phi, ierr)
     end subroutine evaluate_jorek_model303_at
+
+    pure subroutine evaluate_jorek_model303_axis(data, locator, phi, &
+            a_r_phi_z, b_r_z_phi, element, st, ierr)
+        type(jorek_restart_t), intent(in) :: data
+        type(jorek_locator_t), intent(in) :: locator
+        real(dp), intent(in) :: phi
+        real(dp), intent(out) :: a_r_phi_z(3), b_r_z_phi(3)
+        integer, intent(out) :: element
+        real(dp), intent(out) :: st(2)
+        integer, intent(out) :: ierr
+
+        real(dp), parameter :: delta(2) = [1.0e-2_dp, 1.0e-3_dp]
+        real(dp), allocatable :: a_sample(:, :, :), angles(:), b_sample(:, :, :)
+        real(dp), allocatable :: weights(:)
+        real(dp) :: a_mean(3, 2), b_mean(3, 2), rz(2), rz_st(2, 2)
+        real(dp) :: weight_sum
+        integer :: i, level, n_axis
+
+        a_r_phi_z = 0.0_dp
+        b_r_z_phi = 0.0_dp
+        element = 0
+        st = 0.0_dp
+        ierr = 8
+        if (data%jorek_model /= 303) then
+            ierr = 7
+            return
+        end if
+        if (.not. locator%has_axis .or. locator%axis_rz(1) <= 0.0_dp) return
+        if (.not. allocated(locator%axis_elements) &
+            .or. .not. allocated(locator%axis_sides)) return
+        n_axis = size(locator%axis_elements)
+        if (n_axis < 1 .or. size(locator%axis_sides) /= n_axis) return
+        allocate (a_sample(3, n_axis, 2), b_sample(3, n_axis, 2))
+        allocate (angles(n_axis), weights(n_axis))
+        do level = 1, 2
+            do i = 1, n_axis
+                call inward_axis_coordinates(locator%axis_sides(i), &
+                    delta(level), st)
+                call evaluate_jorek_geometry(data, locator%axis_elements(i), &
+                    st(1), st(2), rz, rz_st, ierr)
+                if (ierr /= 0) return
+                if (level == 2) angles(i) = atan2(rz(2) - locator%axis_rz(2), &
+                    rz(1) - locator%axis_rz(1))
+                call evaluate_jorek_model303_a(data, &
+                    locator%axis_elements(i), st(1), st(2), phi, &
+                    a_sample(:, i, level), ierr)
+                if (ierr /= 0) return
+                call evaluate_jorek_model303_b(data, &
+                    locator%axis_elements(i), st(1), st(2), phi, &
+                    b_sample(:, i, level), ierr)
+                if (ierr /= 0) return
+                b_sample(1:2, i, level) = &
+                    rz(1)*b_sample(1:2, i, level)
+            end do
+        end do
+        call angular_voronoi_weights(angles, weights)
+        weight_sum = sum(weights)
+        if (weight_sum <= 0.0_dp) then
+            ierr = 8
+            return
+        end if
+        do level = 1, 2
+            do i = 1, 3
+                a_mean(i, level) = sum(weights*a_sample(i, :, level))/weight_sum
+                b_mean(i, level) = sum(weights*b_sample(i, :, level))/weight_sum
+            end do
+        end do
+        a_r_phi_z = (10.0_dp*a_mean(:, 2) - a_mean(:, 1))/9.0_dp
+        b_r_z_phi = (10.0_dp*b_mean(:, 2) - b_mean(:, 1))/9.0_dp
+        a_r_phi_z(1) = 0.0_dp
+        a_r_phi_z(3) = -data%F0*log(locator%axis_rz(1))
+        b_r_z_phi(1:2) = b_r_z_phi(1:2)/locator%axis_rz(1)
+        b_r_z_phi(3) = data%F0/locator%axis_rz(1)
+        element = locator%axis_elements(1)
+        call inward_axis_coordinates(locator%axis_sides(1), 0.0_dp, st)
+        ierr = 0
+    end subroutine evaluate_jorek_model303_axis
+
+    pure subroutine inward_axis_coordinates(side, delta, st)
+        integer, intent(in) :: side
+        real(dp), intent(in) :: delta
+        real(dp), intent(out) :: st(2)
+
+        select case (side)
+        case (1)
+            st = [delta, 0.5_dp]
+        case (2)
+            st = [1.0_dp - delta, 0.5_dp]
+        case (3)
+            st = [0.5_dp, delta]
+        case (4)
+            st = [0.5_dp, 1.0_dp - delta]
+        case default
+            st = 0.0_dp
+        end select
+    end subroutine inward_axis_coordinates
+
+    pure subroutine angular_voronoi_weights(angles, weights)
+        real(dp), intent(in) :: angles(:)
+        real(dp), intent(out) :: weights(size(angles))
+
+        real(dp), parameter :: two_pi = 2.0_dp*acos(-1.0_dp)
+        real(dp) :: backward, difference, forward
+        integer :: i, j
+
+        if (size(angles) == 1) then
+            weights = 1.0_dp
+            return
+        end if
+        do i = 1, size(angles)
+            forward = two_pi
+            backward = two_pi
+            do j = 1, size(angles)
+                if (j == i) cycle
+                difference = modulo(angles(j) - angles(i), two_pi)
+                if (difference > 0.0_dp) forward = min(forward, difference)
+                difference = modulo(angles(i) - angles(j), two_pi)
+                if (difference > 0.0_dp) backward = min(backward, difference)
+            end do
+            weights(i) = 0.5_dp*(forward + backward)
+        end do
+    end subroutine angular_voronoi_weights
 
 end module jorek_model303_field

--- a/test/jorek/test_jorek_model303_field.f90
+++ b/test/jorek/test_jorek_model303_field.f90
@@ -15,6 +15,7 @@ program test_jorek_model303_field
     call test_reduced_mhd_field
     call test_reduced_mhd_potential
     call test_global_field_query
+    call test_collapsed_axis_field
     call test_rejected_model
     call test_rejected_singular_geometry
     if (nfail > 0) error stop
@@ -85,6 +86,33 @@ contains
         call report(nfail_before)
     end subroutine test_global_field_query
 
+    subroutine test_collapsed_axis_field
+        type(jorek_restart_t) :: data
+        type(jorek_locator_t) :: locator
+        real(dp), parameter :: axis_r = 10.0_dp, axis_z = 0.0_dp
+        real(dp), parameter :: psi_axis = 3.0_dp, psi_r = 2.0_dp
+        real(dp), parameter :: psi_z = -4.0_dp
+        real(dp) :: a_r_phi_z(3), b_r_z_phi(3), st(2)
+        integer :: element, ierr, nfail_before
+
+        call print_test('global model 303 query has a finite collapsed-axis limit')
+        nfail_before = nfail
+        call make_model303_axis_element(data, axis_r, psi_axis, psi_r, psi_z)
+        call build_jorek_locator(data, locator, ierr)
+        call check_int('build ierr', ierr, 0)
+        call evaluate_jorek_model303_at(data, [axis_r, axis_z], 0.4_dp, &
+            a_r_phi_z, b_r_z_phi, element, st, ierr, locator)
+        call check_int('ierr', ierr, 0)
+        call check_int('element', element, 1)
+        call check_real('axis A_R', a_r_phi_z(1), 0.0_dp)
+        call check_real('axis A_phi', a_r_phi_z(2), -psi_axis)
+        call check_real('axis A_Z', a_r_phi_z(3), -data%F0*log(axis_r))
+        call check_axis_real('axis B_R', b_r_z_phi(1), psi_z/axis_r)
+        call check_axis_real('axis B_Z', b_r_z_phi(2), -psi_r/axis_r)
+        call check_real('axis B_phi', b_r_z_phi(3), data%F0/axis_r)
+        call report(nfail_before)
+    end subroutine test_collapsed_axis_field
+
     subroutine test_rejected_model
         type(jorek_restart_t) :: data
         real(dp) :: b_r_z_phi(3)
@@ -152,6 +180,36 @@ contains
         end do
     end subroutine make_model303_element
 
+    subroutine make_model303_axis_element(data, axis_r, psi_axis, psi_r, psi_z)
+        type(jorek_restart_t), intent(out) :: data
+        real(dp), intent(in) :: axis_r, psi_axis, psi_r, psi_z
+
+        real(dp), parameter :: s_node(4) = [0.0_dp, 1.0_dp, 1.0_dp, 0.0_dp]
+        real(dp), parameter :: t_node(4) = [0.0_dp, 0.0_dp, 1.0_dp, 1.0_dp]
+        real(dp) :: s, t
+        integer :: node
+
+        call make_model303_element(data)
+        do node = 1, 4
+            s = s_node(node)
+            t = t_node(node)
+            data%x(node, 1, 1, 1) = axis_r + s
+            data%x(node, 1, 1, 2) = s*(2.0_dp*t - 1.0_dp)
+            data%x(node, 1, 2, 1) = 1.0_dp/3.0_dp
+            data%x(node, 1, 2, 2) = (2.0_dp*t - 1.0_dp)/3.0_dp
+            data%x(node, 1, 3, 1) = 0.0_dp
+            data%x(node, 1, 3, 2) = 2.0_dp*s/3.0_dp
+            data%x(node, 1, 4, 1) = 0.0_dp
+            data%x(node, 1, 4, 2) = 2.0_dp/9.0_dp
+            data%values(node, 1, 1, 1) = psi_axis &
+                + s*(psi_r + psi_z*(2.0_dp*t - 1.0_dp))
+            data%values(node, 1, 2, 1) = &
+                (psi_r + psi_z*(2.0_dp*t - 1.0_dp))/3.0_dp
+            data%values(node, 1, 3, 1) = 2.0_dp*s*psi_z/3.0_dp
+            data%values(node, 1, 4, 1) = 2.0_dp*psi_z/9.0_dp
+        end do
+    end subroutine make_model303_axis_element
+
     subroutine check_real(name, actual, expected)
         character(len=*), intent(in) :: name
         real(dp), intent(in) :: actual, expected
@@ -160,6 +218,14 @@ contains
             call fail(name//' mismatch')
         end if
     end subroutine check_real
+
+    subroutine check_axis_real(name, actual, expected)
+        character(len=*), intent(in) :: name
+        real(dp), intent(in) :: actual, expected
+
+        if (abs(actual - expected) > 1.0e-12_dp*max(1.0_dp, abs(expected))) &
+            call fail(name//' mismatch')
+    end subroutine check_axis_real
 
     subroutine check_int(name, actual, expected)
         character(len=*), intent(in) :: name


### PR DESCRIPTION
## Summary

- detect collapsed magnetic-axis edges while building the spatial locator
- evaluate the finite model-303 axis limit from two stable off-axis radii
- angularly weight nonuniform axis sectors and preserve the exact F0/R toroidal field
- cover the collapsed-axis behavior with an analytic reduced-MHD fixture

The off-axis Hermite field, Newton locator, component ordering, and units are unchanged. At the coordinate singularity, the implementation extrapolates the physical flux gradient before applying the exact axis radius. The extrapolation uses normalized element radii 1e-2 and 1e-3; the analytic axis regression uses a relative tolerance of 1e-12.

## Verification

Red before the implementation:

```text
global model 303 query has a finite collapsed-axis limit
 ierr mismatch
 axis B_R mismatch
 axis B_Z mismatch
 axis B_phi mismatch
 FAIL
```

Green after the implementation:

- `fo`
  - `Static: OK (228 modules, 228 changed, 228 affected)`
  - `Build: OK`
- `ctest --test-dir /tmp/libneo-axis-build -R jorek --output-on-failure`
  - `100% tests passed, 0 tests failed out of 5`
- full model-303 restart (6,129 elements, 115 collapsed axis elements)
  - finite axis evaluation at two toroidal phases
  - `B_phi = F0/R_axis` exactly
  - regularized poloidal field agrees with the convergent off-axis limit