### PR TITLE
Fix covariant B_theta and add psimax stop in EQDSK chartmap converter

### DIFF
--- a/python/libneo/eqdsk_to_boozer_chartmap.py
+++ b/python/libneo/eqdsk_to_boozer_chartmap.py
@@ -125,6 +125,7 @@ def convert_eqdsk_to_chartmap(
     nsurfmax=10000,
     nsurf=2000,
     convexwall=None,
+    psimax=None,
 ):
     """Read an EQDSK g-file and write a libneo Boozer chartmap.
 
@@ -141,6 +142,15 @@ def convert_eqdsk_to_chartmap(
     convexwall : path-like or None
         Path to a convex wall file for stretch_coords.  If None a default
         circular wall is generated from the g-file boundary.
+    psimax : float or None
+        Poloidal flux at the plasma boundary in CGS (G*cm^2/rad), absolute
+        value as interpolated by field_eq from the g-file psi map.  The
+        flux-surface scan stops at the first surface with psi beyond this
+        value.  If None, the boundary is located purely by the field-line
+        integration leaving the computational box; that fails for synthetic
+        equilibria without an X-point, whose psi keeps rising to the box
+        edge (the scan then runs to nsurfmax and the last box-confined
+        surface, not the LCFS, becomes s = 1).
     """
     import _efit_to_boozer as _etb
     from _efit_to_boozer import efit_to_boozer_mod
