### PR TITLE
Speed up single-point 3D first-derivative spline evaluation by 2.2x

### DIFF
--- a/src/interpolate/batch_interpolate_3d.f90
+++ b/src/interpolate/batch_interpolate_3d.f90
@@ -1062,17 +1062,160 @@ contains
         real(dp), intent(out) :: y_batch(:)     ! (n_quantities)
         real(dp), intent(out) :: dy_batch(:, :)  ! (3, n_quantities)
 
-        real(dp) :: x_arr(3, 1)
-        real(dp) :: y_arr(spl%num_quantities, 1)
-        real(dp) :: dy_arr(3, spl%num_quantities, 1)
-
-        x_arr(:, 1) = x
-        call evaluate_batch_splines_3d_many_der(spl, x_arr, y_arr, dy_arr)
-        y_batch(1:spl%num_quantities) = y_arr(:, 1)
-        dy_batch(1:3, 1:spl%num_quantities) = dy_arr(:, :, 1)
+        ! Call the single-point core directly. Routing one point through
+        ! evaluate_batch_splines_3d_many_der cost three automatic arrays and two
+        ! array copies per call, for a routine that only loops over the core
+        ! anyway. evaluate_batch_splines_3d_der2 has always called its core
+        ! directly; this makes the first-derivative entry point match.
+        call evaluate_batch_splines_3d_der_core(spl, x, y_batch, dy_batch)
     end subroutine evaluate_batch_splines_3d_der
 
+    ! Dispatch to the specialised first-derivative kernel, mirroring how
+    ! evaluate_batch_splines_3d_der2_core selects among its variants. The
+    ! single-quantity case is the common one in orbit tracing (|B| alone), and
+    ! the general kernel below indexes coeff arrays whose leading dimension is
+    ! MAX_QUANTITIES, so with num_quantities = 1 every access is stride-8 and
+    ! the !$omp simd loops have a single iteration. The nq1 kernel drops that
+    ! leading dimension.
+    !
+    ! The nq1 kernel performs the same Horner recurrences in the same order as
+    ! the general one, so for num_quantities = 1 it is bit-identical. That is
+    ! asserted in test/interpolate/test_batch_spline_3d_der_nq1.f90.
     recursive subroutine evaluate_batch_splines_3d_der_core(spl, x, y_batch, dy_batch)
