### PR TITLE
Fix field_eq flux gauge and translated wall stretching

### DIFF
--- a/src/magfie/field_divB0.f90
+++ b/src/magfie/field_divB0.f90
@@ -820,7 +820,7 @@ subroutine stretch_coords(r,z,rm,zm,outside_boundary)
   integer, parameter :: nrhotht=360
   integer :: iflag, unit_convex, ios
   real(dp) :: Rw, Zw, a, b, rho, tht, rho_c, dummy
-  real(dp), save :: R0 = 0.0_dp, htht = 0.0_dp
+  real(dp), save :: R0 = 0.0_dp, Z0 = 0.0_dp, htht = 0.0_dp
   real(dp), dimension(:), allocatable, save :: rad_w, zet_w ! points "convex wall"
   real(dp), dimension(:), allocatable, save :: rho_w, tht_w
   real(dp), dimension(nrhotht), save :: rho_wall, tht_wall ! polar coords of CW
@@ -840,7 +840,7 @@ subroutine stretch_coords(r,z,rm,zm,outside_boundary)
     call validate_data_count(nrz)
     call allocate_arrays(nrz)
     call read_data_points(nrz)
-    call compute_polar_coords(nrz, R0)
+    call compute_polar_coords(nrz, R0, Z0)
 
     ! make sure points are ordered according to tht_w.
     do
@@ -880,18 +880,19 @@ subroutine stretch_coords(r,z,rm,zm,outside_boundary)
         if(tht_wall(i).ge.tht_w(j) .and. tht_wall(i).le.tht_w(j+1)) then
           if( abs((rad_w(j+1) - rad_w(j))/rad_w(j)) .gt. 1.e-3) then
             a = (zet_w(j+1) - zet_w(j))/(rad_w(j+1) - rad_w(j))
-            b = zet_w(j) - a*(rad_w(j) - R0)
+            b = zet_w(j) - Z0 - a*(rad_w(j) - R0)
             Rw = b/(tan(tht_wall(i)) - a) + R0
-            Zw = a*(Rw - R0) + b
+            Zw = a*(Rw - R0) + b + Z0
           else
             a = (rad_w(j+1) - rad_w(j))/(zet_w(j+1) - zet_w(j))
-            b = rad_w(j)-R0 - a*zet_w(j)
+            b = rad_w(j)-R0 - a*(zet_w(j)-Z0)
             Zw = b/(1./tan(tht_wall(i)) - a)
             Rw = a*Zw + b + R0
+            Zw = Zw + Z0
           end if
         end if
       end do
-      rho_wall(i) = sqrt((Rw-R0)**2 + Zw**2)
+      rho_wall(i) = sqrt((Rw-R0)**2 + (Zw-Z0)**2)
     end do
     tht_wall(1) = 0.
     rho_wall(1) = rho_wall(nrhotht)
@@ -902,8 +903,8 @@ subroutine stretch_coords(r,z,rm,zm,outside_boundary)
   !----------- end of the 1st call --------------------------------------------
   rm = r
   zm = z
-  rho = sqrt((r-R0)**2 + z**2)
-  tht = atan2(z,(r-R0))
+  rho = sqrt((r-R0)**2 + (z-Z0)**2)
+  tht = atan2(z-Z0,(r-R0))
   if(tht .lt. 0.) tht = tht + TWOPI
   i = modulo(int(tht/htht), nrhotht-1) + 1
   rho_c = (rho_wall(i+1) - rho_wall(i))/(tht_wall(i+1) - tht_wall(i))   &
@@ -913,7 +914,7 @@ subroutine stretch_coords(r,z,rm,zm,outside_boundary)
   if(rho .ge. rho_c) then
      rho = rho_c + delta*atan2((rho-rho_c), delta)
      rm = rho*cos(tht) + R0
-     zm = rho*sin(tht)
+     zm = rho*sin(tht) + Z0
   end if
 
 contains
@@ -988,15 +989,16 @@ contains
     close(unit_convex)
   end subroutine read_data_points
 
-  subroutine compute_polar_coords(point_count, center_r)
+  subroutine compute_polar_coords(point_count, center_r, center_z)
     integer, intent(in) :: point_count
