### PR TITLE
Add reproducible EQDSK to booz_xform pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ docs = [
 
 [project.scripts]
 libneo-write-chartmap = "libneo.chartmap_cli:main"
+libneo-booz-xform = "libneo.run_booz_xform:main"
 nemec2vmec = "libneo.nemec2vmec:main"
 
 [tool.scikit-build]

--- a/python/libneo/bc_to_booz_xform.py
+++ b/python/libneo/bc_to_booz_xform.py
@@ -193,6 +193,10 @@ def write_boozmn(bc, output, source=None):
             _var("pmnc_b", "f8", ("comput_surfs", "mn_mode"), pmnc_h)
 
         ds.bc2boozmn_source = str(source if source is not None else output)
+        if hasattr(bc, "a"):
+            ds.libneo_vmec_aminor_m = float(bc.a)
+        if hasattr(bc, "R"):
+            ds.libneo_vmec_rmajor_m = float(bc.R)
 
 
 def convert_bc_to_boozmn(bc_file, output):

--- a/python/libneo/booz_xform_to_boozer_chartmap.py
+++ b/python/libneo/booz_xform_to_boozer_chartmap.py
@@ -54,6 +54,16 @@ def _read_boozmn(filename):
         d["buco"] = var("buco_b")
         d["bvco"] = var("bvco_b")
         d["phi"] = var("phi_b")
+        d["aminor_m"] = (
+            float(ds.libneo_vmec_aminor_m)
+            if "libneo_vmec_aminor_m" in ds.ncattrs()
+            else None
+        )
+        d["rmajor_m"] = (
+            float(ds.libneo_vmec_rmajor_m)
+            if "libneo_vmec_rmajor_m" in ds.ncattrs()
+            else None
+        )
         d["bmnc"] = var("bmnc_b")
         d["rmnc"] = var("rmnc_b")
         d["zmns"] = var("zmns_b")
@@ -185,6 +195,7 @@ def convert_boozmn_to_chartmap(
     nrho=50,
     ntheta=48,
     nzeta=96,
+    covariant_sign=1,
 ):
     """Read a boozmn file and write a libneo Boozer chartmap.
 
@@ -192,6 +203,9 @@ def convert_boozmn_to_chartmap(
     optional dependencies.
     """
     from scipy.interpolate import CubicSpline
+
+    if covariant_sign not in (-1, 1):
+        raise ValueError("covariant_sign must be -1 or 1")
 
     d = _read_boozmn(boozmn)
     nfp = d["nfp"]
@@ -215,8 +229,8 @@ def convert_boozmn_to_chartmap(
     zeta_geom = np.linspace(0.0, TWOPI / nfp, nzeta, endpoint=False)
 
     iota_spline = CubicSpline(s_half, iota_h)
-    B_theta = CubicSpline(s_half, buco_h)(s_grid)
-    B_phi = CubicSpline(s_half, bvco_h)(s_grid)
+    B_theta = covariant_sign * CubicSpline(s_half, buco_h)(s_grid)
+    B_phi = covariant_sign * CubicSpline(s_half, bvco_h)(s_grid)
     iota_int = iota_spline.antiderivative()
     A_phi = -torflux_si * (iota_int(s) - iota_int(0.0))
 
@@ -253,6 +267,15 @@ def convert_boozmn_to_chartmap(
     torflux = torflux_si * TESLA_METER2_TO_GAUSS_CM2
     X, Y, Z = X * METER_TO_CM, Y * METER_TO_CM, Z * METER_TO_CM
 
+    attrs = {
+        "booz2chartmap_source": str(boozmn),
+        "booz2chartmap_covariant_sign": np.int32(covariant_sign),
+    }
+    if d["aminor_m"] is not None:
+        attrs["aminor_m"] = d["aminor_m"]
+    if d["rmajor_m"] is not None:
+        attrs["vmec_rmajor_m"] = d["rmajor_m"]
+
     write_boozer_chartmap(
         output,
         rho=rho_grid,
@@ -268,7 +291,7 @@ def convert_boozmn_to_chartmap(
         Bmod=Bmod,
         num_field_periods=nfp,
         torflux=torflux,
-        booz2chartmap_source=str(boozmn),
+        **attrs,
     )
     return torflux
 
@@ -293,6 +316,17 @@ def main(argv=None):
         default=96,
         help="toroidal points per field period, endpoint-excluded",
     )
+    parser.add_argument(
+        "--covariant-sign",
+        type=int,
+        choices=(-1, 1),
+        default=1,
+        help=(
+            "explicit common sign applied to B_theta and B_phi; use -1 "
+            "when mapping native VMEC/booz_xform covariants to a target "
+            "convention with the opposite current signs"
+        ),
+    )
     args = parser.parse_args(argv)
 
     torflux = convert_boozmn_to_chartmap(
@@ -301,6 +335,7 @@ def main(argv=None):
         nrho=args.nrho,
         ntheta=args.ntheta,
         nzeta=args.nzeta,
+        covariant_sign=args.covariant_sign,
     )
     print(f"Done. torflux={torflux:.6e} G cm^2")
 

--- a/python/libneo/run_booz_xform.py
+++ b/python/libneo/run_booz_xform.py
@@ -1,0 +1,147 @@
+"""Run hiddenSymmetries booz_xform on a pinned VMEC wout file.
+
+The wrapper makes the Fourier resolution and selected half-grid surfaces
+explicit and records enough provenance in the resulting boozmn NetCDF file to
+identify the exact VMEC input used for the transform.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+import numpy as np
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _record_provenance(
+    output: Path,
+    source: Path,
+    *,
+    version: str,
+    mboz: int,
+    nboz: int,
+    surfaces: np.ndarray,
+) -> None:
+    import netCDF4
+
+    with netCDF4.Dataset(source) as vmec:
+        aminor_m = float(np.asarray(vmec.variables["Aminor_p"][:]))
+        rmajor_m = float(np.asarray(vmec.variables["Rmajor_p"][:]))
+
+    with netCDF4.Dataset(output, "a") as dataset:
+        dataset.libneo_booz_xform_source = str(source.resolve())
+        dataset.libneo_booz_xform_source_sha256 = _sha256(source)
+        dataset.libneo_booz_xform_version = version
+        dataset.libneo_booz_xform_mboz = mboz
+        dataset.libneo_booz_xform_nboz = nboz
+        dataset.libneo_booz_xform_surfaces = ",".join(
+            str(surface) for surface in surfaces
+        )
+        dataset.libneo_vmec_aminor_m = aminor_m
+        dataset.libneo_vmec_rmajor_m = rmajor_m
+
+
+def run_booz_xform(
+    wout,
+    output,
+    *,
+    mboz=64,
+    nboz=0,
+    surfaces=None,
+):
+    """Transform a VMEC equilibrium and return the output path.
+
+    ``surfaces`` contains zero-based indices into booz_xform's VMEC half grid.
+    Omitting it transforms every available half-grid surface.
+    """
+    import booz_xform
+
+    wout = Path(wout)
+    output = Path(output)
+    if mboz < 1:
+        raise ValueError("mboz must be positive")
+    if nboz < 0:
+        raise ValueError("nboz must be nonnegative")
+
+    transform = booz_xform.Booz_xform()
+    # flux=True is essential: without it booz_xform writes phi_b=0 and the
+    # resulting file cannot preserve the VMEC toroidal-flux normalization.
+    transform.read_wout(str(wout), flux=True)
+    transform.mboz = int(mboz)
+    transform.nboz = int(nboz)
+
+    if surfaces is None:
+        selected = np.asarray(transform.compute_surfs, dtype=int)
+    else:
+        selected = np.asarray(surfaces, dtype=int)
+        if selected.ndim != 1 or selected.size == 0:
+            raise ValueError("surfaces must be a nonempty one-dimensional list")
+        if np.any(selected < 0) or np.any(selected >= transform.ns_in):
+            raise ValueError(
+                f"surfaces outside zero-based half-grid range "
+                f"0..{transform.ns_in - 1}"
+            )
+        if len(np.unique(selected)) != len(selected):
+            raise ValueError("surfaces must not contain duplicates")
+        transform.compute_surfs = selected
+
+    transform.run()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    transform.write_boozmn(str(output))
+    _record_provenance(
+        output,
+        wout,
+        version=str(getattr(booz_xform, "__version__", "unknown")),
+        mboz=int(mboz),
+        nboz=int(nboz),
+        surfaces=selected,
+    )
+    return output
+
+
+def _parse_surfaces(value):
+    if value is None:
+        return None
+    try:
+        return [int(item) for item in value.split(",")]
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            "surfaces must be comma-separated integers"
+        ) from error
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Run booz_xform on a VMEC wout file with provenance"
+    )
+    parser.add_argument("wout", help="VMEC wout NetCDF file")
+    parser.add_argument("output", help="Output boozmn NetCDF file")
+    parser.add_argument("--mboz", type=int, default=64)
+    parser.add_argument("--nboz", type=int, default=0)
+    parser.add_argument(
+        "--surfaces",
+        type=_parse_surfaces,
+        help="comma-separated zero-based VMEC half-grid indices (default: all)",
+    )
+    args = parser.parse_args(argv)
+    output = run_booz_xform(
+        args.wout,
+        args.output,
+        mboz=args.mboz,
+        nboz=args.nboz,
+        surfaces=args.surfaces,
+    )
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/libneo/vmec_utils.py
+++ b/python/libneo/vmec_utils.py
@@ -1,13 +1,18 @@
 import numpy as np
 from os.path import splitext
-from scipy.interpolate import PchipInterpolator, LinearNDInterpolator, interp1d
-from scipy.integrate import quad
+from scipy.interpolate import (
+    CubicSpline,
+    LinearNDInterpolator,
+    PchipInterpolator,
+    interp1d,
+)
+from scipy.integrate import cumulative_trapezoid, quad
 from datetime import datetime
 from netCDF4 import Dataset
 from libneo import eqdsk_base
 
-def eqdsk2vmec(eqdsk_file, vmec_in_file=None):
-    data = eqdsk2vmec_gfile(eqdsk_file)
+def eqdsk2vmec(eqdsk_file, vmec_in_file=None, boundary_mpol=20):
+    data = eqdsk2vmec_gfile(eqdsk_file, boundary_mpol=boundary_mpol)
     vmec_input = default_vmec_input(data)
 
     if vmec_in_file is None:
@@ -64,15 +69,16 @@ def default_vmec_input(data):
         "zbc": data['zbc'].T
     }
 
-def eqdsk2vmec_gfile(filename):
+def eqdsk2vmec_gfile(filename, boundary_mpol=20):
     data = eqdsk_base.read_eqdsk(filename)
 
     # Extract boundary and profiles
     R = data['Lcfs'][:, 0]
     Z = data['Lcfs'][:, 1]
-    theta = np.arctan2(Z, R - np.mean(R))
+    theta = np.arctan2(Z - data['Zpsi0'], R - data['Rpsi0'])
     theta[theta < 0] += 2 * np.pi
     sorted_indices = np.argsort(theta)
+    theta = theta[sorted_indices]
     R, Z = R[sorted_indices], Z[sorted_indices]
 
     # Interpolate flux functions
@@ -81,12 +87,10 @@ def eqdsk2vmec_gfile(filename):
     press = data['ptotprof']
     qprof = data['qprof']
 
-    qprof_interp = interp1d(pflux, qprof, kind='linear', fill_value="extrapolate")
-
-    torflux = np.zeros(len(pflux))
-
-    for i in range(len(pflux)):
-        torflux[i], _ = quad(qprof_interp, pflux[0], pflux[i])   # EQDSK uses flux in Weber/rad
+    # EQDSK q is tabulated on this exact poloidal-flux grid. Integrating that
+    # tabulation directly is deterministic and avoids adaptive-quadrature
+    # warnings at profile knots.
+    torflux = cumulative_trapezoid(qprof, pflux, initial=0.0)
 
     torflux_vmec = torflux * 2 * np.pi  # VMEC uses flux in Weber
     torflux_norm = torflux/torflux[-1]
@@ -110,7 +114,7 @@ def eqdsk2vmec_gfile(filename):
     ai_aux_f = PchipInterpolator(torflux_norm, 1/data['qprof'])(ai_aux_s)
     p = np.polyfit(ai_aux_s, ai_aux_f, 9)
     p[-1] = ai_aux_f[0]
-    p = np.concatenate(([-np.sum(p[:10]) + ac_aux_f[-1]], p))
+    p = np.concatenate(([-np.sum(p[:10]) + ai_aux_f[-1]], p))
     ai = np.flip(p)
 
     data2 = {
@@ -129,52 +133,57 @@ def eqdsk2vmec_gfile(filename):
         'ai_aux_f': ai_aux_f
     }
 
-    compute_boundary_fourier(R, Z, data2)
+    compute_boundary_fourier(
+        R, Z, data2, mpol=boundary_mpol, theta=theta
+    )
 
     return data2
 
-def compute_boundary_fourier(R, Z, data, mpol=12, ntor=0):
+def compute_boundary_fourier(R, Z, data, mpol=12, ntor=0, theta=None):
+    if ntor != 0:
+        raise ValueError("A one-dimensional EQDSK boundary must have ntor=0")
+
+    R, Z, theta = _uniform_periodic_boundary(R, Z, theta)
     data['rbc'] = np.zeros((mpol+1, ntor+1))
     data['zbs'] = np.zeros((mpol+1, ntor+1))
     data['rbs'] = np.zeros((mpol+1, ntor+1))
     data['zbc'] = np.zeros((mpol+1, ntor+1))
 
     nu = len(R)
-    nv = 1
+    for m in range(mpol + 1):
+        scale = 1.0 if m == 0 else 2.0
+        cosine = np.cos(m * theta)
+        sine = np.sin(m * theta)
+        data['rbc'][m, 0] = scale * np.dot(R, cosine) / nu
+        data['zbs'][m, 0] = scale * np.dot(Z, sine) / nu
+        data['rbs'][m, 0] = scale * np.dot(R, sine) / nu
+        data['zbc'][m, 0] = scale * np.dot(Z, cosine) / nu
 
-    cosu = np.zeros((nu, mpol + 1))
-    cosv = np.zeros((nv, 2 * ntor + 1))
-    sinu = np.zeros((nu, mpol + 1))
-    sinv = np.zeros((nv, 2 * ntor + 1))
 
-    alu = 2 * np.pi / nu
-    for i in range(nu):
-        for j in range(mpol + 1):
-            m = j
-            cosu[i, j] = np.cos(m * i * alu)
-            sinu[i, j] = np.sin(m * i * alu)
+def _uniform_periodic_boundary(R, Z, theta):
+    R = np.asarray(R, dtype=float)
+    Z = np.asarray(Z, dtype=float)
+    if theta is None:
+        theta = np.arctan2(Z - np.mean(Z), R - np.mean(R))
+    theta = np.mod(np.asarray(theta, dtype=float), 2.0 * np.pi)
+    if R.shape != Z.shape or R.shape != theta.shape or R.ndim != 1:
+        raise ValueError("R, Z, and theta must be one-dimensional equal arrays")
 
-    alv = 2 * np.pi / nv
-    for i in range(nv):
-        for j in range(2 * ntor + 1):
-            n = j - ntor
-            cosv[i, j] = np.cos(n * i * alv)
-            sinv[i, j] = np.sin(n * i * alv)
+    order = np.argsort(theta)
+    theta, unique = np.unique(theta[order], return_index=True)
+    R, Z = R[order][unique], Z[order][unique]
+    if theta.size < 4:
+        raise ValueError("At least four unique boundary points are required")
 
-    # Initialize fnuv
-    fnuv = np.zeros(mpol + 1)
-    fnuv[0] = 1.0 / (nu * nv)
-    for i in range(1, mpol + 1):
-        fnuv[i] = 2 * fnuv[0]
-
-    for m1 in range(mpol + 1):
-        for n1 in range(2 * ntor + 1):
-            for i in range(nu):
-                for j in range(nv):
-                    data['rbc'][m1, n1] += R[i] * (cosv[j, n1] * cosu[i, m1] - sinv[j, n1] * sinu[i, m1]) * fnuv[m1]
-                    data['zbs'][m1, n1] += Z[i] * (sinv[j, n1] * cosu[i, m1] + cosv[j, n1] * sinu[i, m1]) * fnuv[m1]
-                    data['rbs'][m1, n1] += R[i] * (sinv[j, n1] * cosu[i, m1] + cosv[j, n1] * sinu[i, m1]) * fnuv[m1]
-                    data['zbc'][m1, n1] += Z[i] * (cosv[j, n1] * cosu[i, m1] - sinv[j, n1] * sinu[i, m1]) * fnuv[m1]
+    theta_closed = np.append(theta, theta[0] + 2.0 * np.pi)
+    theta_uniform = 2.0 * np.pi * np.arange(theta.size) / theta.size
+    theta_query = theta_uniform.copy()
+    theta_query[theta_query < theta[0]] += 2.0 * np.pi
+    R = CubicSpline(theta_closed, np.append(R, R[0]),
+                    bc_type="periodic")(theta_query)
+    Z = CubicSpline(theta_closed, np.append(Z, Z[0]),
+                    bc_type="periodic")(theta_query)
+    return R, Z, theta_uniform
 
 
 def write_vmec_input_vec(f, vec):

--- a/python/tests/test_bc_to_booz_xform.py
+++ b/python/tests/test_bc_to_booz_xform.py
@@ -100,6 +100,7 @@ def _read_chartmap(path):
         d["B_theta"] = np.asarray(ds.variables["B_theta"][:])
         d["B_phi"] = np.asarray(ds.variables["B_phi"][:])
         d["torflux"] = float(ds.torflux)
+        d["aminor_m"] = float(ds.aminor_m)
         d["nfp"] = int(np.asarray(ds.variables["num_field_periods"][:]).item())
     return d
 
@@ -366,6 +367,7 @@ def test_chartmap_from_bc_structure(chartmap_path):
     """Chartmap built from .bc boozmn has nfp=1 and plausible geometry."""
     d = _read_chartmap(chartmap_path)
     assert d["nfp"] == 1, f"expected nfp=1, got {d['nfp']}"
+    assert d["aminor_m"] == pytest.approx(A_expected)
     # R is sqrt(x^2+y^2) in cm; R0 should be near R0_expected*100 cm
     R_cm = np.sqrt(d["x"] ** 2 + d["y"] ** 2)
     R_mid = R_cm[R_cm.shape[0] // 2].mean()
@@ -387,3 +389,32 @@ def test_chartmap_from_bc_Bmod(chartmap_path):
     assert 1.0e3 < Bmod_outer < 5.0e4, (
         f"Bmod_outer={Bmod_outer:.2f} G out of expected range [1e3,5e4]"
     )
+
+
+def test_chartmap_explicit_covariant_sign_changes_only_covariants(
+    boozmn_path, tmp_path
+):
+    from libneo.booz_xform_to_boozer_chartmap import convert_boozmn_to_chartmap
+
+    positive = tmp_path / "positive.nc"
+    negative = tmp_path / "negative.nc"
+    convert_boozmn_to_chartmap(
+        boozmn_path, positive, nrho=20, ntheta=24, nzeta=2,
+        covariant_sign=1,
+    )
+    convert_boozmn_to_chartmap(
+        boozmn_path, negative, nrho=20, ntheta=24, nzeta=2,
+        covariant_sign=-1,
+    )
+    pos = _read_chartmap(positive)
+    neg = _read_chartmap(negative)
+
+    np.testing.assert_allclose(neg["B_theta"], -pos["B_theta"])
+    np.testing.assert_allclose(neg["B_phi"], -pos["B_phi"])
+    np.testing.assert_allclose(neg["A_phi"], pos["A_phi"])
+    np.testing.assert_allclose(neg["Bmod"], pos["Bmod"])
+    assert neg["torflux"] == pytest.approx(pos["torflux"])
+
+    import netCDF4
+    with netCDF4.Dataset(negative) as dataset:
+        assert dataset.booz2chartmap_covariant_sign == -1

--- a/python/tests/test_run_booz_xform.py
+++ b/python/tests/test_run_booz_xform.py
@@ -1,0 +1,97 @@
+import sys
+from types import SimpleNamespace
+
+import netCDF4
+import numpy as np
+import pytest
+
+from libneo.run_booz_xform import run_booz_xform
+
+
+class FakeBoozXform:
+    latest = None
+
+    def __init__(self):
+        self.ns_in = 5
+        self.compute_surfs = np.arange(self.ns_in)
+        self.mboz = 0
+        self.nboz = 0
+        self.ran = False
+        FakeBoozXform.latest = self
+
+    def read_wout(self, filename, flux=False):
+        self.input = filename
+        self.flux = flux
+
+    def run(self):
+        self.ran = True
+
+    def write_boozmn(self, filename):
+        with netCDF4.Dataset(filename, "w"):
+            pass
+
+
+def install_fake(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "booz_xform",
+        SimpleNamespace(Booz_xform=FakeBoozXform, __version__="test-1.0"),
+    )
+
+
+def test_run_booz_xform_sets_resolution_surfaces_and_provenance(
+    tmp_path, monkeypatch
+):
+    install_fake(monkeypatch)
+    wout = tmp_path / "wout_case.nc"
+    with netCDF4.Dataset(wout, "w") as dataset:
+        aminor = dataset.createVariable("Aminor_p", "f8")
+        aminor.assignValue(2.6)
+        rmajor = dataset.createVariable("Rmajor_p", "f8")
+        rmajor.assignValue(6.1)
+    output = tmp_path / "boozmn_case.nc"
+
+    result = run_booz_xform(
+        wout, output, mboz=64, nboz=0, surfaces=[0, 2, 4]
+    )
+
+    transform = FakeBoozXform.latest
+    assert result == output
+    assert transform.mboz == 64
+    assert transform.nboz == 0
+    assert transform.flux is True
+    assert np.array_equal(transform.compute_surfs, [0, 2, 4])
+    assert transform.ran
+    with netCDF4.Dataset(output) as ds:
+        assert ds.libneo_booz_xform_source == str(wout.resolve())
+        assert len(ds.libneo_booz_xform_source_sha256) == 64
+        assert ds.libneo_booz_xform_version == "test-1.0"
+        assert ds.libneo_booz_xform_mboz == 64
+        assert ds.libneo_booz_xform_nboz == 0
+        assert ds.libneo_booz_xform_surfaces == "0,2,4"
+        assert ds.libneo_vmec_aminor_m == pytest.approx(2.6)
+        assert ds.libneo_vmec_rmajor_m == pytest.approx(6.1)
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"mboz": 0}, "mboz"),
+        ({"nboz": -1}, "nboz"),
+        ({"surfaces": []}, "surfaces"),
+        ({"surfaces": [5]}, "outside"),
+    ],
+)
+def test_run_booz_xform_rejects_invalid_controls(
+    tmp_path, monkeypatch, kwargs, match
+):
+    install_fake(monkeypatch)
+    wout = tmp_path / "wout_case.nc"
+    with netCDF4.Dataset(wout, "w") as dataset:
+        aminor = dataset.createVariable("Aminor_p", "f8")
+        aminor.assignValue(0.46)
+        rmajor = dataset.createVariable("Rmajor_p", "f8")
+        rmajor.assignValue(1.64)
+
+    with pytest.raises(ValueError, match=match):
+        run_booz_xform(wout, tmp_path / "boozmn.nc", **kwargs)

--- a/python/tests/test_vmec_utils.py
+++ b/python/tests/test_vmec_utils.py
@@ -1,0 +1,87 @@
+import numpy as np
+import pytest
+
+from libneo import vmec_utils
+
+
+def synthetic_eqdsk():
+    theta = 2.0 * np.pi * np.linspace(0.0, 1.0, 73, endpoint=False) ** 1.4
+    nprof = 32
+    return {
+        "Lcfs": np.column_stack((6.2 + 2.0 * np.cos(theta),
+                                  0.2 + 1.4 * np.sin(theta))),
+        "PsiaxisVs": 0.0,
+        "PsiedgeVs": 1.0,
+        "fprof": np.ones(nprof),
+        "ptotprof": np.linspace(2.0e5, 0.0, nprof),
+        "qprof": np.linspace(1.0, 3.0, nprof),
+        "dpressdpsiprof": np.linspace(-2.0e5, -1.0e4, nprof),
+        "fdfdpsiprof": np.linspace(5.0e4, 1.0e3, nprof),
+        "Ip": 15.0e6,
+        "Rpsi0": 6.2,
+        "Zpsi0": 0.2,
+    }
+
+
+def test_boundary_fourier_resamples_nonuniform_geometric_angle():
+    theta = 2.0 * np.pi * np.linspace(0.0, 1.0, 97, endpoint=False) ** 1.7
+    major_radius = 6.2
+    minor_radius_r = 2.0
+    minor_radius_z = 1.4
+    r = major_radius + minor_radius_r * np.cos(theta)
+    z = 0.25 + minor_radius_z * np.sin(theta)
+    data = {}
+
+    vmec_utils.compute_boundary_fourier(
+        r, z, data, mpol=4, ntor=0, theta=theta
+    )
+
+    assert data["rbc"][0, 0] == pytest.approx(major_radius, abs=1.0e-6)
+    assert data["rbc"][1, 0] == pytest.approx(minor_radius_r, abs=2.0e-3)
+    assert data["zbc"][0, 0] == pytest.approx(0.25, abs=1.0e-6)
+    assert data["zbs"][1, 0] == pytest.approx(minor_radius_z, abs=2.0e-3)
+    assert np.max(np.abs(data["rbs"])) < 2.0e-3
+    assert np.max(np.abs(data["zbc"][1:])) < 2.0e-3
+
+
+def test_eqdsk_iota_polynomial_closes_on_iota_endpoint(monkeypatch):
+    monkeypatch.setattr(vmec_utils.eqdsk_base, "read_eqdsk",
+                        lambda _: synthetic_eqdsk())
+
+    converted = vmec_utils.eqdsk2vmec_gfile("synthetic.eqdsk")
+
+    assert np.sum(converted["ai"]) == pytest.approx(
+        converted["ai_aux_f"][-1], abs=1.0e-12
+    )
+    assert np.sum(converted["ai"]) != pytest.approx(
+        converted["ac_aux_f"][-1]
+    )
+
+
+def test_eqdsk_conversion_uses_discrete_profile_quadrature(monkeypatch):
+    monkeypatch.setattr(vmec_utils.eqdsk_base, "read_eqdsk",
+                        lambda _: synthetic_eqdsk())
+    monkeypatch.setattr(
+        vmec_utils,
+        "quad",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("adaptive quadrature must not be used")
+        ),
+        raising=False,
+    )
+
+    converted = vmec_utils.eqdsk2vmec_gfile("synthetic.eqdsk")
+
+    assert converted["phiedge"] == pytest.approx(4.0 * np.pi)
+
+
+def test_eqdsk_default_retains_twenty_boundary_harmonics(monkeypatch):
+    monkeypatch.setattr(vmec_utils.eqdsk_base, "read_eqdsk",
+                        lambda _: synthetic_eqdsk())
+
+    converted = vmec_utils.eqdsk2vmec_gfile("synthetic.eqdsk")
+    vmec_input = vmec_utils.default_vmec_input(converted)
+
+    assert converted["rbc"].shape == (21, 1)
+    assert vmec_input["mpol"] == 21
+    assert vmec_input["ntheta"] >= 48

--- a/src/boozer_chartmap_types.f90
+++ b/src/boozer_chartmap_types.f90
@@ -12,22 +12,23 @@ module boozer_chartmap_types
     type :: boozer_chartmap_data_t
         integer :: n_rho = 0
         integer :: n_s = 0
-        integer :: n_theta = 0       !< internal field grid, endpoint-included
-        integer :: n_phi = 0         !< internal field grid, endpoint-included
+        integer :: n_theta = 0 !< internal field grid, endpoint-included
+        integer :: n_phi = 0 !< internal field grid, endpoint-included
         integer :: nfp = 1
         real(dp) :: torflux = 0.0_dp
-        real(dp) :: rmajor = 0.0_dp  !< metres, derived from innermost-surface geometry
+        real(dp) :: rmajor = 0.0_dp !< metres, derived from innermost-surface geometry
+        real(dp) :: aminor = 0.0_dp !< metres; metadata or edge-area equivalent radius
         real(dp) :: rho_min = 0.0_dp
         real(dp) :: rho_max = 0.0_dp
-        real(dp) :: h_rho = 0.0_dp   !< uniform rho step
+        real(dp) :: h_rho = 0.0_dp !< uniform rho step
         real(dp) :: h_s = 0.0_dp
         real(dp) :: h_theta = 0.0_dp !< 2*pi/(n_theta-1)
-        real(dp) :: h_phi = 0.0_dp   !< 2*pi/nfp/(n_phi-1)
+        real(dp) :: h_phi = 0.0_dp !< 2*pi/nfp/(n_phi-1)
         real(dp), allocatable :: rho(:)
         real(dp), allocatable :: s(:)
         real(dp), allocatable :: A_phi(:)
         real(dp), allocatable :: B_theta(:)
         real(dp), allocatable :: B_phi(:)
-        real(dp), allocatable :: Bmod(:, :, :)  !< (n_rho, n_theta, n_phi)
+        real(dp), allocatable :: Bmod(:, :, :) !< (n_rho, n_theta, n_phi)
     end type boozer_chartmap_data_t
 end module boozer_chartmap_types

--- a/src/coordinates/geoflux_coordinates.f90
+++ b/src/coordinates/geoflux_coordinates.f90
@@ -3,10 +3,10 @@ module geoflux_coordinates
     use, intrinsic :: iso_fortran_env, only : dp => real64
     use cylindrical_cartesian, only : cyl_to_cart, cart_to_cyl
     use math_constants, only : pi
-    use geqdsk_tools, only : geqdsk_t, geqdsk_read, geqdsk_standardise, geqdsk_deinit
+    use geqdsk_tools, only : geqdsk_t, geqdsk_read, geqdsk_deinit
     use binsrc_sub, only : binsrc
     use interpolate, only : SplineData1D, construct_splines_1d, &
-        destroy_splines_1d, evaluate_splines_1d
+        destroy_splines_1d, evaluate_splines_1d, evaluate_splines_1d_der
 
     implicit none
 
@@ -42,8 +42,10 @@ module geoflux_coordinates
         real(dp), allocatable :: Z_cache(:,:)
         type(SplineData1D) :: psi_of_s_spline
         type(SplineData1D) :: s_of_psi_spline
+        type(SplineData1D) :: q_of_s_spline
         logical :: psi_of_s_ready = .false.
         logical :: s_of_psi_ready = .false.
+        logical :: q_of_s_ready = .false.
         logical :: cache_built = .false.
     end type geoflux_context_t
 
@@ -68,7 +70,11 @@ contains
         call cleanup_context()
 
         call geqdsk_read(ctx%geqdsk, filename)
-        call geqdsk_standardise(ctx%geqdsk)
+        ! Keep the native GEQDSK signs.  The geoflux chart is used together with
+        ! field_eq/magfie, whose cylindrical field also reads the native file;
+        ! standardizing only this private copy would mix q/flux and field
+        ! orientations.  Callers that require another COCOS convention must
+        ! convert the GEQDSK as a whole before initialization.
 
         ctx%psi_axis = ctx%geqdsk%simag
         ctx%psi_sep = ctx%geqdsk%sibry
@@ -237,6 +243,10 @@ contains
             call destroy_splines_1d(ctx%s_of_psi_spline)
             ctx%s_of_psi_ready = .false.
         end if
+        if (ctx%q_of_s_ready) then
+            call destroy_splines_1d(ctx%q_of_s_spline)
+            ctx%q_of_s_ready = .false.
+        end if
         if (allocated(ctx%psi_grid)) deallocate(ctx%psi_grid)
         if (allocated(ctx%s_grid)) deallocate(ctx%s_grid)
         if (allocated(ctx%s_nodes)) deallocate(ctx%s_nodes)
@@ -307,7 +317,7 @@ contains
 
     subroutine build_radial_splines()
         integer :: npsi, i
-        real(dp), allocatable :: psi_samples(:)
+        real(dp), allocatable :: psi_samples(:), q_samples(:)
         real(dp) :: s_uniform
         real(dp) :: psi_min, psi_max
         integer, parameter :: spline_order = 5
@@ -328,16 +338,20 @@ contains
             ctx%s_of_psi_ready = .false.
         end if
 
-        allocate(psi_samples(npsi))
+        allocate(psi_samples(npsi), q_samples(npsi))
         do i = 1, npsi
             s_uniform = real(i - 1, dp) / real(npsi - 1, dp)
             psi_samples(i) = linear_interp_monotonic(ctx%s_grid, ctx%psi_grid, s_uniform)
+            q_samples(i) = linear_interp_monotonic(ctx%s_grid, ctx%geqdsk%qpsi, s_uniform)
         end do
 
         call construct_splines_1d(0.0_dp, 1.0_dp, psi_samples, spline_order, &
             .false., ctx%psi_of_s_spline)
         ctx%psi_of_s_ready = .true.
-        deallocate(psi_samples)
+        call construct_splines_1d(0.0_dp, 1.0_dp, q_samples, spline_order, &
+            .false., ctx%q_of_s_spline)
+        ctx%q_of_s_ready = .true.
+        deallocate(psi_samples, q_samples)
 
         psi_min = minval(ctx%psi_grid)
         psi_max = maxval(ctx%psi_grid)
@@ -409,7 +423,9 @@ contains
             dpsi = ctx%psi_grid(i) - ctx%psi_grid(i-1)
             q_lo = ctx%geqdsk%qpsi(i-1)
             q_hi = ctx%geqdsk%qpsi(i)
-            tor_flux(i) = tor_flux(i-1) + 0.5_dp * (q_lo + q_hi) * dpsi / (2.0_dp * pi)
+            ! GEQDSK poloidal flux is standardized per radian and q=dPsi_tor/dPsi_pol,
+            ! so the toroidal flux uses the direct integral with no extra 2*pi.
+            tor_flux(i) = tor_flux(i-1) + 0.5_dp * (q_lo + q_hi) * dpsi
         end do
     end subroutine integrate_toroidal_flux
 
@@ -853,5 +869,25 @@ contains
         R_axis = ctx%R_axis
         Z_axis = ctx%Z_axis
     end subroutine geoflux_get_axis
+
+    subroutine geoflux_get_flux_profiles(s_tor, q, dq_ds, psi_pol, dpsi_pol_ds, psi_tor_edge)
+        ! Return the raw-GEQDSK signed profiles used by the geoflux chart.
+        ! Lengths, fields, and fluxes are in libneo CGS units; s_tor is normalized
+        ! toroidal flux.  This routine intentionally reports the same native sign
+        ! lineage as the cylindrical EQDSK field used by POTATO.
+        real(dp), intent(in) :: s_tor
+        real(dp), intent(out) :: q, dq_ds, psi_pol, dpsi_pol_ds, psi_tor_edge
+        real(dp) :: s_use
+
+        call ensure_initialised()
+        if (.not. ctx%q_of_s_ready .or. .not. ctx%psi_of_s_ready) then
+            error stop 'geoflux_coordinates: flux-profile splines are not ready.'
+        end if
+
+        s_use = clamp01(s_tor)
+        call evaluate_splines_1d_der(ctx%q_of_s_spline, s_use, q, dq_ds)
+        call evaluate_splines_1d_der(ctx%psi_of_s_spline, s_use, psi_pol, dpsi_pol_ds)
+        psi_tor_edge = ctx%psi_tor_edge
+    end subroutine geoflux_get_flux_profiles
 
 end module geoflux_coordinates

--- a/src/field/boozer_chartmap_io.f90
+++ b/src/field/boozer_chartmap_io.f90
@@ -70,15 +70,17 @@ contains
 
         ! Scalars.
         call check(nf90_get_att(ncid, nf90_global, "torflux", d%torflux), &
-                   "att torflux")
+            "att torflux")
+        status = nf90_get_att(ncid, nf90_global, "aminor_m", d%aminor)
+        if (status /= nf90_noerr) d%aminor = 0.0_dp
         call require_scalar_variable(ncid, "num_field_periods")
         call check(nf90_inq_varid(ncid, "num_field_periods", varid), &
-                   "inq_var num_field_periods")
+            "inq_var num_field_periods")
         call check(nf90_get_var(ncid, varid, d%nfp), "get num_field_periods")
         call require_positive_nfp(d%nfp)
         call require_endpoint_excluded_grid("theta", theta_geom, d%h_theta, twopi)
         call require_endpoint_excluded_grid("zeta", zeta_geom, d%h_phi, &
-                                            twopi/real(d%nfp, dp))
+            twopi/real(d%nfp, dp))
 
         ! Major radius from geometry: (theta,zeta)-average of sqrt(x^2+y^2) on
         ! the innermost rho surface (the chartmap analogue of libneo's
@@ -87,7 +89,8 @@ contains
         ! attribute, so the vmec_RZ_scale applied downstream by the field
         ! loaders stays correct. A leftover "rmajor" attribute in older files
         ! is ignored.
-        call derive_rmajor(ncid, n_theta_geom, n_phi_geom, d%rmajor)
+        call derive_radii(ncid, n_rho, n_theta_geom, n_phi_geom, &
+            d%rmajor, d%aminor)
 
         ! 1D profiles. A_phi has its own abscissa; B_theta/B_phi remain on rho.
         call read_aphi_profile(ncid, d)
@@ -107,7 +110,7 @@ contains
         allocate (bmod_file(n_rho, n_theta_geom, n_phi_geom))
         allocate (d%Bmod(n_rho, d%n_theta, d%n_phi))
         call require_variable_dimensions(ncid, "Bmod", &
-                                         [character(len=5) :: "rho", "theta", "zeta"])
+            [character(len=5) :: "rho", "theta", "zeta"])
         call check(nf90_inq_varid(ncid, "Bmod", varid), "inq_var Bmod")
         call check(nf90_get_var(ncid, varid, bmod_file), "get Bmod")
         d%Bmod(:, 1:n_theta_geom, 1:n_phi_geom) = bmod_file
@@ -118,34 +121,67 @@ contains
         call check(nf90_close(ncid), "close")
     end subroutine read_boozer_chartmap
 
-    subroutine derive_rmajor(ncid, n_theta_geom, n_phi_geom, rmajor)
-        integer, intent(in) :: ncid, n_theta_geom, n_phi_geom
+    subroutine derive_radii(ncid, n_rho, n_theta_geom, n_phi_geom, rmajor, aminor)
+        integer, intent(in) :: ncid, n_rho, n_theta_geom, n_phi_geom
         real(dp), intent(out) :: rmajor
+        real(dp), intent(inout) :: aminor
 
-        integer :: varid
+        integer :: varid, j, k, j_next
+        real(dp) :: area_plane, area_sum, rj, rj_next
         real(dp), allocatable :: x_in(:, :, :), y_in(:, :, :)
+        real(dp), allocatable :: x_edge(:, :, :), y_edge(:, :, :), z_edge(:, :, :)
         real(dp), parameter :: cm_to_m = 1.0e-2_dp
+        real(dp), parameter :: pi = 4.0_dp*atan(1.0_dp)
 
         call require_variable_dimensions(ncid, "x", &
-                                         [character(len=5) :: "rho", "theta", "zeta"])
+            [character(len=5) :: "rho", "theta", "zeta"])
         call require_variable_dimensions(ncid, "y", &
-                                         [character(len=5) :: "rho", "theta", "zeta"])
+            [character(len=5) :: "rho", "theta", "zeta"])
         call require_variable_dimensions(ncid, "z", &
-                                         [character(len=5) :: "rho", "theta", "zeta"])
+            [character(len=5) :: "rho", "theta", "zeta"])
 
         allocate (x_in(1, n_theta_geom, n_phi_geom), &
-                  y_in(1, n_theta_geom, n_phi_geom))
+            y_in(1, n_theta_geom, n_phi_geom))
 
         call check(nf90_inq_varid(ncid, "x", varid), "inq_var x")
         call check(nf90_get_var(ncid, varid, x_in, start=[1, 1, 1], &
-                                count=[1, n_theta_geom, n_phi_geom]), "get x")
+            count=[1, n_theta_geom, n_phi_geom]), "get x")
         call check(nf90_inq_varid(ncid, "y", varid), "inq_var y")
         call check(nf90_get_var(ncid, varid, y_in, start=[1, 1, 1], &
-                                count=[1, n_theta_geom, n_phi_geom]), "get y")
+            count=[1, n_theta_geom, n_phi_geom]), "get y")
 
         rmajor = sum(sqrt(x_in**2 + y_in**2))*cm_to_m &
-                 /real(n_theta_geom*n_phi_geom, dp)
-    end subroutine derive_rmajor
+            /real(n_theta_geom*n_phi_geom, dp)
+
+        if (aminor > 0.0_dp) return
+
+        allocate (x_edge(1, n_theta_geom, n_phi_geom), &
+            y_edge(1, n_theta_geom, n_phi_geom), &
+            z_edge(1, n_theta_geom, n_phi_geom))
+        call check(nf90_inq_varid(ncid, "x", varid), "inq_var x")
+        call check(nf90_get_var(ncid, varid, x_edge, start=[n_rho, 1, 1], &
+            count=[1, n_theta_geom, n_phi_geom]), "get edge x")
+        call check(nf90_inq_varid(ncid, "y", varid), "inq_var y")
+        call check(nf90_get_var(ncid, varid, y_edge, start=[n_rho, 1, 1], &
+            count=[1, n_theta_geom, n_phi_geom]), "get edge y")
+        call check(nf90_inq_varid(ncid, "z", varid), "inq_var z")
+        call check(nf90_get_var(ncid, varid, z_edge, start=[n_rho, 1, 1], &
+            count=[1, n_theta_geom, n_phi_geom]), "get edge z")
+
+        area_sum = 0.0_dp
+        do k = 1, n_phi_geom
+            area_plane = 0.0_dp
+            do j = 1, n_theta_geom
+                j_next = modulo(j, n_theta_geom) + 1
+                rj = sqrt(x_edge(1, j, k)**2 + y_edge(1, j, k)**2)
+                rj_next = sqrt(x_edge(1, j_next, k)**2 + y_edge(1, j_next, k)**2)
+                area_plane = area_plane + rj*z_edge(1, j_next, k) &
+                    - rj_next*z_edge(1, j, k)
+            end do
+            area_sum = area_sum + abs(area_plane)
+        end do
+        aminor = sqrt(area_sum/(2.0_dp*pi*real(n_phi_geom, dp)))*cm_to_m
+    end subroutine derive_radii
 
     subroutine read_aphi_profile(ncid, d)
         integer, intent(in) :: ncid
@@ -158,13 +194,13 @@ contains
 
         call check(nf90_inq_varid(ncid, "A_phi", varid), "inq_var A_phi")
         call check(nf90_inquire_variable(ncid, varid, ndims=ndims, dimids=dimids), &
-                   "inquire A_phi")
+            "inquire A_phi")
         if (ndims /= 1) then
             print *, "read_boozer_chartmap: A_phi must be one-dimensional"
             error stop "read_boozer_chartmap failed"
         end if
         call check(nf90_inquire_dimension(ncid, dimids(1), name=dim_name, len=n_aphi), &
-                   "A_phi dim")
+            "A_phi dim")
 
         abscissa = ""
         status = nf90_get_att(ncid, varid, "radial_abscissa", abscissa)
@@ -203,9 +239,9 @@ contains
         integer :: varid, ndims
 
         call check(nf90_inq_varid(ncid, trim(var_name), varid), &
-                   "inq_var "//trim(var_name))
+            "inq_var "//trim(var_name))
         call check(nf90_inquire_variable(ncid, varid, ndims=ndims), &
-                   "inquire "//trim(var_name))
+            "inquire "//trim(var_name))
         if (ndims /= 0) then
             print *, "read_boozer_chartmap: ", trim(var_name), " must be scalar"
             error stop "read_boozer_chartmap failed"
@@ -221,9 +257,9 @@ contains
         character(len=nf90_max_name) :: dim_name
 
         call check(nf90_inq_varid(ncid, trim(var_name), varid), &
-                   "inq_var "//trim(var_name))
+            "inq_var "//trim(var_name))
         call check(nf90_inquire_variable(ncid, varid, ndims=ndims, dimids=dimids), &
-                   "inquire "//trim(var_name))
+            "inquire "//trim(var_name))
         if (ndims /= size(expected)) then
             print *, "read_boozer_chartmap: ", trim(var_name), " must have ", &
                 size(expected), " dimensions"
@@ -231,7 +267,7 @@ contains
         end if
         do i = 1, size(expected)
             call check(nf90_inquire_dimension(ncid, dimids(i), name=dim_name), &
-                       "dimension for "//trim(var_name))
+                "dimension for "//trim(var_name))
             if (trim(dim_name) /= trim(expected(i))) then
                 print *, "read_boozer_chartmap: ", trim(var_name), &
                     " dimension ", i, " is ", trim(dim_name), &

--- a/src/vmec_support/vmecinm_m.f90
+++ b/src/vmec_support/vmecinm_m.f90
@@ -74,11 +74,13 @@ contains
         lasym = (lasym_int == 1)
 
         call nc_get(ncid, 'phi', phi)
-        ! VMEC is left-handed (phi_v = -cylindrical angle, signgs = -1), so the wout
-        ! stores a negative enclosed toroidal flux. SIMPLE works with a positive
-        ! internal psi_tor = -phi_vmec/(2*pi). This is the toroidal flux on the
-        ! poloidal covariant component, A_theta = torflux*s (see spline_vmec_data),
-        ! and the reader recovers iota = -dA_phi/dA_theta = +iota_vmec.
+        ! VMEC zeta is the physical geometric cylindrical azimuth.  Its usual
+        ! (s, theta, zeta) chart is nevertheless left-handed (signgs=-1), because
+        ! of the poloidal-angle orientation.  For an oriented Jacobian J<0,
+        ! B^zeta=(dA_theta/ds)/J; hence a positive outward VMEC Phi_tor requires
+        ! A_theta=-Phi_tor/(2*pi).  This is why SIMPLE stores
+        ! torflux=-phi_vmec/(2*pi): no toroidal-angle reversal is involved.
+        ! A_phi=-chi then gives iota=-dA_phi/dA_theta=+iota_vmec.
         phi = -phi/(2*pi)
 
         flux = phi(kparb)

--- a/test/source/test_geoflux.f90
+++ b/test/source/test_geoflux.f90
@@ -1,7 +1,8 @@
 program test_geoflux
     use, intrinsic :: iso_fortran_env, only : dp => real64
     use, intrinsic :: ieee_arithmetic, only : ieee_is_finite
-    use geoflux_coordinates, only : geoflux_to_cyl, cyl_to_geoflux
+    use geoflux_coordinates, only : geoflux_to_cyl, cyl_to_geoflux, &
+                                    geoflux_get_flux_profiles
     use geoflux_field, only : spline_geoflux_data, splint_geoflux_field
     use field_sub, only : field_eq, psif
     use field_eq_mod, only : psi_axis
@@ -29,6 +30,7 @@ program test_geoflux
     real(dp) :: hcov_expected(3)
     real(dp) :: psi_expected
     real(dp) :: tol_field
+    real(dp) :: q_profile, dq_ds, psi_pol, dpsi_pol_ds, psi_tor_edge
 
     geqdsk_file = fallback_geqdsk
     arg_buffer = ''
@@ -44,6 +46,20 @@ program test_geoflux
     end if
 
     call spline_geoflux_data(trim(geqdsk_file), 64, 128)
+
+    call geoflux_get_flux_profiles(0.3_dp, q_profile, dq_ds, psi_pol, &
+                                   dpsi_pol_ds, psi_tor_edge)
+    if (.not. all(ieee_is_finite([q_profile, dq_ds, psi_pol, &
+                                  dpsi_pol_ds, psi_tor_edge]))) then
+        write(*,*) 'Non-finite geoflux profile metadata.'
+        error stop
+    end if
+    if (abs(q_profile) <= tiny(q_profile) .or. &
+        abs(dpsi_pol_ds) <= tiny(dpsi_pol_ds) .or. &
+        abs(psi_tor_edge) <= tiny(psi_tor_edge)) then
+        write(*,*) 'Degenerate geoflux profile metadata.'
+        error stop
+    end if
 
     x_geo = [0.3_dp, 0.5_dp, 0.0_dp]
     call geoflux_to_cyl(x_geo, x_cyl)


### PR DESCRIPTION
## Summary
- harden EQDSK-to-VMEC boundary/profile generation and cover it with regression tests
- add a provenance-recording hiddenSymmetries `booz_xform` runner
- carry VMEC radii and an explicit covariant-current sign into Boozer chartmaps
- derive an equal-area minor radius for legacy chartmaps without metadata

The explicit covariant sign is a coordinate/current-convention map; it does not fit phase, gain, amplitude, or radius.

## Validation
- `uv run --python 3.14 --locked pytest -q python/tests` (63 passed, 1 skipped)
- `fo` (build, tests, lint, format: passed)