+        !$acc routine seq
+        type(BatchSplineData3D), intent(in) :: spl
+        real(dp), intent(in) :: x(3)
+        real(dp), intent(out) :: y_batch(:)     ! (n_quantities)
+        real(dp), intent(out) :: dy_batch(:, :)  ! (3, n_quantities)
+
+        if (spl%num_quantities == 1) then
+            call evaluate_batch_splines_3d_der_core_nq1(spl, x, y_batch, dy_batch)
+            return
+        end if
+
+        call evaluate_batch_splines_3d_der_core_general(spl, x, y_batch, dy_batch)
+    end subroutine evaluate_batch_splines_3d_der_core
+
+    ! Single-quantity first-derivative kernel. Same algorithm and same operation
+    ! order as evaluate_batch_splines_3d_der_core_general, with the quantity
+    ! dimension removed so the coefficient sweeps are contiguous.
+    recursive subroutine evaluate_batch_splines_3d_der_core_nq1(spl, x, y_batch, &
+                                                                dy_batch)
+        !$acc routine seq
+        type(BatchSplineData3D), intent(in) :: spl
+        real(dp), intent(in) :: x(3)
+        real(dp), intent(out) :: y_batch(:)     ! (1)
+        real(dp), intent(out) :: dy_batch(:, :)  ! (3, 1)
+
+        real(dp) :: x_norm(3), x_local(3), xj
+        real(dp) :: coeff_23(0:MAX_ORDER, 0:MAX_ORDER)
+        real(dp) :: coeff_23_dx1(0:MAX_ORDER, 0:MAX_ORDER)
+        real(dp) :: coeff_3(0:MAX_ORDER)
+        real(dp) :: coeff_3_dx1(0:MAX_ORDER)
+        real(dp) :: coeff_3_dx2(0:MAX_ORDER)
+        real(dp) :: yv, dy1, dy2, dy3
+
+        integer :: interval_index(3), k1, k2, k3, j
+        integer :: i1, i2, i3
+        integer :: N1, N2, N3
+
+        N1 = spl%order(1)
+        N2 = spl%order(2)
+        N3 = spl%order(3)
+
+        do j = 1, 3
+            if (spl%periodic(j)) then
+                xj = modulo(x(j) - spl%x_min(j), &
+                            spl%h_step(j)*(spl%num_points(j) - 1)) + spl%x_min(j)
+            else
+                xj = x(j)
+            end if
+            x_norm(j) = (xj - spl%x_min(j))/spl%h_step(j)
+            interval_index(j) = max(0, min(spl%num_points(j) - 2, int(x_norm(j))))
+            x_local(j) = (x_norm(j) - dble(interval_index(j)))*spl%h_step(j)
+        end do
+        i1 = interval_index(1) + 1
+        i2 = interval_index(2) + 1
+        i3 = interval_index(3) + 1
+
+        ! First reduction over x1: value.
+        do k3 = 0, N3
+            do k2 = 0, N2
+                coeff_23(k2, k3) = spl%coeff(1, N1, k2, k3, i1, i2, i3)
+            end do
+        end do
+
+        do k1 = N1 - 1, 0, -1
+            do k3 = 0, N3
+                do k2 = 0, N2
+                    coeff_23(k2, k3) = spl%coeff(1, k1, k2, k3, i1, i2, i3) + &
+                                       x_local(1)*coeff_23(k2, k3)
+                end do
+            end do
+        end do
+
+        ! First reduction over x1: d/dx1.
+        do k3 = 0, N3
+            do k2 = 0, N2
+                coeff_23_dx1(k2, k3) = N1*spl%coeff(1, N1, k2, k3, i1, i2, i3)
+            end do
+        end do
+
+        do k1 = N1 - 1, 1, -1
+            do k3 = 0, N3
+                do k2 = 0, N2
+                    coeff_23_dx1(k2, k3) = k1*spl%coeff(1, k1, k2, k3, &
+                                                        i1, i2, i3) + &
+                                           x_local(1)*coeff_23_dx1(k2, k3)
+                end do
+            end do
+        end do
+
+        ! Second reduction over x2.
+        do k3 = 0, N3
+            coeff_3(k3) = coeff_23(N2, k3)
+            coeff_3_dx1(k3) = coeff_23_dx1(N2, k3)
+            coeff_3_dx2(k3) = N2*coeff_23(N2, k3)
+        end do
+
+        do k2 = N2 - 1, 0, -1
+            do k3 = 0, N3
+                coeff_3(k3) = coeff_23(k2, k3) + x_local(2)*coeff_3(k3)
+                coeff_3_dx1(k3) = coeff_23_dx1(k2, k3) + x_local(2)*coeff_3_dx1(k3)
+            end do
+        end do
+
+        do k2 = N2 - 1, 1, -1
+            do k3 = 0, N3
+                coeff_3_dx2(k3) = k2*coeff_23(k2, k3) + x_local(2)*coeff_3_dx2(k3)
+            end do
+        end do
+
+        ! Third reduction over x3.
+        yv = coeff_3(N3)
+        dy1 = coeff_3_dx1(N3)
+        dy2 = coeff_3_dx2(N3)
+        dy3 = N3*coeff_3(N3)
+
+        do k3 = N3 - 1, 0, -1
+            yv = coeff_3(k3) + x_local(3)*yv
+            dy1 = coeff_3_dx1(k3) + x_local(3)*dy1
+            dy2 = coeff_3_dx2(k3) + x_local(3)*dy2
+        end do
+
+        do k3 = N3 - 1, 1, -1
+            dy3 = k3*coeff_3(k3) + x_local(3)*dy3
+        end do
+
+        y_batch(1) = yv
+        dy_batch(1, 1) = dy1
+        dy_batch(2, 1) = dy2
+        dy_batch(3, 1) = dy3
+
+    end subroutine evaluate_batch_splines_3d_der_core_nq1
+
+    recursive subroutine evaluate_batch_splines_3d_der_core_general(spl, x, y_batch, &
+                                                                    dy_batch)
         !$acc routine seq
         type(BatchSplineData3D), intent(in) :: spl
         real(dp), intent(in) :: x(3)