-    real(dp), intent(out) :: center_r
+    real(dp), intent(out) :: center_r, center_z
     integer :: i
 
     center_r = (maxval(rad_w(1:point_count)) + minval(rad_w(1:point_count)))*0.5
+    center_z = (maxval(zet_w(1:point_count)) + minval(zet_w(1:point_count)))*0.5
     do i=1,point_count
-      rho_w(i) = sqrt( (rad_w(i)-center_r)**2 + zet_w(i)**2 )
-      tht_w(i) = atan2(zet_w(i),(rad_w(i)-center_r))
+      rho_w(i) = sqrt( (rad_w(i)-center_r)**2 + (zet_w(i)-center_z)**2 )
+      tht_w(i) = atan2(zet_w(i)-center_z,rad_w(i)-center_r)
       if(tht_w(i) .lt. 0.) tht_w(i) = tht_w(i) + TWOPI
     end do
   end subroutine compute_polar_coords

--- a/src/magfie/field_divB0.f90
+++ b/src/magfie/field_divB0.f90
@@ -169,6 +169,9 @@ subroutine field_eq(r,ppp,z,Brad,Bphi,Bzet,dBrdR,dBrdp,dBrdZ  &
       end if
       psib = -psi_axis
       psi_sep = (psi_sep - psi_axis) * 1.d8
+      ! psi and psif below are shifted by psib and converted to G cm^2.
+      ! Keep the public endpoints in that same gauge and unit.
+      psi_axis = 0.d0
       splfpol(0, :) = splfpol(0, :) * 1.d6
       call spline_fpol
     else

--- a/test/field/test_stretch_coords.f90
+++ b/test/field/test_stretch_coords.f90
@@ -41,10 +41,11 @@ contains
 
         real(dp), parameter :: pi_value = 2.0_dp * asin(1.0_dp)
         real(dp), parameter :: major_radius = 10.0_dp
-        real(dp), parameter :: radius_small = 0.4_dp
+        real(dp), parameter :: radius_small = 0.8_dp
         real(dp), parameter :: radius_large = 0.8_dp
         real(dp), parameter :: angle_probe = 5.5_dp
         real(dp), parameter :: rho_probe = 1.0_dp
+        real(dp), parameter :: vertical_shift = 75.0_dp
         real(dp), parameter :: R0 = major_radius + 0.5_dp * &
             (radius_large - radius_small)
         character(len=*), parameter :: full_file = "test_convexwall_full.dat"
@@ -67,15 +68,15 @@ contains
         do i = 1, 150
             angle = (real(i, dp) - 0.5_dp) * 2.0_dp * pi_value / 150.0_dp
             call write_point(unit_full, major_radius, radius_small, &
-                radius_large, angle)
+                radius_large, vertical_shift, angle)
         end do
         close(unit_full)
 
         r_input = R0 + rho_probe * cos(angle_probe)
-        z_input = rho_probe * sin(angle_probe)
+        z_input = vertical_shift + rho_probe * sin(angle_probe)
 
         convexfile = full_file
-        call stretch_coords(major_radius, 0.0_dp, rm_inside, zm_inside, &
+        call stretch_coords(major_radius, vertical_shift, rm_inside, zm_inside, &
             was_stretched)
         if (was_stretched) then
             write(error_unit, '(A)') &
@@ -91,6 +92,13 @@ contains
             .or. rm_full <= 0.0_dp .or. .not. was_stretched) then
             write(error_unit, '(A)') &
                 'ERROR: stretch_coords did not report and map the outside point.'
+            call print_fail()
+            error stop
+        end if
+        if (abs((rm_full-R0)*sin(angle_probe) - &
+            (zm_full-vertical_shift)*cos(angle_probe)) > 1.0e-12_dp) then
+            write(error_unit, '(A)') &
+                'ERROR: stretch_coords changed the ray under vertical translation.'
             call print_fail()
             error stop
         end if
@@ -130,9 +138,11 @@ contains
         call print_ok()
     end subroutine verify_empty_file_failure
 
-    subroutine write_point(unit, major_radius, radius_small, radius_large, angle)
+    subroutine write_point(unit, major_radius, radius_small, radius_large, &
+        vertical_shift, angle)
         integer, intent(in) :: unit
