### PR TITLE
Reset derived data portably with NVFORTRAN

### DIFF
--- a/src/field/jorek_restart.f90
+++ b/src/field/jorek_restart.f90
@@ -102,8 +102,9 @@ contains
 
     subroutine free_jorek_restart(data)
         type(jorek_restart_t), intent(inout) :: data
+        type(jorek_restart_t) :: empty
 
-        data = jorek_restart_t()
+        data = empty
     end subroutine free_jorek_restart
 
     subroutine require_datasets(h5id, ierr)

--- a/src/spectre/spectre_reader.f90
+++ b/src/spectre/spectre_reader.f90
@@ -68,8 +68,9 @@ contains
 
     subroutine free_spectre(data)
         type(spectre_data_t), intent(inout) :: data
+        type(spectre_data_t) :: empty
 
-        data = spectre_data_t()
+        data = empty
     end subroutine free_spectre
 
     subroutine read_sizes(h5id, data)


### PR DESCRIPTION
## Summary

- replace two empty derived-type constructors with assignment from a locally
  default-initialized object;
- preserve deallocation and default component initialization semantics;
- make the SPECTRE and JOREK cleanup routines compile with NVFORTRAN 26.3.

The prior constructors omit allocatable components that do not have default
initializers. GFortran accepts that form, while NVFORTRAN rejects it with
`NVFORTRAN-F-0155`. The replacement is compiler-portable and was also verified
with a focused NVFORTRAN allocation/reset probe.

## Verification

- `fo check`: build 227 modules; all tests passed in 48.4 s
- `fo fmt --check` on both changed files: pass
- `fo lint`: zero unused imports; existing 472-warning baseline
- `git diff --check`: pass