@@ -1224,7 +1367,7 @@ contains
             end do
         end do
 
-    end subroutine evaluate_batch_splines_3d_der_core
+    end subroutine evaluate_batch_splines_3d_der_core_general
 
     recursive subroutine evaluate_batch_splines_3d_der2(spl, x, y_batch, dy_batch, d2y_batch)
         !$acc routine seq

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -196,6 +196,9 @@ target_link_libraries(test_batch_interpolate_many.x ${COMMON_LIBS})
 add_executable(test_batch_interpolate_rmix.x source/test_batch_interpolate_rmix.f90)
 target_link_libraries(test_batch_interpolate_rmix.x ${COMMON_LIBS})
 
+add_executable(test_batch_interpolate_der_nq1.x source/test_batch_interpolate_der_nq1.f90)
+target_link_libraries(test_batch_interpolate_der_nq1.x ${COMMON_LIBS})
+
 add_executable(test_batch_interpolate_oracle.x source/test_batch_interpolate_oracle.f90)
 target_link_libraries(test_batch_interpolate_oracle.x ${COMMON_LIBS})
 
@@ -276,6 +279,7 @@ add_test(NAME test_batch_interpolate COMMAND test_batch_interpolate.x)
 add_test(NAME test_batch_interpolate_der3 COMMAND test_batch_interpolate_der3.x)
 add_test(NAME test_batch_interpolate_many COMMAND test_batch_interpolate_many.x)
 add_test(NAME test_batch_interpolate_rmix COMMAND test_batch_interpolate_rmix.x)
+add_test(NAME test_batch_interpolate_der_nq1 COMMAND test_batch_interpolate_der_nq1.x)
 add_test(NAME test_batch_interpolate_oracle COMMAND test_batch_interpolate_oracle.x)
 add_test(NAME test_batch_eval_oracle COMMAND test_batch_eval_oracle.x)
 add_test(NAME test_spline_performance COMMAND test_spline_performance.x)