@@ -155,18 +165,19 @@ def convert_eqdsk_to_chartmap(
     with tempfile.TemporaryDirectory() as tmpdir:
         os.chdir(tmpdir)
         try:
-            # Drive efit_to_boozer with its standard settings: psimax defaults to
-            # 1e10 and the separatrix is located by the field-line integration,
-            # exactly as the existing efit_to_boozer.inp does.
-            _write_inp(
-                "efit_to_boozer.inp",
-                gfile,
+            # Without an explicit psimax the boundary is located purely by
+            # the field-line integration (efit_to_boozer's historical 1e10
+            # placeholder disables the flux-based stop).
+            inp_kwargs = dict(
                 nstep=nstep,
                 nlabel=nlabel,
                 ntheta_int=ntheta_int,
                 nsurfmax=nsurfmax,
                 nsurf=nsurf,
             )
+            if psimax is not None:
+                inp_kwargs["psimax"] = psimax
+            _write_inp("efit_to_boozer.inp", gfile, **inp_kwargs)
             if convexwall is None:
                 from libneo.eqdsk_base import read_eqdsk
                 eq = read_eqdsk(gfile)
@@ -218,11 +229,48 @@ def convert_eqdsk_to_chartmap(
                 C_norm_arr[k] = Cn
                 q_arr[k] = q
 
-            # Covariant B surface functions in SI.
-            # B_phi (G) = C_norm [G*cm] -> SI: C_norm * 1e-6 T*m
-            # B_theta (I) = C_norm / q [G*cm] -> SI
+            # Covariant B surface functions (CGS G*cm).
+            # B_phi = G(s) = R*B_tor = C_norm from magdata.
+            # B_theta = I(s), the Boozer covariant poloidal component, from
+            # Ampere's law: 2*pi*I = loop integral of B_pol along the flux
+            # surface (only the enclosed toroidal current contributes).
+            # NOTE: I is NOT G/q. The field-line pitch iota is the ratio of
+            # the CONTRAvariant components; the covariant ratio I/G measures
+            # enclosed current. For a tokamak I << G/q, and writing G/q here
+            # inflates the field-line length factor (G + iota*I) and slows
+            # every traced orbit's parallel dynamics by O(1/q^2).
             B_phi_cgs = C_norm_arr          # G*cm
-            B_theta_cgs = C_norm_arr / q_arr  # G*cm; iota=I/G => I=G/q
+            # B_pol = |grad psi| / R from the g-file psi map itself: taking
+            # sqrt(B^2 - B_tor^2) instead would difference two nearly equal
+            # interpolants and lose all accuracy on inner surfaces.
+            from libneo.eqdsk_base import read_eqdsk
+            from scipy.interpolate import RectBivariateSpline
+            eq_amp = read_eqdsk(gfile)
+            psi_spl = RectBivariateSpline(
+                np.asarray(eq_amp["R"]) * METER_TO_CM,
+                np.asarray(eq_amp["Z"]) * METER_TO_CM,
+                np.asarray(eq_amp["PsiVs"]).T * 1.0e8,  # Wb/rad -> G*cm^2/rad
+            )
+            B_theta_cgs = np.zeros(nrho)    # G*cm
+            ntheta_amp = 2048
+            thb_amp = np.linspace(0.0, TWOPI, ntheta_amp, endpoint=False)
+            for k in range(nrho):
+                r_amp = np.asarray(r_of_thb[k](thb_amp), dtype=float)
+                dth_amp = np.asarray(dth_of_thb[k](thb_amp), dtype=float)
+                th_geom = thb_amp + dth_amp
+                R_amp = (R_axis_si + r_amp * np.cos(th_geom)) * METER_TO_CM
+                Z_amp = (Z_axis_si + r_amp * np.sin(th_geom)) * METER_TO_CM
+                dR = (np.roll(R_amp, -1) - np.roll(R_amp, 1)) / 2.0
+                dZ = (np.roll(Z_amp, -1) - np.roll(Z_amp, 1)) / 2.0
+                dl = np.hypot(dR, dZ)  # cm
+                dpsi_dR = psi_spl(R_amp, Z_amp, dx=1, grid=False)
+                dpsi_dZ = psi_spl(R_amp, Z_amp, dy=1, grid=False)
+                # Signed circulation of B_pol = (-psi_Z, psi_R)/R along
+                # increasing theta, so the sign of I follows the enclosed
+                # current direction instead of being forced positive.
+                B_R = -dpsi_dZ / R_amp  # G
+                B_Z = dpsi_dR / R_amp   # G
+                B_theta_cgs[k] = np.sum(B_R * dR + B_Z * dZ) / TWOPI  # G*cm
 
             # A_phi(s) = -torflux * integral_0^s iota(s') ds'
             # iota = 1/q.  Use a cubic spline on s_grid.

--- a/python/tests/test_eqdsk_to_boozer_chartmap.py
+++ b/python/tests/test_eqdsk_to_boozer_chartmap.py
@@ -73,10 +73,39 @@ def test_geometry_plausible(chartmap_path):
     assert 1.0 < R_axis < 2.5, f"axis R = {R_axis:.3f} m, expected a tokamak-scale value"
 
 
-def test_q_positive(chartmap_path):
+def test_covariant_components_tokamak_ordering(chartmap_path):
+    # B_phi = G(s) = R*B_tor; B_theta = I(s) from the enclosed toroidal
+    # current. For a tokamak I << G (NOT I = G/q: iota is the ratio of the
+    # contravariant components, while I/G measures enclosed current).
+    # Signs of both track the equilibrium's field and current direction.
     d = _read_chartmap(chartmap_path)
-    q = d["B_phi"] / d["B_theta"]
-    assert np.all(q > 0.0), f"q = B_phi/B_theta has non-positive values: min={q.min():.4f}"
+    assert np.all(np.isfinite(d["B_theta"])) and np.all(d["B_theta"] != 0.0), (
+        f"B_theta (I) has zero/non-finite values: min|I|={np.abs(d['B_theta']).min():.4e}"
+    )
+    assert np.all(np.abs(d["B_phi"]) > 0.0), (
+        f"B_phi (G) has zero values: min|G|={np.abs(d['B_phi']).min():.4e}"
+    )
+    ratio = np.abs(d["B_theta"]).max() / np.abs(d["B_phi"]).min()
+    assert ratio < 0.5, (
+        f"|I/G| = {ratio:.3f}: covariant B_theta is not small against B_phi, "
+        "which suggests the fabricated I = G/q instead of the enclosed-current I"
+    )
+
+
+def test_B_theta_matches_plasma_current(chartmap_path):
+    # Ampere: 2*pi*I(s) = mu0 * I_tor(s), so at the outermost stored surface
+    # I approaches mu0*Ip/(2*pi). In CGS G*cm that is 0.2*Ip[A]. The stored
+    # grid stops just inside the LCFS, so allow a one-sided tolerance.
+    from libneo.eqdsk_base import read_eqdsk
+
+    d = _read_chartmap(chartmap_path)
+    Ip = abs(float(read_eqdsk(EFIT)["Ip"]))
+    I_edge_expected = 0.2 * Ip  # G*cm
+    I_edge = abs(float(d["B_theta"][-1]))
+    assert 0.7 * I_edge_expected < I_edge <= 1.05 * I_edge_expected, (
+        f"I at outermost surface = {I_edge:.4e} G*cm, expected close to "
+        f"mu0*Ip/2pi = {I_edge_expected:.4e} G*cm"
+    )
 
 
 def test_torflux_nonzero(chartmap_path):
@@ -84,6 +113,20 @@ def test_torflux_nonzero(chartmap_path):
     assert np.isfinite(d["torflux"]) and d["torflux"] != 0.0, (
         f"torflux={d['torflux']:.3e} must be finite and nonzero"
     )
+
+
+def test_write_inp_psimax(tmp_path):
+    # psimax bounds the flux-surface scan; required for equilibria without an
+    # X-point, whose psi keeps rising to the box edge. Default stays 1e10.
+    from libneo.eqdsk_to_boozer_chartmap import _write_inp
+
+    inp = tmp_path / "efit_to_boozer.inp"
+    _write_inp(inp, "dummy.geqdsk", psimax=4.25e8)
+    assert "425000000.0" in inp.read_text()
+
+    inp_default = tmp_path / "efit_to_boozer_default.inp"
+    _write_inp(inp_default, "dummy.geqdsk")
+    assert "10000000000.0" in inp_default.read_text()
 
 
 def test_A_phi_consistent_with_torflux(chartmap_path):


### PR DESCRIPTION
Two defects in `eqdsk_to_boozer_chartmap` (follow-up to #346), found while regenerating the reactor-size circular benchmark fixture for itpplasma/benchmark-simple-potato:

**1. `B_theta = G/q` is not the covariant poloidal component.** The inline comment reasoned `iota = I/G => I = G/q`, but iota is the ratio of the *contravariant* components; the covariant `I(s)` measures the enclosed toroidal current (`2*pi*I = mu0*I_tor`). For a tokamak the true `I` is ~40x smaller than `G/q`. SIMPLE consumes `B_theta` as the covariant surface function (`h_theta = B_theta/Bmod`), so the fabricated value inflated the field-line length factor `(G + iota*I)` and made every traced orbit's parallel dynamics too slow by `O(1/q^2)` — 16 % too-low bounce frequencies at `q = 2.26`. Now computed as the signed circulation of `B_pol = |grad psi|/R` from the g-file psi map (using `sqrt(B^2 - B_tor^2)` instead would cancel catastrophically on inner surfaces).

Cross-code check on the circular benchmark EQDSK (5 keV deuteron, `s_tor = 0.3`), SIMPLE canonical frequency API on the converted chartmap vs POTATO adaptive-RK tracing of the same g-file:

| case | omega_b SIMPLE | omega_b POTATO | omega_phi SIMPLE | omega_phi POTATO |
|---|---|---|---|---|
| trapped xi=0.3 | 1.2805e4 | 1.288e4 | -273.3 | -272.6 |
| passing xi=0.8 | 3.7288e4 | 3.738e4 | 8.455e4 | 8.506e4 |

(before the fix: omega_b was 1.0796e4 / 3.1317e4, i.e. 16 % low)

**2. `psimax` was hardwired to the disabled placeholder 1e10.** For real diverted g-files the field-line scan leaves the box just past the X-point, but synthetic equilibria without an X-point have psi rising smoothly to the box edge: the scan then grinds through thousands of vacuum-region surfaces (hours instead of seconds, since `flint_for_Boozer` also ignores its `nstep` argument) and labels the last box-confined surface `s = 1` instead of the LCFS. `convert_eqdsk_to_chartmap` now accepts `psimax` (CGS, absolute) and passes it into `efit_to_boozer.inp`; default behaviour is unchanged.

Tests: Ampere check of `I` at the outermost stored surface against the g-file `Ip`, `|I/G|` ordering, and `psimax` .inp pass-through. Full `python/tests/test_eqdsk_to_boozer_chartmap.py` + `test_eqdsk_base.py`: 13 passed.