### PR TITLE
Add Boozer/SFL chart gate tests and signed chartmap Jacobian

### DIFF
--- a/src/coordinates/libneo_coordinates_chartmap.f90
+++ b/src/coordinates/libneo_coordinates_chartmap.f90
@@ -64,6 +64,7 @@ module libneo_coordinates_chartmap
         procedure :: evaluate_cart => chartmap_evaluate_cart
         procedure :: evaluate_cyl => chartmap_evaluate_cyl
         procedure :: covariant_basis => chartmap_covariant_basis
+        procedure :: jacobian_det => chartmap_jacobian_det
         procedure :: metric_tensor => chartmap_metric_tensor
         procedure :: christoffel => chartmap_christoffel
         procedure :: from_cyl => chartmap_from_cyl
@@ -664,6 +665,22 @@ contains
         e_cov = dvals
     end subroutine chartmap_covariant_basis
 
+    !> Signed Jacobian determinant det(dx/du) of the forward map, from the analytic
+    !> covariant basis. metric_tensor's sqrtg = sqrt(abs(det g)) = |jacobian_det|
+    !> discards the orientation; chart gates need the sign to certify one
+    !> consistent handedness across theta/zeta seams on the full torus.
+    real(dp) function chartmap_jacobian_det(self, u) result(det)
+        class(chartmap_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+
+        real(dp) :: e(3, 3)
+
+        call self%covariant_basis(u, e)
+        det = e(1, 1)*(e(2, 2)*e(3, 3) - e(2, 3)*e(3, 2)) &
+              - e(1, 2)*(e(2, 1)*e(3, 3) - e(2, 3)*e(3, 1)) &
+              + e(1, 3)*(e(2, 1)*e(3, 2) - e(2, 2)*e(3, 1))
+    end function chartmap_jacobian_det
+
     subroutine chartmap_metric_tensor(self, u, g, ginv, sqrtg)
         class(chartmap_coordinate_system_t), intent(in) :: self
         real(dp), intent(in) :: u(3)
@@ -1118,7 +1135,7 @@ contains
         real(dp) :: zeta_seed(5)
         logical :: trace
         integer :: k
-        integer :: ierr_seed, ierr_try
+        integer :: ierr_try
 
         ierr = chartmap_from_cyl_err_max_iter
         best_res = huge(1.0_dp)
@@ -1142,8 +1159,7 @@ contains
             x_wedge(2) = -sa*x_target(1) + ca*x_target(2)
             x_wedge(3) = x_target(3)
             call chartmap_initial_guess_cartesian_3d(self, x_wedge, u_try)
-            call chartmap_refine_cart_seed(self, x_wedge, zeta_period, u_try, &
-                                           res_norm, ierr_seed)
+            call chartmap_refine_cart_seed(self, x_wedge, zeta_period, u_try)
             call chartmap_solve_cart(self, x_wedge, u_try(1), u_try(2), u_try(3), &
                                      ierr_try, trace)
             ! Accept on the final residual, not on the solver exit path: the Newton
@@ -1613,20 +1629,17 @@ contains
         end do
     end subroutine chartmap_initial_guess_cartesian_3d
 
-    subroutine chartmap_refine_cart_seed(self, x_target, zeta_period, u, res_norm, ierr)
+    subroutine chartmap_refine_cart_seed(self, x_target, zeta_period, u)
         class(chartmap_coordinate_system_t), intent(in) :: self
         real(dp), intent(in) :: x_target(3)
         real(dp), intent(in) :: zeta_period
         real(dp), intent(inout) :: u(3)
-        real(dp), intent(out) :: res_norm
-        integer, intent(out) :: ierr
 
         real(dp) :: trial(3), best_u(3), x_trial(3)
         real(dp) :: step_rho, step_theta, step_zeta
         real(dp) :: best_dist2, dist2
         integer :: iter, ir, it, iz
 
-        ierr = chartmap_from_cyl_ok
         step_rho = 1.0_dp/16.0_dp
         step_theta = TWOPI/64.0_dp
         step_zeta = zeta_period/48.0_dp
@@ -1661,10 +1674,6 @@ contains
                 if (max(step_rho, max(step_theta, step_zeta)) < 1.0e-12_dp) exit
             end if
         end do
-
-        call chartmap_eval_cart(self, u, x_trial)
-        res_norm = sqrt(sum((x_target - x_trial)**2))
-        if (res_norm > 1.0e-4_dp) ierr = chartmap_from_cyl_err_max_iter
     end subroutine chartmap_refine_cart_seed
 
     subroutine chartmap_newton_delta(self, x_target, rho, theta, zeta, delta, &

--- a/src/coordinates/libneo_coordinates_chartmap.f90
+++ b/src/coordinates/libneo_coordinates_chartmap.f90
@@ -1160,8 +1160,6 @@ contains
             x_wedge(3) = x_target(3)
             call chartmap_initial_guess_cartesian_3d(self, x_wedge, u_try)
             call chartmap_refine_cart_seed(self, x_wedge, zeta_period, u_try)
-            call chartmap_solve_cart(self, x_wedge, u_try(1), u_try(2), u_try(3), &
-                                     ierr_try, trace)
             ! Accept on the final residual, not on the solver exit path: the Newton
             ! step-size exit fires once steps reach tol_step in chart units, which
             ! on a reactor-size chart is a Cartesian residual of order
@@ -1171,6 +1169,8 @@ contains
             ! rejected. The threshold carries the solver's own convergence floors
             ! (tol_newton and the scale-aware term) so a root the Newton
             ! legitimately declares converged is never rejected here.
+            call chartmap_solve_cart(self, x_wedge, u_try(1), u_try(2), u_try(3), &
+                                     ierr_try, trace)
             call chartmap_eval_cart(self, u_try, x_round)
             res_norm = sqrt(sum((x_wedge - x_round)**2))
             accept_tol = max(chartmap_invert_accept_tol, self%tol_newton, &

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -486,6 +486,35 @@ set_tests_properties(test_chartmap_invert_cart PROPERTIES
 add_library(chartmap_test_utils STATIC source/chartmap_test_utils.f90)
 target_link_libraries(chartmap_test_utils PUBLIC neo)
 
+add_library(chartmap_gate_fixtures STATIC source/chartmap_gate_fixtures.f90)
+target_link_libraries(chartmap_gate_fixtures PUBLIC neo)
+
+add_executable(test_chartmap_gate_jacobian.x source/test_chartmap_gate_jacobian.f90)
+target_link_libraries(test_chartmap_gate_jacobian.x chartmap_gate_fixtures)
+add_test(NAME test_chartmap_gate_jacobian
+  COMMAND test_chartmap_gate_jacobian.x)
+set_tests_properties(test_chartmap_gate_jacobian PROPERTIES
+  FAIL_REGULAR_EXPRESSION "STOP"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_executable(test_chartmap_gate_fieldline.x source/test_chartmap_gate_fieldline.f90)
+target_link_libraries(test_chartmap_gate_fieldline.x chartmap_gate_fixtures neo_field)
+add_test(NAME test_chartmap_gate_fieldline
+  COMMAND test_chartmap_gate_fieldline.x)
+set_tests_properties(test_chartmap_gate_fieldline PROPERTIES
+  FAIL_REGULAR_EXPRESSION "STOP"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_executable(test_chartmap_gate_reconstruction.x
+  source/test_chartmap_gate_reconstruction.f90)
+target_link_libraries(test_chartmap_gate_reconstruction.x
+  chartmap_gate_fixtures neo_field)
+add_test(NAME test_chartmap_gate_reconstruction
+  COMMAND test_chartmap_gate_reconstruction.x)
+set_tests_properties(test_chartmap_gate_reconstruction PROPERTIES
+  FAIL_REGULAR_EXPRESSION "STOP"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 add_executable(test_vmec_chartmap_generator.x source/test_vmec_chartmap_generator.f90)
 target_link_libraries(test_vmec_chartmap_generator.x chartmap_test_utils)
 add_test(NAME test_vmec_chartmap_generator

--- a/test/source/chartmap_gate_fixtures.f90
+++ b/test/source/chartmap_gate_fixtures.f90
@@ -1,0 +1,198 @@
+module chartmap_gate_fixtures
+    ! Analytic Boozer-convention chartmap fixtures for the SFL/Boozer chart gate
+    ! tests (signed periodic Jacobian, bounded flux-label drift, launch-independent
+    ! rotational transform, converged field reconstruction). Self-contained NetCDF
+    ! writers in the style of test_chartmap_invert_cart; no external generator.
+    !
+    ! Circular fixture: concentric circular tori around (CIRC_R_AXIS, 0) with
+    ! minor radius r = CIRC_A_MINOR*rho, nfp = 1, and Boozer-like periodic angle
+    ! offsets so the chart angles differ from the geometric ones while the rho
+    ! surfaces stay exact circles. handedness = +1 makes (rho, theta, zeta)
+    ! right-handed (det(dx/du) > 0) by putting theta clockwise in the (R, Z)
+    ! plane; handedness = -1 mirrors Z (left-handed chart).
+    !
+    ! Stellarator fixture: the nfp = 3 rotating-frame construction of
+    ! test_chartmap_invert_cart with the same handedness switch.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use math_constants, only: TWOPI
+    use netcdf, only: NF90_NETCDF4, NF90_GLOBAL, NF90_DOUBLE, NF90_INT, NF90_NOERR, &
+                      nf90_create, nf90_def_dim, nf90_def_var, nf90_put_att, &
+                      nf90_enddef, nf90_put_var, nf90_close, nf90_strerror
+    implicit none
+    private
+
+    public :: write_circular_boozer_chartmap
+    public :: write_stellarator_boozer_chartmap
+    public :: circular_chart_position
+
+    real(dp), parameter, public :: CIRC_R_AXIS = 180.0_dp
+    real(dp), parameter, public :: CIRC_A_MINOR = 45.0_dp
+    real(dp), parameter, public :: CIRC_LAM_AMP = 0.04_dp
+    real(dp), parameter, public :: CIRC_NU_AMP = 0.03_dp
+
+contains
+
+    subroutine nc_check(status)
+        integer, intent(in) :: status
+        if (status /= NF90_NOERR) then
+            print *, trim(nf90_strerror(status))
+            error stop 2
+        end if
+    end subroutine nc_check
+
+    ! Exact analytic forward map of the circular fixture: chart u = (rho, theta,
+    ! zeta) to Cartesian x in cm. Reference truth for the gate tests, independent
+    ! of any chart grid resolution.
+    subroutine circular_chart_position(rho, theta, zeta, handedness, x)
+        real(dp), intent(in) :: rho, theta, zeta
+        integer, intent(in) :: handedness
+        real(dp), intent(out) :: x(3)
+
+        real(dp) :: r, thg, phg, rmaj
+
+        r = CIRC_A_MINOR*rho
+        thg = theta + CIRC_LAM_AMP*rho*sin(theta)
+        phg = zeta + CIRC_NU_AMP*rho*sin(thg)
+        rmaj = CIRC_R_AXIS + r*cos(thg)
+        x(1) = rmaj*cos(phg)
+        x(2) = rmaj*sin(phg)
+        x(3) = -real(handedness, dp)*r*sin(thg)
+    end subroutine circular_chart_position
+
+    subroutine write_circular_boozer_chartmap(path, nrho, ntheta, nzeta, handedness)
+        character(len=*), intent(in) :: path
+        integer, intent(in) :: nrho, ntheta, nzeta
+        integer, intent(in) :: handedness
+
+        real(dp) :: rho(nrho), theta(ntheta), zeta(nzeta)
+        real(dp), allocatable :: x(:, :, :), y(:, :, :), z(:, :, :)
+        real(dp) :: pos(3)
+        integer :: ir, it, iz
+
+        do ir = 1, nrho
+            rho(ir) = real(ir - 1, dp)/real(nrho - 1, dp)
+        end do
+        do it = 1, ntheta
+            theta(it) = TWOPI*real(it - 1, dp)/real(ntheta, dp)
+        end do
+        do iz = 1, nzeta
+            zeta(iz) = TWOPI*real(iz - 1, dp)/real(nzeta, dp)
+        end do
+
+        allocate (x(nrho, ntheta, nzeta))
+        allocate (y(nrho, ntheta, nzeta))
+        allocate (z(nrho, ntheta, nzeta))
+        do iz = 1, nzeta
+            do it = 1, ntheta
+                do ir = 1, nrho
+                    call circular_chart_position(rho(ir), theta(it), zeta(iz), &
+                                                 handedness, pos)
+                    x(ir, it, iz) = pos(1)
+                    y(ir, it, iz) = pos(2)
+                    z(ir, it, iz) = pos(3)
+                end do
+            end do
+        end do
+
+        call write_chartmap_netcdf(path, nrho, ntheta, nzeta, 1, rho, theta, zeta, &
+                                   x, y, z)
+    end subroutine write_circular_boozer_chartmap
+
+    ! Reactor-scale synthetic nfp = 3 Boozer chartmap with a genuinely
+    ! non-cylindrical toroidal angle (same shaping as test_chartmap_invert_cart).
+    subroutine write_stellarator_boozer_chartmap(path, nrho, ntheta, nzeta, handedness)
+        character(len=*), intent(in) :: path
+        integer, intent(in) :: nrho, ntheta, nzeta
+        integer, intent(in) :: handedness
+
+        integer, parameter :: nfp = 3
+        real(dp), parameter :: r0 = 180.0_dp
+        real(dp), parameter :: a = 45.0_dp
+        real(dp) :: rho(nrho), theta(ntheta), zeta(nzeta)
+        real(dp), allocatable :: x(:, :, :), y(:, :, :), z(:, :, :)
+        real(dp) :: rho_val, theta_val, zeta_val
+        real(dp) :: phi_geom, rmaj, zpos, period
+        integer :: ir, it, iz
+
+        period = TWOPI/real(nfp, dp)
+
+        do ir = 1, nrho
+            rho(ir) = real(ir - 1, dp)/real(nrho - 1, dp)
+        end do
+        do it = 1, ntheta
+            theta(it) = TWOPI*real(it - 1, dp)/real(ntheta, dp)
+        end do
+        do iz = 1, nzeta
+            zeta(iz) = period*real(iz - 1, dp)/real(nzeta, dp)
+        end do
+
+        allocate (x(nrho, ntheta, nzeta))
+        allocate (y(nrho, ntheta, nzeta))
+        allocate (z(nrho, ntheta, nzeta))
+        do iz = 1, nzeta
+            zeta_val = zeta(iz)
+            do it = 1, ntheta
+                theta_val = theta(it)
+                do ir = 1, nrho
+                    rho_val = rho(ir)
+                    phi_geom = zeta_val + 0.08_dp*rho_val*sin(theta_val) + &
+                               0.02_dp*sin(2.0_dp*zeta_val)
+                    rmaj = r0 + a*rho_val*cos(theta_val) + &
+                           0.04_dp*a*rho_val*cos(theta_val - 2.0_dp*zeta_val)
+                    zpos = a*rho_val*sin(theta_val) + &
+                           0.02_dp*a*rho_val*sin(zeta_val)
+
+                    x(ir, it, iz) = rmaj*cos(phi_geom)
+                    y(ir, it, iz) = rmaj*sin(phi_geom)
+                    z(ir, it, iz) = -real(handedness, dp)*zpos
+                end do
+            end do
+        end do
+
+        call write_chartmap_netcdf(path, nrho, ntheta, nzeta, nfp, rho, theta, zeta, &
+                                   x, y, z)
+    end subroutine write_stellarator_boozer_chartmap
+
+    subroutine write_chartmap_netcdf(path, nrho, ntheta, nzeta, nfp, rho, theta, &
+                                     zeta, x, y, z)
+        character(len=*), intent(in) :: path
+        integer, intent(in) :: nrho, ntheta, nzeta, nfp
+        real(dp), intent(in) :: rho(nrho), theta(ntheta), zeta(nzeta)
+        real(dp), intent(in) :: x(nrho, ntheta, nzeta), y(nrho, ntheta, nzeta), &
+                                z(nrho, ntheta, nzeta)
+
+        integer :: ncid
+        integer :: dim_rho, dim_theta, dim_zeta
+        integer :: var_rho, var_theta, var_zeta, var_x, var_y, var_z, var_nfp
+
+        call nc_check(nf90_create(trim(path), NF90_NETCDF4, ncid))
+        call nc_check(nf90_put_att(ncid, NF90_GLOBAL, "zeta_convention", "boozer"))
+        call nc_check(nf90_def_dim(ncid, "rho", nrho, dim_rho))
+        call nc_check(nf90_def_dim(ncid, "theta", ntheta, dim_theta))
+        call nc_check(nf90_def_dim(ncid, "zeta", nzeta, dim_zeta))
+        call nc_check(nf90_def_var(ncid, "rho", NF90_DOUBLE, [dim_rho], var_rho))
+        call nc_check(nf90_def_var(ncid, "theta", NF90_DOUBLE, [dim_theta], var_theta))
+        call nc_check(nf90_def_var(ncid, "zeta", NF90_DOUBLE, [dim_zeta], var_zeta))
+        call nc_check(nf90_def_var(ncid, "x", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_x))
+        call nc_check(nf90_def_var(ncid, "y", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_y))
+        call nc_check(nf90_def_var(ncid, "z", NF90_DOUBLE, &
+                                   [dim_rho, dim_theta, dim_zeta], var_z))
+        call nc_check(nf90_def_var(ncid, "num_field_periods", NF90_INT, var_nfp))
+        call nc_check(nf90_put_att(ncid, var_x, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_y, "units", "cm"))
+        call nc_check(nf90_put_att(ncid, var_z, "units", "cm"))
+        call nc_check(nf90_enddef(ncid))
+
+        call nc_check(nf90_put_var(ncid, var_rho, rho))
+        call nc_check(nf90_put_var(ncid, var_theta, theta))
+        call nc_check(nf90_put_var(ncid, var_zeta, zeta))
+        call nc_check(nf90_put_var(ncid, var_x, x))
+        call nc_check(nf90_put_var(ncid, var_y, y))
+        call nc_check(nf90_put_var(ncid, var_z, z))
+        call nc_check(nf90_put_var(ncid, var_nfp, nfp))
+        call nc_check(nf90_close(ncid))
+    end subroutine write_chartmap_netcdf
+
+end module chartmap_gate_fixtures

--- a/test/source/test_chartmap_gate_fieldline.f90
+++ b/test/source/test_chartmap_gate_fieldline.f90
@@ -1,0 +1,247 @@
+program test_chartmap_gate_fieldline
+    ! Boozer/SFL chart gates (b) and (c) (ROADMAP straight-field-line gauge gates):
+    !   (b) bounded flux-label drift over N toroidal transits of a traced field
+    !       line pulled back through the chart inverse;
+    !   (c) launch-independent rotational transform from an ensemble of launch
+    !       points and angles covering radii, poloidal angles, and toroidal
+    !       sectors of the full torus.
+    !
+    ! Field: the production circular tokamak field (neo_circular_tokamak_field),
+    ! B_R = -Bp (Z - Z0)/R, B_phi = Bt, B_Z = Bp (R - R0)/R. Its field lines lie
+    ! exactly on circular tori r = const around (R0, Z0) and are straight in the
+    ! geometric angles: alpha(phi) = alpha0 + (Bp/Bt) (phi - phi0). The trace
+    ! therefore uses the closed-form line (zero integrator noise); a tangency
+    ! self-check first verifies at machine precision that the closed form is a
+    ! field line of the production evaluator.
+    !
+    ! Chart: the analytic circular Boozer-convention fixture whose rho surfaces
+    ! are exactly the field's flux surfaces (r = CIRC_A_MINOR*rho), with periodic
+    ! Boozer-like angle offsets so chart angles differ from geometric ones. The
+    ! fixture is right-handed (theta clockwise in the (R, Z) plane), so the
+    ! transform measured in chart angles is iota_chart = -Bp/Bt.
+    !
+    ! Every pullback uses the warm single-point inverse invert_cart with the
+    ! previous sample as guess -- the orbit-pusher usage pattern.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use libneo_coordinates, only: coordinate_system_t, chartmap_coordinate_system_t, &
+                                  make_chartmap_coordinate_system, CHARTMAP_LOCATED
+    use math_constants, only: TWOPI
+    use neo_circular_tokamak_field, only: circular_tokamak_field_t
+    use chartmap_gate_fixtures, only: write_circular_boozer_chartmap, &
+                                      circular_chart_position, CIRC_R_AXIS, &
+                                      CIRC_A_MINOR
+    implicit none
+
+    character(len=*), parameter :: chart_path = "chartmap_gate_fieldline.nc"
+    real(dp), parameter :: B_POL = 0.3183099_dp
+    real(dp), parameter :: B_TOR = 1.0_dp
+    real(dp), parameter :: iota_geom = B_POL/B_TOR
+    real(dp), parameter :: iota_chart_ref = -iota_geom
+    integer, parameter :: n_transit = 50
+    integer, parameter :: n_per_transit = 12
+    real(dp), parameter :: tol_drift = 1.0e-5_dp
+    real(dp), parameter :: tol_iota_abs = 5.0e-4_dp
+    real(dp), parameter :: tol_iota_spread = 5.0e-4_dp
+
+    type(circular_tokamak_field_t) :: field
+    class(coordinate_system_t), allocatable :: cs
+    integer :: nerrors
+
+    nerrors = 0
+
+    call field%circular_tokamak_field_init(R_axis=CIRC_R_AXIS, Z_axis=0.0_dp, &
+                                           B_pol_ampl=B_POL, B_tor_ampl=B_TOR)
+    call check_closed_form_is_field_line(field, nerrors)
+
+    call write_circular_boozer_chartmap(chart_path, 17, 48, 12, 1)
+    call make_chartmap_coordinate_system(cs, chart_path)
+
+    select type (ccs => cs)
+    type is (chartmap_coordinate_system_t)
+        call run_ensemble_gates(ccs, nerrors)
+    class default
+        print *, "  FAIL: fixture did not load as chartmap type"
+        nerrors = nerrors + 1
+    end select
+
+    if (nerrors > 0) then
+        print *, "FAILED: ", nerrors, " error(s) detected in field-line gate tests"
+        error stop 1
+    end if
+
+    print *, "All chartmap field-line gate tests passed!"
+
+contains
+
+    ! Verify the closed-form line alpha(phi) = alpha0 + iota_geom*(phi - phi0) is
+    ! a field line of the production evaluator: the Cartesian curve tangent must
+    ! be parallel to B (relative mismatch at rounding level).
+    subroutine check_closed_form_is_field_line(fld, nerrors)
+        type(circular_tokamak_field_t), intent(in) :: fld
+        integer, intent(inout) :: nerrors
+
+        real(dp), parameter :: tol = 1.0e-12_dp
+        real(dp) :: r, alpha, phi, rmaj, zpos
+        real(dp) :: dr_dphi, dz_dphi, tangent(3), b_cyl(3), b_cart(3), scale
+        real(dp) :: rel
+        integer :: k, m, nfail
+
+        nfail = 0
+        do m = 1, 3
+            r = CIRC_A_MINOR*(0.2_dp + 0.3_dp*real(m - 1, dp))
+            do k = 1, 7
+                alpha = 0.83_dp*real(k, dp)
+                phi = 1.7_dp*real(k, dp)
+                rmaj = CIRC_R_AXIS + r*cos(alpha)
+                zpos = r*sin(alpha)
+                dr_dphi = -iota_geom*r*sin(alpha)
+                dz_dphi = iota_geom*r*cos(alpha)
+                tangent = [dr_dphi*cos(phi) - rmaj*sin(phi), &
+                           dr_dphi*sin(phi) + rmaj*cos(phi), dz_dphi]
+                call fld%compute_bfield([rmaj, phi, zpos], b_cyl)
+                b_cart = [b_cyl(1)*cos(phi) - b_cyl(2)*sin(phi), &
+                          b_cyl(1)*sin(phi) + b_cyl(2)*cos(phi), b_cyl(3)]
+                scale = rmaj/b_cyl(2)
+                rel = sqrt(sum((tangent - scale*b_cart)**2))/sqrt(sum(tangent**2))
+                if (rel > tol) then
+                    print *, "  FAIL: closed form not tangent to B, rel=", rel
+                    nfail = nfail + 1
+                end if
+            end do
+        end do
+        nerrors = nerrors + nfail
+        if (nfail == 0) print *, &
+            "  PASS: closed-form trace is a field line of the production evaluator"
+    end subroutine check_closed_form_is_field_line
+
+    subroutine run_ensemble_gates(ccs, nerrors)
+        type(chartmap_coordinate_system_t), intent(in) :: ccs
+        integer, intent(inout) :: nerrors
+
+        real(dp), parameter :: rho_vals(3) = [0.30_dp, 0.55_dp, 0.80_dp]
+        real(dp), parameter :: theta_vals(3) = [0.5_dp, 2.6_dp, 4.9_dp]
+        real(dp), parameter :: zeta_vals(3) = [0.3_dp, 2.2_dp, 4.5_dp]
+        real(dp) :: iota_est(27), drift(27)
+        real(dp) :: iota_min, iota_max
+        integer :: ir, it, iz, m, nfail_trace, nfail
+
+        m = 0
+        nfail_trace = 0
+        do iz = 1, size(zeta_vals)
+            do it = 1, size(theta_vals)
+                do ir = 1, size(rho_vals)
+                    m = m + 1
+                    call trace_and_pull_back(ccs, rho_vals(ir), theta_vals(it), &
+                                             zeta_vals(iz), iota_est(m), drift(m), &
+                                             nfail_trace)
+                end do
+            end do
+        end do
+        nerrors = nerrors + nfail_trace
+        if (nfail_trace == 0) print *, &
+            "  PASS: all pullbacks LOCATED on 27 launches x", &
+            n_transit*n_per_transit, " samples"
+
+        ! Gate (b): bounded flux-label drift.
+        nfail = 0
+        if (maxval(drift) > tol_drift) then
+            print *, "  FAIL: flux-label drift ", maxval(drift), " > ", tol_drift
+            nfail = nfail + 1
+        end if
+        nerrors = nerrors + nfail
+        if (nfail == 0) print *, "  PASS: flux-label drift over ", n_transit, &
+            " transits bounded by ", tol_drift, " (max ", maxval(drift), ")"
+
+        ! Gate (c): launch-independent rotational transform.
+        nfail = 0
+        iota_min = minval(iota_est)
+        iota_max = maxval(iota_est)
+        if (iota_max - iota_min > tol_iota_spread) then
+            print *, "  FAIL: iota ensemble spread ", iota_max - iota_min, &
+                " > ", tol_iota_spread
+            nfail = nfail + 1
+        end if
+        if (maxval(abs(iota_est - iota_chart_ref)) > tol_iota_abs) then
+            print *, "  FAIL: iota deviates from reference ", iota_chart_ref, &
+                " max err ", maxval(abs(iota_est - iota_chart_ref))
+            nfail = nfail + 1
+        end if
+        nerrors = nerrors + nfail
+        if (nfail == 0) print *, "  PASS: transform launch-independent, iota=", &
+            0.5_dp*(iota_min + iota_max), " ref=", iota_chart_ref, &
+            " spread=", iota_max - iota_min
+    end subroutine run_ensemble_gates
+
+    ! Trace the closed-form field line launched from chart point (rho0, theta0,
+    ! zeta0) over n_transit toroidal transits, pulling every sample back through
+    ! the warm chart inverse. Returns the endpoint transform estimate and the
+    ! maximum flux-label drift; counts non-LOCATED pullbacks into nfail.
+    subroutine trace_and_pull_back(ccs, rho0, theta0, zeta0, iota_out, drift_out, &
+                                   nfail)
+        type(chartmap_coordinate_system_t), intent(in) :: ccs
+        real(dp), intent(in) :: rho0, theta0, zeta0
+        real(dp), intent(out) :: iota_out, drift_out
+        integer, intent(inout) :: nfail
+
+        real(dp) :: x0(3), x(3), u(3), u_guess(3)
+        real(dp) :: r, alpha0, phi0, rmaj0
+        real(dp) :: alpha, phi, rmaj
+        real(dp) :: th_prev, ze_prev, th_un, ze_un, th_start, ze_start
+        real(dp) :: dphi, dth, dze
+        integer :: k, status, nsteps
+
+        call circular_chart_position(rho0, theta0, zeta0, 1, x0)
+        rmaj0 = sqrt(x0(1)**2 + x0(2)**2)
+        phi0 = atan2(x0(2), x0(1))
+        r = sqrt((rmaj0 - CIRC_R_AXIS)**2 + x0(3)**2)
+        alpha0 = atan2(x0(3), rmaj0 - CIRC_R_AXIS)
+
+        nsteps = n_transit*n_per_transit
+        dphi = TWOPI/real(n_per_transit, dp)
+
+        u_guess = [rho0 + 0.02_dp, theta0 + 0.05_dp, zeta0 - 0.03_dp]
+        drift_out = 0.0_dp
+        th_un = 0.0_dp
+        ze_un = 0.0_dp
+        th_prev = 0.0_dp
+        ze_prev = 0.0_dp
+        th_start = 0.0_dp
+        ze_start = 0.0_dp
+
+        do k = 0, nsteps
+            phi = phi0 + real(k, dp)*dphi
+            alpha = alpha0 + iota_geom*real(k, dp)*dphi
+            rmaj = CIRC_R_AXIS + r*cos(alpha)
+            x = [rmaj*cos(phi), rmaj*sin(phi), r*sin(alpha)]
+
+            call ccs%invert_cart(x, u_guess, u, status)
+            if (status /= CHARTMAP_LOCATED) then
+                print *, "  FAIL: pullback status=", status, " at k=", k, &
+                    " launch rho0=", rho0
+                nfail = nfail + 1
+                iota_out = huge(1.0_dp)
+                drift_out = huge(1.0_dp)
+                return
+            end if
+            u_guess = u
+
+            drift_out = max(drift_out, abs(u(1) - rho0))
+            if (k == 0) then
+                th_un = u(2)
+                ze_un = u(3)
+                th_start = th_un
+                ze_start = ze_un
+            else
+                dth = modulo(u(2) - th_prev + 0.5_dp*TWOPI, TWOPI) - 0.5_dp*TWOPI
+                dze = modulo(u(3) - ze_prev + 0.5_dp*TWOPI, TWOPI) - 0.5_dp*TWOPI
+                th_un = th_un + dth
+                ze_un = ze_un + dze
+            end if
+            th_prev = u(2)
+            ze_prev = u(3)
+        end do
+
+        iota_out = (th_un - th_start)/(ze_un - ze_start)
+    end subroutine trace_and_pull_back
+
+end program test_chartmap_gate_fieldline

--- a/test/source/test_chartmap_gate_fieldline.f90
+++ b/test/source/test_chartmap_gate_fieldline.f90
@@ -33,7 +33,7 @@ program test_chartmap_gate_fieldline
     implicit none
 
     character(len=*), parameter :: chart_path = "chartmap_gate_fieldline.nc"
-    real(dp), parameter :: B_POL = 0.3183099_dp
+    real(dp), parameter :: B_POL = 2.0_dp/TWOPI ! 1/pi
     real(dp), parameter :: B_TOR = 1.0_dp
     real(dp), parameter :: iota_geom = B_POL/B_TOR
     real(dp), parameter :: iota_chart_ref = -iota_geom

--- a/test/source/test_chartmap_gate_jacobian.f90
+++ b/test/source/test_chartmap_gate_jacobian.f90
@@ -1,0 +1,265 @@
+program test_chartmap_gate_jacobian
+    ! Boozer/SFL chart gate (a): signed periodic Jacobian positivity across chart
+    ! seams on the full torus (ROADMAP straight-field-line gauge gates).
+    !
+    ! Uses the signed accessor cs%jacobian_det (det of the analytic covariant
+    ! basis), not sqrt(abs(det g)), so an orientation flip cannot hide behind the
+    ! absolute value. Checks on synthetic analytic fixtures:
+    !   - right-handed nfp = 3 rotating-frame chart: det > 0 at every probe of a
+    !     full-torus scan that straddles every field-period seam, the theta seam,
+    !     and the 2pi zeta wrap;
+    !   - seam pairs are continuous (relative jump at solver-noise level, not O(1));
+    !   - |jacobian_det| agrees with metric_tensor's sqrtg;
+    !   - the mirrored (left-handed) chart gives det < 0 everywhere: the accessor
+    !     is genuinely signed;
+    !   - right-handed circular nfp = 1 chart: det > 0 including both angular seams.
+    ! The magnetic axis rho = 0 is excluded: det -> 0 there by construction of any
+    ! polar chart; the scan starts at small but finite rho.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use libneo_coordinates, only: coordinate_system_t, chartmap_coordinate_system_t, &
+                                  make_chartmap_coordinate_system
+    use math_constants, only: TWOPI
+    use chartmap_gate_fixtures, only: write_circular_boozer_chartmap, &
+                                      write_stellarator_boozer_chartmap
+    implicit none
+
+    integer :: nerrors
+
+    nerrors = 0
+
+    call run_stellarator_checks(nerrors)
+    call run_mirrored_checks(nerrors)
+    call run_circular_checks(nerrors)
+
+    if (nerrors > 0) then
+        print *, "FAILED: ", nerrors, " error(s) detected in Jacobian gate tests"
+        error stop 1
+    end if
+
+    print *, "All chartmap Jacobian gate tests passed!"
+
+contains
+
+    subroutine load_chart(path, cs)
+        character(len=*), intent(in) :: path
+        class(coordinate_system_t), allocatable, intent(out) :: cs
+
+        call make_chartmap_coordinate_system(cs, path)
+    end subroutine load_chart
+
+    subroutine run_stellarator_checks(nerrors)
+        integer, intent(inout) :: nerrors
+
+        character(len=*), parameter :: path = "chartmap_gate_jacobian_rh.nc"
+        class(coordinate_system_t), allocatable :: cs
+
+        call write_stellarator_boozer_chartmap(path, 9, 16, 12, 1)
+        call load_chart(path, cs)
+        select type (ccs => cs)
+        type is (chartmap_coordinate_system_t)
+            call check_positive_full_torus(ccs, "stellarator RH", nerrors)
+            call check_seam_continuity(ccs, "stellarator RH", nerrors)
+            call check_sqrtg_consistency(ccs, "stellarator RH", nerrors)
+        class default
+            print *, "  FAIL: fixture did not load as chartmap type"
+            nerrors = nerrors + 1
+        end select
+    end subroutine run_stellarator_checks
+
+    subroutine run_mirrored_checks(nerrors)
+        integer, intent(inout) :: nerrors
+
+        character(len=*), parameter :: path = "chartmap_gate_jacobian_lh.nc"
+        class(coordinate_system_t), allocatable :: cs
+        real(dp) :: u(3), det
+        integer :: ir, it, iz, nfail
+        real(dp), parameter :: rho_vals(3) = [0.2_dp, 0.6_dp, 1.0_dp]
+        real(dp), parameter :: theta_vals(3) = [0.5_dp, 2.7_dp, 5.0_dp]
+        real(dp), parameter :: zeta_fracs(4) = [0.1_dp, 0.35_dp, 0.6_dp, 0.85_dp]
+
+        call write_stellarator_boozer_chartmap(path, 9, 16, 12, -1)
+        call load_chart(path, cs)
+        nfail = 0
+        select type (ccs => cs)
+        type is (chartmap_coordinate_system_t)
+            do iz = 1, size(zeta_fracs)
+                do it = 1, size(theta_vals)
+                    do ir = 1, size(rho_vals)
+                        u = [rho_vals(ir), theta_vals(it), zeta_fracs(iz)*TWOPI]
+                        det = ccs%jacobian_det(u)
+                        if (det >= 0.0_dp) then
+                            print *, "  FAIL: mirrored chart det>=0 at u=", u, &
+                                " det=", det
+                            nfail = nfail + 1
+                        end if
+                    end do
+                end do
+            end do
+        class default
+            print *, "  FAIL: fixture did not load as chartmap type"
+            nfail = nfail + 1
+        end select
+        nerrors = nerrors + nfail
+        if (nfail == 0) print *, "  PASS: mirrored chart det < 0 (accessor is signed)"
+    end subroutine run_mirrored_checks
+
+    subroutine run_circular_checks(nerrors)
+        integer, intent(inout) :: nerrors
+
+        character(len=*), parameter :: path = "chartmap_gate_jacobian_circ.nc"
+        class(coordinate_system_t), allocatable :: cs
+
+        call write_circular_boozer_chartmap(path, 9, 16, 8, 1)
+        call load_chart(path, cs)
+        select type (ccs => cs)
+        type is (chartmap_coordinate_system_t)
+            call check_positive_full_torus(ccs, "circular RH", nerrors)
+            call check_seam_continuity(ccs, "circular RH", nerrors)
+            call check_sqrtg_consistency(ccs, "circular RH", nerrors)
+        class default
+            print *, "  FAIL: fixture did not load as chartmap type"
+            nerrors = nerrors + 1
+        end select
+    end subroutine run_circular_checks
+
+    ! Full-torus zeta scan including probes an epsilon on both sides of every
+    ! field-period seam and of the 2pi wrap, plus theta-seam probes.
+    subroutine check_positive_full_torus(ccs, label, nerrors)
+        type(chartmap_coordinate_system_t), intent(in) :: ccs
+        character(len=*), intent(in) :: label
+        integer, intent(inout) :: nerrors
+
+        real(dp), parameter :: eps = 1.0e-6_dp
+        real(dp), parameter :: rho_vals(6) = &
+            [0.05_dp, 0.25_dp, 0.45_dp, 0.65_dp, 0.85_dp, 1.0_dp]
+        real(dp), parameter :: theta_vals(7) = &
+            [eps, 0.9_dp, 1.9_dp, 3.1_dp, 4.2_dp, 5.4_dp, TWOPI - eps]
+        real(dp) :: zeta_vals(24 + 2*(3 + 1))
+        real(dp) :: u(3), det, period
+        integer :: ir, it, iz, k, nz, nfail
+
+        period = TWOPI/real(ccs%num_field_periods, dp)
+        nz = 0
+        do k = 0, 23
+            nz = nz + 1
+            zeta_vals(nz) = TWOPI*real(k, dp)/24.0_dp + 0.013_dp
+        end do
+        do k = 0, ccs%num_field_periods
+            nz = nz + 1
+            zeta_vals(nz) = real(k, dp)*period - eps
+            nz = nz + 1
+            zeta_vals(nz) = real(k, dp)*period + eps
+        end do
+
+        nfail = 0
+        do iz = 1, nz
+            do it = 1, size(theta_vals)
+                do ir = 1, size(rho_vals)
+                    u = [rho_vals(ir), theta_vals(it), zeta_vals(iz)]
+                    det = ccs%jacobian_det(u)
+                    if (det /= det) then
+                        print *, "  FAIL: ", label, " det is NaN at u=", u
+                        nfail = nfail + 1
+                    else if (det <= 0.0_dp) then
+                        print *, "  FAIL: ", label, " det<=0 at u=", u, " det=", det
+                        nfail = nfail + 1
+                    end if
+                end do
+            end do
+        end do
+        nerrors = nerrors + nfail
+        if (nfail == 0) print *, "  PASS: ", label, &
+            " signed Jacobian positive on the full torus incl. seams"
+    end subroutine check_positive_full_torus
+
+    ! Seam pairs must agree to solver-noise level: a chart whose orientation or
+    ! periodic closure breaks at a seam shows an O(1) jump there.
+    subroutine check_seam_continuity(ccs, label, nerrors)
+        type(chartmap_coordinate_system_t), intent(in) :: ccs
+        character(len=*), intent(in) :: label
+        integer, intent(inout) :: nerrors
+
+        real(dp), parameter :: eps = 1.0e-6_dp
+        real(dp), parameter :: tol_pair = 5.0e-6_dp
+        real(dp), parameter :: tol_wrap = 1.0e-10_dp
+        real(dp) :: u_lo(3), u_hi(3), det_lo, det_hi, rel
+        real(dp) :: period
+        integer :: k, nfail
+
+        period = TWOPI/real(ccs%num_field_periods, dp)
+        nfail = 0
+
+        ! Field-period seams (interior continuity of the periodic spline).
+        do k = 0, ccs%num_field_periods
+            u_lo = [0.6_dp, 1.1_dp, real(k, dp)*period - eps]
+            u_hi = [0.6_dp, 1.1_dp, real(k, dp)*period + eps]
+            det_lo = ccs%jacobian_det(u_lo)
+            det_hi = ccs%jacobian_det(u_hi)
+            rel = abs(det_hi - det_lo)/max(abs(det_lo), abs(det_hi))
+            if (rel > tol_pair) then
+                print *, "  FAIL: ", label, " zeta-seam jump at k=", k, " rel=", rel
+                nfail = nfail + 1
+            end if
+        end do
+
+        ! Theta seam.
+        u_lo = [0.6_dp, TWOPI - eps, 0.37_dp*period]
+        u_hi = [0.6_dp, eps, 0.37_dp*period]
+        det_lo = ccs%jacobian_det(u_lo)
+        det_hi = ccs%jacobian_det(u_hi)
+        rel = abs(det_hi - det_lo)/max(abs(det_lo), abs(det_hi))
+        if (rel > tol_pair) then
+            print *, "  FAIL: ", label, " theta-seam jump rel=", rel
+            nfail = nfail + 1
+        end if
+
+        ! Exact 2pi periodicity in both angles (same spline cell, rotation only).
+        u_lo = [0.6_dp, 1.3_dp, 0.61_dp*period]
+        u_hi = [0.6_dp, 1.3_dp + TWOPI, 0.61_dp*period + TWOPI]
+        det_lo = ccs%jacobian_det(u_lo)
+        det_hi = ccs%jacobian_det(u_hi)
+        rel = abs(det_hi - det_lo)/abs(det_lo)
+        if (rel > tol_wrap) then
+            print *, "  FAIL: ", label, " 2pi wrap not exact, rel=", rel
+            nfail = nfail + 1
+        end if
+
+        nerrors = nerrors + nfail
+        if (nfail == 0) print *, "  PASS: ", label, " Jacobian continuous across seams"
+    end subroutine check_seam_continuity
+
+    ! sqrtg from metric_tensor is sqrt(abs(det g)) built from the same basis;
+    ! |jacobian_det| must reproduce it to rounding.
+    subroutine check_sqrtg_consistency(ccs, label, nerrors)
+        type(chartmap_coordinate_system_t), intent(in) :: ccs
+        character(len=*), intent(in) :: label
+        integer, intent(inout) :: nerrors
+
+        real(dp), parameter :: tol = 1.0e-9_dp
+        real(dp), parameter :: rho_vals(3) = [0.2_dp, 0.55_dp, 0.9_dp]
+        real(dp), parameter :: theta_vals(3) = [0.7_dp, 2.9_dp, 5.2_dp]
+        real(dp), parameter :: zeta_fracs(3) = [0.2_dp, 0.5_dp, 0.8_dp]
+        real(dp) :: u(3), det, g(3, 3), ginv(3, 3), sqrtg, rel
+        integer :: ir, it, iz, nfail
+
+        nfail = 0
+        do iz = 1, size(zeta_fracs)
+            do it = 1, size(theta_vals)
+                do ir = 1, size(rho_vals)
+                    u = [rho_vals(ir), theta_vals(it), zeta_fracs(iz)*TWOPI]
+                    det = ccs%jacobian_det(u)
+                    call ccs%metric_tensor(u, g, ginv, sqrtg)
+                    rel = abs(abs(det) - sqrtg)/sqrtg
+                    if (rel > tol) then
+                        print *, "  FAIL: ", label, " |det| vs sqrtg rel=", rel, &
+                            " at u=", u
+                        nfail = nfail + 1
+                    end if
+                end do
+            end do
+        end do
+        nerrors = nerrors + nfail
+        if (nfail == 0) print *, "  PASS: ", label, " |jacobian_det| matches sqrtg"
+    end subroutine check_sqrtg_consistency
+
+end program test_chartmap_gate_jacobian

--- a/test/source/test_chartmap_gate_reconstruction.f90
+++ b/test/source/test_chartmap_gate_reconstruction.f90
@@ -1,0 +1,218 @@
+program test_chartmap_gate_reconstruction
+    ! Boozer/SFL chart gate (d) (ROADMAP straight-field-line gauge gates):
+    ! converged field reconstruction against the native evaluator under chart
+    ! grid refinement.
+    !
+    ! Pipeline under test, at three chart resolutions (each doubling the grid):
+    !   native field sampled on the chart nodes -> periodic batch splines of
+    !   (B_R, B_phi, B_Z, |B|) over the chart -> physical probe point x ->
+    !   chart inverse invert_cart(x) -> spline evaluation at the inverted
+    !   logical point -> compare against the native evaluator at x.
+    ! This is the consumer path (GORILLA/SIMPLE style): position inverse plus
+    ! field interpolation together, so chart geometry error, inverse residual,
+    ! and field spline error all enter the reconstruction error.
+    !
+    ! Gates: the max relative error (vector B and |B|) decreases monotonically
+    ! with refinement, each refinement contracts it by at least 4 (cubic splines
+    ! give ~16 asymptotically), and the finest level is below 8e-5 -- the same
+    ! bound as the WP3 analytic |B| roundtrip gate.
+    !
+    ! Scope (honest limits): the native evaluator is the analytic circular
+    ! tokamak field on the analytic circular Boozer-convention fixture; the
+    ! chart-relevant machinery (node sampling, periodic closure, seams, inverse,
+    ! spline order) is production, but there is no JOREK-native comparison here.
+    ! libneo has no JOREK-to-chartmap builder yet, so a JOREK-native gate (d)
+    ! (against jorek_field on an AUG restart) must follow with that builder.
+    ! This test does NOT cover: shaped/X-point geometry, non-nested regions,
+    ! fields with toroidal ripple, or the Fourier Boozer-transform pipeline.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use libneo_coordinates, only: coordinate_system_t, chartmap_coordinate_system_t, &
+                                  make_chartmap_coordinate_system, CHARTMAP_LOCATED
+    use math_constants, only: TWOPI
+    use interpolate, only: BatchSplineData3D, construct_batch_splines_3d, &
+                           evaluate_batch_splines_3d
+    use neo_circular_tokamak_field, only: circular_tokamak_field_t
+    use chartmap_gate_fixtures, only: write_circular_boozer_chartmap, &
+                                      circular_chart_position, CIRC_R_AXIS
+    implicit none
+
+    real(dp), parameter :: B_POL = 0.3183099_dp
+    real(dp), parameter :: B_TOR = 1.0_dp
+    integer, parameter :: n_levels = 3
+    integer, parameter :: nrho_l(n_levels) = [9, 17, 33]
+    integer, parameter :: ntheta_l(n_levels) = [16, 32, 64]
+    integer, parameter :: nzeta_l(n_levels) = [8, 16, 32]
+    real(dp), parameter :: contraction_min = 4.0_dp
+    real(dp), parameter :: tol_finest = 8.0e-5_dp
+
+    type(circular_tokamak_field_t) :: field
+    real(dp) :: err_vec(n_levels), err_mod(n_levels)
+    integer :: level, nerrors
+
+    nerrors = 0
+    call field%circular_tokamak_field_init(R_axis=CIRC_R_AXIS, Z_axis=0.0_dp, &
+                                           B_pol_ampl=B_POL, B_tor_ampl=B_TOR)
+
+    do level = 1, n_levels
+        call reconstruction_error(level, err_vec(level), err_mod(level), nerrors)
+        print *, "  level ", level, " grid ", nrho_l(level), ntheta_l(level), &
+            nzeta_l(level), " max rel err vec=", err_vec(level), &
+            " mod=", err_mod(level)
+    end do
+
+    call check_convergence("vector B", err_vec, nerrors)
+    call check_convergence("|B|", err_mod, nerrors)
+
+    if (nerrors > 0) then
+        print *, "FAILED: ", nerrors, " error(s) detected in reconstruction gate"
+        error stop 1
+    end if
+
+    print *, "All chartmap field-reconstruction gate tests passed!"
+
+contains
+
+    subroutine check_convergence(label, err, nerrors)
+        character(len=*), intent(in) :: label
+        real(dp), intent(in) :: err(n_levels)
+        integer, intent(inout) :: nerrors
+
+        integer :: l, nfail
+
+        nfail = 0
+        do l = 1, n_levels - 1
+            if (err(l + 1) >= err(l)) then
+                print *, "  FAIL: ", label, " error not monotone at level ", l + 1
+                nfail = nfail + 1
+            else if (err(l)/err(l + 1) < contraction_min) then
+                print *, "  FAIL: ", label, " contraction ", err(l)/err(l + 1), &
+                    " < ", contraction_min
+                nfail = nfail + 1
+            end if
+        end do
+        if (err(n_levels) > tol_finest) then
+            print *, "  FAIL: ", label, " finest error ", err(n_levels), &
+                " > ", tol_finest
+            nfail = nfail + 1
+        end if
+        nerrors = nerrors + nfail
+        if (nfail == 0) print *, "  PASS: ", label, &
+            " reconstruction converges under refinement, finest below ", tol_finest
+    end subroutine check_convergence
+
+    ! Build the chart and the field splines at one resolution and measure the
+    ! max relative reconstruction error over a fixed physical probe set.
+    subroutine reconstruction_error(level, emax_vec, emax_mod, nerrors)
+        integer, intent(in) :: level
+        real(dp), intent(out) :: emax_vec, emax_mod
+        integer, intent(inout) :: nerrors
+
+        character(len=64) :: path
+        class(coordinate_system_t), allocatable :: cs
+        type(BatchSplineData3D) :: spl_b
+        real(dp), parameter :: rho_probe(4) = [0.13_dp, 0.38_dp, 0.62_dp, 0.87_dp]
+        real(dp) :: u_probe(3), u_guess(3), u_inv(3), x_probe(3)
+        real(dp) :: b_true(3), bmod_true, b_recon(4)
+        real(dp) :: theta_p, zeta_p, ev, em
+        integer :: ip, jp, kp, status, nfail
+
+        write (path, '(a,i0,a)') "chartmap_gate_recon_L", level, ".nc"
+        call write_circular_boozer_chartmap(trim(path), nrho_l(level), &
+                                            ntheta_l(level), nzeta_l(level), 1)
+        call make_chartmap_coordinate_system(cs, trim(path))
+
+        emax_vec = 0.0_dp
+        emax_mod = 0.0_dp
+        nfail = 0
+
+        select type (ccs => cs)
+        type is (chartmap_coordinate_system_t)
+            call build_field_splines(nrho_l(level), ntheta_l(level), &
+                                     nzeta_l(level), spl_b)
+
+            do kp = 0, 5
+                zeta_p = 0.11_dp + 0.97_dp*real(kp, dp)
+                do jp = 0, 7
+                    theta_p = 0.21_dp + 0.77_dp*real(jp, dp)
+                    do ip = 1, size(rho_probe)
+                        u_probe = [rho_probe(ip), theta_p, zeta_p]
+                        call circular_chart_position(u_probe(1), u_probe(2), &
+                                                     u_probe(3), 1, x_probe)
+                        ! Inward radial offset keeps the guess out of the warm
+                        ! edge band so all probes take the interior 3-D solve.
+                        u_guess = [u_probe(1) - 0.05_dp, u_probe(2) + 0.11_dp, &
+                                   u_probe(3) - 0.07_dp]
+                        call ccs%invert_cart(x_probe, u_guess, u_inv, status)
+                        if (status /= CHARTMAP_LOCATED) then
+                            print *, "  FAIL: probe not LOCATED, u=", u_probe, &
+                                " status=", status
+                            nfail = nfail + 1
+                            cycle
+                        end if
+                        call evaluate_batch_splines_3d(spl_b, u_inv, b_recon)
+                        call native_field_cyl(x_probe, b_true, bmod_true)
+                        ev = sqrt(sum((b_recon(1:3) - b_true)**2))/bmod_true
+                        em = abs(b_recon(4) - bmod_true)/bmod_true
+                        emax_vec = max(emax_vec, ev)
+                        emax_mod = max(emax_mod, em)
+                    end do
+                end do
+            end do
+        class default
+            print *, "  FAIL: fixture did not load as chartmap type"
+            nfail = nfail + 1
+        end select
+        nerrors = nerrors + nfail
+    end subroutine reconstruction_error
+
+    ! Periodic batch splines of (B_R, B_phi, B_Z, |B|) on the chart grid: nodes
+    ! at the exact analytic positions, theta/zeta closed with one appended wrap
+    ! plane, same order and periodicity layout as the chart splines themselves.
+    subroutine build_field_splines(nrho, ntheta, nzeta, spl_b)
+        integer, intent(in) :: nrho, ntheta, nzeta
+        type(BatchSplineData3D), intent(out) :: spl_b
+
+        real(dp), allocatable :: batch(:, :, :, :)
+        real(dp) :: rho, theta, zeta, x(3), b_cyl(3), bmod
+        real(dp) :: x_min(3), x_max(3)
+        integer :: ir, it, iz
+
+        allocate (batch(nrho, ntheta + 1, nzeta + 1, 4))
+        do iz = 1, nzeta
+            zeta = TWOPI*real(iz - 1, dp)/real(nzeta, dp)
+            do it = 1, ntheta
+                theta = TWOPI*real(it - 1, dp)/real(ntheta, dp)
+                do ir = 1, nrho
+                    rho = real(ir - 1, dp)/real(nrho - 1, dp)
+                    call circular_chart_position(rho, theta, zeta, 1, x)
+                    call native_field_cyl(x, b_cyl, bmod)
+                    batch(ir, it, iz, 1:3) = b_cyl
+                    batch(ir, it, iz, 4) = bmod
+                end do
+            end do
+        end do
+        batch(:, ntheta + 1, 1:nzeta, :) = batch(:, 1, 1:nzeta, :)
+        batch(:, :, nzeta + 1, :) = batch(:, :, 1, :)
+
+        x_min = [0.0_dp, 0.0_dp, 0.0_dp]
+        x_max = [1.0_dp, TWOPI, TWOPI]
+        call construct_batch_splines_3d(x_min, x_max, batch, [3, 3, 3], &
+                                        [.false., .true., .true.], spl_b)
+    end subroutine build_field_splines
+
+    ! Native evaluator at a Cartesian point: cylindrical components and modulus
+    ! of the production circular tokamak field.
+    subroutine native_field_cyl(x, b_cyl, bmod)
+        real(dp), intent(in) :: x(3)
+        real(dp), intent(out) :: b_cyl(3)
+        real(dp), intent(out) :: bmod
+
+        real(dp) :: rmaj, phi
+
+        rmaj = sqrt(x(1)**2 + x(2)**2)
+        phi = atan2(x(2), x(1))
+        call field%compute_bfield([rmaj, phi, x(3)], b_cyl)
+        bmod = sqrt(sum(b_cyl**2))
+    end subroutine native_field_cyl
+
+end program test_chartmap_gate_reconstruction

--- a/test/source/test_chartmap_gate_reconstruction.f90
+++ b/test/source/test_chartmap_gate_reconstruction.f90
@@ -36,7 +36,7 @@ program test_chartmap_gate_reconstruction
                                       circular_chart_position, CIRC_R_AXIS
     implicit none
 
-    real(dp), parameter :: B_POL = 0.3183099_dp
+    real(dp), parameter :: B_POL = 2.0_dp/TWOPI ! 1/pi
     real(dp), parameter :: B_TOR = 1.0_dp
     integer, parameter :: n_levels = 3
     integer, parameter :: nrho_l(n_levels) = [9, 17, 33]


### PR DESCRIPTION
Follow-up to #397 (the intended base branch `fix/395-boozer-cold-inverse` was merged to main and deleted, so this stacks directly on main). Implements the ROADMAP straight-field-line/Boozer gauge gates as executable tests, ahead of the JOREK-sourced chart builder.

## What

**Signed Jacobian accessor.** `chartmap_metric_tensor` returns `sqrtg = sqrt(abs(det g))`, which cannot distinguish a consistent chart orientation from a sign flip across a seam. New type-bound `cs%jacobian_det(u)` returns the signed `det(dx/du)` from the analytic covariant basis; `metric_tensor` is unchanged.

**Gate (a) — signed periodic Jacobian positivity** (`test_chartmap_gate_jacobian`): full-torus scan of a right-handed nfp = 3 rotating-frame fixture with probe pairs straddling every field-period seam, the theta seam, and the 2pi wrap; requires det > 0 everywhere (rho > 0), seam-pair continuity at solver-noise level, exact 2pi periodicity, and `|jacobian_det| == sqrtg` to 1e-9. A mirrored fixture must give det < 0 everywhere, proving the accessor is genuinely signed. Same positivity scan on the circular nfp = 1 fixture.

**Gate (b) — bounded flux-label drift** (`test_chartmap_gate_fieldline`): field lines of the production `neo_circular_tokamak_field` lie exactly on circular tori and are straight in the geometric angles; a tangency self-check verifies the closed-form trace against `compute_bfield` at 1e-12 first. 27 launches x 50 toroidal transits x 12 samples are pulled back through the warm `invert_cart` (orbit-pusher pattern, guess chained along the line). All 16 227 pullbacks must report LOCATED; max flux-label drift gate 1e-5 (measured 7.9e-7).

**Gate (c) — launch-independent rotational transform** (same test): endpoint transform estimate from unwrapped chart angles for the 3 radii x 3 poloidal x 3 toroidal launch ensemble; ensemble spread and deviation from the analytic transform (`-B_pol/B_tor` in the right-handed chart) gated at 5e-4, the analytic worst-case bound from the bounded periodic angle offsets (measured error ~9e-6).

**Gate (d) — converged field reconstruction against the native evaluator** (`test_chartmap_gate_reconstruction`): the consumer pipeline — native field sampled on chart nodes, periodic batch splines of (B_R, B_phi, B_Z, |B|), physical probe -> `invert_cart` -> spline evaluation — compared against the native evaluator at three resolutions (9,16,8) -> (17,32,16) -> (33,64,32). Gates: monotone error decrease, contraction >= 4 per refinement (measured 33x/15x vector, 7.7x/31x |B|), finest max relative error < 8e-5, the WP3 analytic |B| gate bound (measured 3.2e-8 vector, 5.3e-9 |B|).

**Cleanup.** `chartmap_invert_cart` computed a seed-refinement residual and error code (`ierr_seed`) that nothing read; `chartmap_refine_cart_seed` loses the two dead outputs.

## Scope (honest limits)

Gate (d) runs against the analytic circular fixture, not JOREK: libneo has no JOREK-to-chartmap builder yet, so a JOREK-native gate (d) (against `jorek_field` on an AUG restart) must land together with that builder. The fixtures are smooth nested-surface charts; shaped/X-point geometry, non-nested regions, toroidal ripple, and the Fourier Boozer-transform pipeline are not covered. The constant-transform field makes gate (c) a launch-independence and absolute-value check, not a radial-profile-ordering check.

## Tests

New: `test_chartmap_gate_jacobian`, `test_chartmap_gate_fieldline`, `test_chartmap_gate_reconstruction` (shared fixture writer `chartmap_gate_fixtures`, self-contained NetCDF in the style of `test_chartmap_invert_cart`). Full local `ctest`: 98/98 pass (Debug preset, gfortran), including all existing chartmap/Boozer inverse tests against the cleaned-up cold inverse.