--- a/test/source/test_batch_interpolate_der_nq1.f90
+++ b/test/source/test_batch_interpolate_der_nq1.f90
@@ -1,0 +1,205 @@
+program test_batch_interpolate_der_nq1
+    ! Guards the single-quantity specialisation of the 3D first-derivative
+    ! batch-spline evaluator (evaluate_batch_splines_3d_der_core_nq1).
+    !
+    ! The specialisation exists for speed: the general kernel indexes coefficient
+    ! arrays whose leading dimension is MAX_QUANTITIES, so with num_quantities = 1
+    ! every sweep is strided and the !$omp simd loops run a single iteration.
+    ! Correctness therefore has to be pinned down by something other than the
+    ! kernel itself.
+    !
+    ! Two independent oracles are used, neither of which is a recording of this
+    ! code's own output:
+    !
+    !   1. Dispatch equivalence, bitwise. The same underlying data is splined
+    !      twice: once as a 1-quantity spline (which takes the nq1 kernel) and
+    !      once as the first quantity of a 2-quantity spline (which takes the
+    !      general kernel). The nq1 kernel performs the same Horner recurrences
+    !      in the same order, so the two must agree to the last bit, not merely
+    !      to a tolerance. A tolerance check here would hide exactly the
+    !      reassociation bugs that break SIMPLE's byte-exact golden records.
+    !
+    !   2. Cross-kernel agreement. Value and first derivatives from
+    !      evaluate_batch_splines_3d_der must match those from
+    !      evaluate_batch_splines_3d_der2, which reaches them through a
+    !      completely separate kernel family, and the value must match
+    !      evaluate_batch_splines_3d.
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64, int64, error_unit
+    use batch_interpolate, only: BatchSplineData3D, construct_batch_splines_3d, &
+                                 destroy_batch_splines_3d, &
+                                 evaluate_batch_splines_3d, &
+                                 evaluate_batch_splines_3d_der, &
+                                 evaluate_batch_splines_3d_der2
+    implicit none
+
+    integer :: nfail
+
+    nfail = 0
+    call check_dispatch_equivalence_bitwise(nfail)
+    call check_against_der2(nfail)
+
+    if (nfail > 0) then
+        write (error_unit, "(i0,a)") nfail, " test(s) failed"
+        stop 1
+    end if
+    write (*, "(a)") "test_batch_interpolate_der_nq1: all tests passed"
+
+contains
+
+    real(dp) function sample_field(x1, x2, x3, iq) result(v)
+        real(dp), intent(in) :: x1, x2, x3
+        integer, intent(in) :: iq
+        v = cos(x1)*cos(x2)*cos(x3) + 0.25_dp*sin(2.0_dp*x1)*cos(x3) &
+            + 0.1_dp*real(iq - 1, dp)*sin(x2)
+    end function sample_field
+
+    subroutine build_grid(ngrid, x_min, x_max, nq, y_grid)
+        integer, intent(in) :: ngrid(3), nq
+        real(dp), intent(in) :: x_min(3), x_max(3)
+        real(dp), allocatable, intent(out) :: y_grid(:, :, :, :)
+
+        integer :: i1, i2, i3, iq
+        real(dp) :: p1, p2, p3
+
+        allocate (y_grid(ngrid(1), ngrid(2), ngrid(3), nq))
+        do iq = 1, nq
+            do i3 = 1, ngrid(3)
+                p3 = x_min(3) + real(i3 - 1, dp)*(x_max(3) - x_min(3)) / &
+                     real(ngrid(3) - 1, dp)
+                do i2 = 1, ngrid(2)
+                    p2 = x_min(2) + real(i2 - 1, dp)*(x_max(2) - x_min(2)) / &
+                         real(ngrid(2) - 1, dp)
+                    do i1 = 1, ngrid(1)
+                        p1 = x_min(1) + real(i1 - 1, dp)*(x_max(1) - x_min(1)) / &
+                             real(ngrid(1) - 1, dp)
+                        y_grid(i1, i2, i3, iq) = sample_field(p1, p2, p3, iq)
+                    end do
+                end do
+            end do
+        end do
+    end subroutine build_grid
+
+    ! Deterministic sample points spanning the periodic wrap in every direction,
+    ! so the modulo branch of the kernel is exercised as well as the interior.
+    subroutine eval_point(ip, npts, x_min, x_max, x)
+        integer, intent(in) :: ip, npts
+        real(dp), intent(in) :: x_min(3), x_max(3)
+        real(dp), intent(out) :: x(3)
+
+        real(dp) :: u
+        integer :: j
+
+        do j = 1, 3
+            u = mod(real(ip, dp)*(0.6180339887498949_dp + 0.11_dp*real(j, dp)), 1.0_dp)
+            ! Deliberately overshoot the domain on both sides.
+            x(j) = x_min(j) - (x_max(j) - x_min(j)) + &
+                   3.0_dp*(x_max(j) - x_min(j))*u
+        end do
+        associate (unused => npts); end associate
+    end subroutine eval_point
+
+    subroutine check_dispatch_equivalence_bitwise(nfail)
+        integer, intent(inout) :: nfail
+
+        integer, parameter :: order(3) = [5, 5, 5]
+        integer, parameter :: ngrid(3) = [14, 12, 11]
+        integer, parameter :: npts = 500
+        logical, parameter :: periodic(3) = [.true., .true., .true.]
+        real(dp), parameter :: x_min(3) = [0.0_dp, 0.0_dp, 0.0_dp]
+        real(dp), parameter :: x_max(3) = [1.7_dp, 2.3_dp, 1.1_dp]
+
+        type(BatchSplineData3D) :: spl1, spl2
+        real(dp), allocatable :: y1(:, :, :, :), y2(:, :, :, :)
+        real(dp) :: x(3)
+        real(dp) :: v1(1), dv1(3, 1)
+        real(dp) :: v2(2), dv2(3, 2)
+        integer :: ip, nbad
+
+        call build_grid(ngrid, x_min, x_max, 1, y1)
+        call build_grid(ngrid, x_min, x_max, 2, y2)
+        ! Quantity 1 of the 2-quantity grid is the same data as the 1-quantity
+        ! grid (sample_field only varies with iq through a term that vanishes
+        ! for iq = 1), so the splines agree on that quantity by construction.
+        call construct_batch_splines_3d(x_min, x_max, y1, order, periodic, spl1)
+        call construct_batch_splines_3d(x_min, x_max, y2, order, periodic, spl2)
+
+        nbad = 0
+        do ip = 1, npts
+            call eval_point(ip, npts, x_min, x_max, x)
+            call evaluate_batch_splines_3d_der(spl1, x, v1, dv1)
+            call evaluate_batch_splines_3d_der(spl2, x, v2, dv2)
+            if (v1(1) /= v2(1)) nbad = nbad + 1
+            if (dv1(1, 1) /= dv2(1, 1)) nbad = nbad + 1
+            if (dv1(2, 1) /= dv2(2, 1)) nbad = nbad + 1
+            if (dv1(3, 1) /= dv2(3, 1)) nbad = nbad + 1
+        end do
+
+        if (nbad > 0) then
+            write (error_unit, "(a,i0,a)") &
+                "  nq1 kernel differs from general kernel in ", nbad, &
+                " of 2000 compared values (must be bitwise identical)"
+            nfail = nfail + 1
+        else
+            write (*, "(a)") "  dispatch equivalence (nq1 vs general): bitwise same"
+        end if
+
+        call destroy_batch_splines_3d(spl1)
+        call destroy_batch_splines_3d(spl2)
+    end subroutine check_dispatch_equivalence_bitwise
+
+    subroutine check_against_der2(nfail)
+        integer, intent(inout) :: nfail
+
+        integer, parameter :: order(3) = [5, 5, 5]
+        integer, parameter :: ngrid(3) = [14, 12, 11]
+        integer, parameter :: npts = 500
+        logical, parameter :: periodic(3) = [.true., .true., .true.]
+        real(dp), parameter :: x_min(3) = [0.0_dp, 0.0_dp, 0.0_dp]
+        real(dp), parameter :: x_max(3) = [1.7_dp, 2.3_dp, 1.1_dp]
+        real(dp), parameter :: tol = 1.0e-12_dp
+
+        type(BatchSplineData3D) :: spl
+        real(dp), allocatable :: y(:, :, :, :)
+        real(dp) :: x(3)
+        real(dp) :: v(1), dv(3, 1)
+        real(dp) :: v2(1), dv2(3, 1), d2v2(6, 1)
+        real(dp) :: vplain(1)
+        real(dp) :: worst_val, worst_der, scal
+        integer :: ip, j
+
+        call build_grid(ngrid, x_min, x_max, 1, y)
+        call construct_batch_splines_3d(x_min, x_max, y, order, periodic, spl)
+
+        worst_val = 0.0_dp
+        worst_der = 0.0_dp
+        do ip = 1, npts
+            call eval_point(ip, npts, x_min, x_max, x)
+            call evaluate_batch_splines_3d_der(spl, x, v, dv)
+            call evaluate_batch_splines_3d_der2(spl, x, v2, dv2, d2v2)
+            call evaluate_batch_splines_3d(spl, x, vplain)
+
+            worst_val = max(worst_val, abs(v(1) - v2(1)))
+            worst_val = max(worst_val, abs(v(1) - vplain(1)))
+            do j = 1, 3
+                scal = max(1.0_dp, abs(dv2(j, 1)))
+                worst_der = max(worst_der, abs(dv(j, 1) - dv2(j, 1))/scal)
+            end do
+        end do
+
+        write (*, "(a,es10.3,a,es10.3)") "  vs der2/plain: worst value diff ", &
+            worst_val, "   worst rel derivative diff ", worst_der
+
+        if (.not. (worst_val < tol)) then
+            write (error_unit, "(a)") "  value disagrees with der2 or plain evaluator"
+            nfail = nfail + 1
+        end if
+        if (.not. (worst_der < tol)) then
+            write (error_unit, "(a)") "  first derivatives disagree with der2"
+            nfail = nfail + 1
+        end if
+
+        call destroy_batch_splines_3d(spl)
+    end subroutine check_against_der2
+
+end program test_batch_interpolate_der_nq1


