### PR TITLE
Clarify JOREK neighbour sentinels

### DIFF
--- a/src/field/jorek_restart.f90
+++ b/src/field/jorek_restart.f90
@@ -5,8 +5,9 @@ module jorek_restart
     !> one-element datasets. Arrays keep the Fortran dimension order of the
     !> JOREK writer, so the C-order file shape (n_var, n_degrees, n_tor,
     !> n_nodes) reads back as (n_nodes, n_tor, n_degrees, n_var). Node indices
-    !> in vertex stay 1-based as stored; neighbours keeps -1 for boundary
-    !> edges. Values keep JOREK normalized units (t_norm = sqrt(mu0 rho0)).
+    !> in vertex stay 1-based as stored; neighbours keeps nonpositive boundary
+    !> sentinels as stored (-1 at a collapsed axis, 0 at a physical boundary).
+    !> Values keep JOREK normalized units (t_norm = sqrt(mu0 rho0)).
 
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use hdf5_tools, only: HID_T, h5_init, h5_deinit, h5_open, h5_close, h5_get, &
@@ -43,7 +44,7 @@ module jorek_restart
         integer, allocatable :: vertex(:, :)
         !> Element scalings, (n_elements, n_vertex_max, n_degrees)
         real(dp), allocatable :: size(:, :, :)
-        !> Element adjacency, (n_elements, n_vertex_max); -1 marks boundaries
+        !> Element adjacency; nonpositive values mark boundary sides as stored
         integer, allocatable :: neighbours(:, :)
     end type jorek_restart_t
 

--- a/test/jorek/test_jorek_restart.f90
+++ b/test/jorek/test_jorek_restart.f90
@@ -180,7 +180,7 @@ contains
         end do
         vertex = reshape([1, 2, 2, 3, 3, 1, 1, 2], &
             [n_elements, n_vertex_max])
-        neighbours = reshape([2, 1, -1, -1, -1, -1, -1, -1], &
+        neighbours = reshape([2, 1, 0, -1, -1, -1, -1, -1], &
             [n_elements, n_vertex_max])
 
         call h5_init()
@@ -325,7 +325,7 @@ contains
         integer, intent(in) :: i, k
 
         integer, parameter :: ref(n_elements, n_vertex_max) = &
-            reshape([2, 1, -1, -1, -1, -1, -1, -1], &
+            reshape([2, 1, 0, -1, -1, -1, -1, -1], &
             [n_elements, n_vertex_max])
 
         neighbours_ref = ref(i, k)


### PR DESCRIPTION
## Problem

The JOREK restart reader says `-1` is the boundary marker for `neighbours`. Model-303 restarts can contain two nonpositive sentinels: `-1` at collapsed-axis sides and `0` at physical-boundary sides. The reader already preserves both values, but its public contract and synthetic round-trip fixture cover only `-1`.

This PR documents the stored-value contract and adds `0` to the existing synthetic round trip. It changes no read path.

## Numerical and interface invariants

- Neighbor values remain unmodified after HDF5 input.
- Array shape, Fortran indexing, restart validation, ABI, memory layout, and HDF5 schema are unchanged.
- JOREK geometry, field evaluation, locator behavior, units, and boundary conditions are unchanged.
- The fixture now proves that positive neighbors, zero physical-boundary sentinels, and negative collapsed-axis sentinels all round-trip.

## Verification

### Test fails on main

The documented nonpositive-sentinel contract and zero fixture are absent:

```text
$ rg 'nonpositive boundary' src/field/jorek_restart.f90
exit=1
```

### Test passes after fix

```text
$ fo
Static: OK (227 modules, 227 changed, 227 affected)
Build: OK
Tests: OK
Lint: OK
All stages passed (.4s)
```