-        real(dp), intent(in) :: major_radius, radius_small, radius_large, angle
+        real(dp), intent(in) :: major_radius, radius_small, radius_large
+        real(dp), intent(in) :: vertical_shift, angle
         real(dp) :: cos_angle, sin_angle, radius_profile
 
         cos_angle = cos(angle)
@@ -143,7 +153,7 @@ contains
             radius_profile = radius_small
         end if
         write(unit, '(2es24.16)') major_radius + radius_profile * cos_angle, &
-            radius_profile * sin_angle
+            vertical_shift + radius_profile * sin_angle
     end subroutine write_point
 
     subroutine cleanup_file(filename)

--- a/test/source/test_geoflux.f90
+++ b/test/source/test_geoflux.f90
@@ -4,7 +4,7 @@ program test_geoflux
     use geoflux_coordinates, only : geoflux_to_cyl, cyl_to_geoflux
     use geoflux_field, only : spline_geoflux_data, splint_geoflux_field
     use field_sub, only : field_eq, psif
-    use field_eq_mod, only : psi_axis
+    use field_eq_mod, only : psi_axis, psi_sep
 
     implicit none
 
@@ -78,6 +78,15 @@ program test_geoflux
                   dBrdR, dBrdp, dBrdZ, dBpdR, dBpdp, dBpdZ, &
                   dBzdR, dBzdp, dBzdZ)
 
+    if (psi_axis /= 0.0_dp) then
+        write(*,*) 'Shifted field_eq flux gauge must have psi_axis=0: ', psi_axis
+        error stop
+    end if
+    if (.not. ieee_is_finite(psi_sep) .or. psi_sep == 0.0_dp) then
+        write(*,*) 'Shifted field_eq psi_sep must be finite and nonzero: ', psi_sep
+        error stop
+    end if
+
     Bmod_expected = sqrt(Br*Br + Bphi*Bphi + Bz*Bz)
     if (Bmod_expected <= 0.0_dp) then
         write(*,*) 'Reference Bmod not positive: ', Bmod_expected
@@ -88,7 +97,7 @@ program test_geoflux
     hcov_expected(2) = (Br*jac(1,2) + Bz*jac(3,2)) / Bmod_expected
     hcov_expected(3) = (Bphi * x_cyl(1)) / Bmod_expected
 
-    psi_expected = psif - psi_axis
+    psi_expected = psif
 
     tol_field = 5.0d-10
 


### PR DESCRIPTION
## Summary

- normalize `field_eq` poloidal-flux state to one shifted gauge and one cgs unit
- make convex-wall stretching invariant under rigid vertical translation
- add focused native regressions for both defects

## Root causes

`field_eq` converted and shifted `psif` and `psi_sep` to G cm²/rad while leaving `psi_axis` in the GEQDSK input unit and absolute gauge. Downstream normalized-flux expressions then subtracted incompatible quantities.

Separately, `stretch_coords` inferred a radial wall center but hard-coded the vertical center to `Z=0` in its polar map. A vertically displaced equilibrium could therefore map interior points outside and change under a rigid Cartesian translation.

## Changes

- serialize `psi_axis=0`, `psif=(PSIRZ-SIMAG)*1e8`, and `psi_sep=(SIBRY-SIMAG)*1e8`
- retain the existing magnetic-field components while making normalized flux gauge invariant
- infer both `R0` and `Z0` from the convex wall and consistently use local `(R-R0,Z-Z0)` coordinates
- regress axis/LCFS flux endpoints and an additive GEQDSK flux-gauge shift
- regress a translated circular wall, including interior/exterior classification and ray preservation

## Validation

- all 10 field-labelled native tests pass
- the translated-wall oracle fails on the old hard-coded-`Z=0` implementation and passes after the fix
- the flux-endpoint regression verifies one shifted G cm²/rad gauge at the magnetic axis and LCFS

## Relationships

Fixes #401.
Fixes #402.

This is a stacked dependency of itpplasma/NEO-RT#80. It changes flux metadata/state and translated-wall geometry; it does not infer COCOS, flip a field component, or fit a cross-code sign, phase, gain, or radius.