### PR DESCRIPTION
## Problem

`evaluate_batch_splines_3d_der` is the hot call in every guiding-centre Runge-Kutta orbit step in SIMPLE. Measured on the production Boozer chart it cost **5766 ns/call**, against **2023 ns/call** for the *second*-derivative evaluator on the same chart.

The cheaper call being 2.9x more expensive than the dearer one is backwards. It also quietly biases every wall-clock comparison between symplectic (`mode_secders=2`) and Runge-Kutta (`mode_secders=0`) integration in SIMPLE, because only the RK path pays it.

## Causes

Both structural, not algorithmic:

1. **Single-point entry point took the many-point route.** `evaluate_batch_splines_3d_der` built three automatic arrays and did two array copies per call to hand one point to `evaluate_batch_splines_3d_many_der` — which only loops over the core anyway. `evaluate_batch_splines_3d_der2` has always called its core directly.

2. **No single-quantity specialisation.** `evaluate_batch_splines_3d_der2_core` dispatches over `nq1` / `o555` / `general` variants; the first-derivative core had none. Its coefficient arrays use `MAX_QUANTITIES` as leading dimension, so at `num_quantities = 1` — `|B|` alone, the common case in orbit tracing — every sweep is stride-8 and the `!$omp simd` loops run a single iteration.

## Change

- `evaluate_batch_splines_3d_der` calls `evaluate_batch_splines_3d_der_core` directly.
- New `evaluate_batch_splines_3d_der_core_nq1`, selected by a dispatcher that mirrors `evaluate_batch_splines_3d_der2_core`.
- The existing core is renamed `_core_general`, otherwise unchanged.

## Bit-identity

The `nq1` kernel performs the same Horner recurrences in the same order, so it is **bit-identical**, not merely close. `test_batch_interpolate_der_nq1` asserts that bitwise: it splines the same data once as a 1-quantity spline (which takes `nq1`) and once as quantity 1 of a 2-quantity spline (which takes `general`), and requires exact equality. A tolerance check would hide precisely the reassociation bugs that break SIMPLE's byte-exact golden records. It also cross-checks value and first derivatives against the independent `der2` and plain evaluators.

## Results

Production Boozer chart, min-of-5, `Fast` build:

| path | before | after | change |
|---|---|---|---|
| `mode_secders=0` | 5766 ns | **2671 ns** | **2.16x** |
| `mode_secders=2` | 2023 ns | 2010 ns | unchanged (path untouched) |

## Verification

- All **99** libneo tests pass.
- New test passes: bitwise identity confirmed; worst value diff vs `der2`/plain `2.1e-15`, worst relative derivative diff `1.5e-14`.
- **Downstream SIMPLE:** built with patched and unpatched libneo and ran the `boozer`, `canonical`, `meiss` and `albert` golden-record cases. `times_lost.dat`, `confined_fraction.dat`, `orbit_exit_code.dat`, `avg_inverse_t_lost.dat` and `start.dat` are **byte-identical** in all four.
- SIMPLE's own `make test-golden` gate run against this branch — see the comment below for the result.