### PR TITLE
Return the converged ray root from the GEQDSK surface tracer

### DIFF
--- a/src/coordinates/geoflux_coordinates.f90
+++ b/src/coordinates/geoflux_coordinates.f90
@@ -455,11 +455,14 @@ contains
                     hypot(ctx%R_cache(is,itheta) - ctx%R_axis, &
                           ctx%Z_cache(is,itheta) - ctx%Z_axis)/ctx%rho_nodes(is)
             end do
-            ! The innermost resolved contour supplies the leading near-axis
-            ! radius. Holding that leading coefficient to the axis is the
-            ! stable discrete form of r=rho*r1; extrapolating
-            ! several tiny traced contours would instead amplify root tolerance.
-            surface_data(1,itheta,:) = surface_data(2,itheta,:)
+            ! r/rho tends to the finite shape coefficient r1(theta) as rho->0,
+            ! so the axis node is an extrapolation, not a copy.  Copying node 2
+            ! leaves an O(h) error in r1 and a slope discontinuity that the
+            ! quintic carries into its first derivatives.  Linear extrapolation
+            ! on the equidistant rho nodes is O(h^2) and is safe now that the
+            ! ray root is converged to sub-micron rather than bracket accuracy.
+            surface_data(1,itheta,1) = 2.0_dp*surface_data(2,itheta,1) &
+                - surface_data(3,itheta,1)
         end do
         ! Orbit integration consumes first derivatives of this map at high
         ! accuracy. A quintic tensor spline keeps those coefficients smooth
@@ -646,6 +649,7 @@ contains
         real(dp), intent(out) :: R_val, Z_val
 
         real(dp) :: r_low, r_high, flux_low, flux_high, r_mid, flux_mid
+        real(dp) :: r_root
         integer :: iter
 
         if (target_norm <= tol_s) then
@@ -680,9 +684,19 @@ contains
             end if
         end if
 
+        ! r_root always holds the last abscissa whose flux was actually
+        ! evaluated against the target.  Returning the bracket bound r_high
+        ! instead would discard the converged midpoint whenever the tolerance
+        ! test below exits early, leaving an error of up to half the current
+        ! bracket width.  That happens for a small fraction of targets and
+        ! displaces isolated cache nodes by centimetres, which the quintic
+        ! surface spline then turns into a ringing wave packet in dV/ds_tor.
+        r_root = 0.5_dp * (r_low + r_high)
+
         do iter = 1, max_bisect_iter
             r_mid = 0.5_dp * (r_low + r_high)
             flux_mid = flux_along_ray(r_mid, theta_val)
+            r_root = r_mid
 
             if (abs(flux_mid - target_norm) <= tol_root) exit
 
@@ -695,8 +709,8 @@ contains
             end if
         end do
 
-        R_val = clamp(ctx%R_axis + r_high * cos(theta_val), ctx%R_min, ctx%R_max)
-        Z_val = clamp(ctx%Z_axis + r_high * sin(theta_val), ctx%Z_min, ctx%Z_max)
+        R_val = clamp(ctx%R_axis + r_root * cos(theta_val), ctx%R_min, ctx%R_max)
+        Z_val = clamp(ctx%Z_axis + r_root * sin(theta_val), ctx%Z_min, ctx%Z_max)
     end subroutine locate_by_normalized_flux
 
     function flux_along_ray(r_val, theta_val) result(s_norm)

--- a/test/source/test_geoflux.f90
+++ b/test/source/test_geoflux.f90
@@ -42,6 +42,23 @@ program test_geoflux
     real(dp), parameter :: s_inner = (0.001_dp*cache_rho_step)**2
     real(dp), parameter :: s_outer = (0.002_dp*cache_rho_step)**2
     real(dp), parameter :: tol_axis_scaling = 1.0e-3_dp
+    !> Surface-residual oracle.  The chart's defining equation is that the point
+    !> returned for (s, theta) lies on the surface whose normalized poloidal flux
+    !> belongs to s.  Reading that flux back through the independent field_eq
+    !> path measures how far the returned point actually sits off it.
+    !> Sweeping the radial node count matters: an unconverged ray root
+    !> displaces one cache node by centimetres and the quintic surface spline
+    !> rings around it, so whether a given chart rings depends on which node
+    !> count happens to draw a bad root.  A converged chart is flat at ~1e-6
+    !> here for every node count; an unconverged one scatters over two decades.
+    integer, parameter :: ns_sweep(4) = [64, 72, 80, 90]
+    real(dp), parameter :: tol_surface_residual = 5.0e-6_dp
+    integer, parameter :: n_s_residual = 401, n_theta_residual = 64
+    real(dp), parameter :: s_residual_min = 1.0e-3_dp
+    real(dp), parameter :: s_residual_max = 0.64_dp
+    real(dp) :: psi_pol_axis, psi_pol_edge, psi_norm_expected, psi_norm_actual
+    real(dp) :: max_residual, s_residual, x_geo_scan(3), x_cyl_scan(3)
+    integer :: is_residual, itheta_residual, i_sweep
 
     geqdsk_file = fallback_geqdsk
     arg_buffer = ''
@@ -213,6 +230,42 @@ program test_geoflux
         write(*,*) 'expected=', psi_expected, ' got=', Acov(3)
         error stop
     end if
+
+    do i_sweep = 1, size(ns_sweep)
+        call spline_geoflux_data(trim(geqdsk_file), ns_sweep(i_sweep), &
+                                 ntheta_cache)
+        call geoflux_get_flux_profiles(0.0_dp, q_profile, dq_ds, psi_pol_axis, &
+                                       dpsi_pol_ds, psi_tor_edge)
+        call geoflux_get_flux_profiles(1.0_dp, q_profile, dq_ds, psi_pol_edge, &
+                                       dpsi_pol_ds, psi_tor_edge)
+        max_residual = 0.0_dp
+        do is_residual = 1, n_s_residual
+            s_residual = s_residual_min + (s_residual_max - s_residual_min) &
+                *real(is_residual - 1, dp)/real(n_s_residual - 1, dp)
+            call geoflux_get_flux_profiles(s_residual, q_profile, dq_ds, &
+                                           psi_pol, dpsi_pol_ds, psi_tor_edge)
+            psi_norm_expected = (psi_pol - psi_pol_axis) &
+                /(psi_pol_edge - psi_pol_axis)
+            do itheta_residual = 1, n_theta_residual
+                theta_scan = -pi + 2.0_dp*pi*real(itheta_residual - 1, dp) &
+                    /real(n_theta_residual, dp)
+                x_geo_scan = [s_residual, theta_scan, 0.0_dp]
+                call geoflux_to_cyl(x_geo_scan, x_cyl_scan)
+                call field_eq(x_cyl_scan(1), x_cyl_scan(2), x_cyl_scan(3), &
+                              Br, Bphi, Bz, dBrdR, dBrdp, dBrdZ, &
+                              dBpdR, dBpdp, dBpdZ, dBzdR, dBzdp, dBzdZ)
+                psi_norm_actual = psif/psi_sep
+                max_residual = max(max_residual, &
+                                   abs(psi_norm_actual - psi_norm_expected))
+            end do
+        end do
+        if (max_residual > tol_surface_residual) then
+            write(*,*) 'Flux surfaces are misplaced for ns_cache=', &
+                ns_sweep(i_sweep), ': ', max_residual, &
+                ' >', tol_surface_residual
+            error stop
+        end if
+    end do
 
 contains
 


### PR DESCRIPTION
Fixes the ringing wave packet in `dV/ds_tor` from the direct-EQDSK chart.

### The defect

`locate_by_normalized_flux` bisects along a ray and exits when `|flux(r_mid) - target| <= tol_root` — it has accepted `r_mid` as the root. It then built `(R,Z)` from **`r_high`**, the bracket bound, discarding that root.

If the loop instead runs all 60 iterations, `r_high` has itself converged and nothing is visible. The damage is confined to the early-exit branch, where `r_high` is off by up to half the current bracket width. Replicating the loop with the TC24 constants (`max_radius=7.055`, `ray_step=0.0706`, `tol_root=1e-8`) over 200 000 targets:

| returned value | max radial error | fraction worse than 0.1 mm | expected bad nodes in a 65x128 cache |
|---|---|---|---|
| `r_high` (current) | **52.9 mm** | 0.0295 % | **2.5** |
| `r_mid` (converged) | 0.00088 mm | 0 | 0 |

So two or three of the 8320 cache nodes are displaced by centimetres, and the quintic surface spline rings around each one: a decaying, alternating packet with one half-period per radial node. Observed extrema on TC24 spaced 0.0213, 0.0163, 0.0158, 0.0154 — converging on 1/64, the node spacing.

Which nodes go bad depends on the node count, so the defect is a lottery. Sweeping `ns_cache` over sixteen values on TC24, only `ns_cache=80` rings, at 0.524 % centred on rho_tor 0.423; the default 64 draws no bad node at all, which is why the existing tests never saw it.

### The fix

`r_root` carries the last abscissa whose flux was actually evaluated, and the surface point is built from that.

Also extrapolates rather than copies the axis node of `r/rho`. Copying node 2 left an O(h) error in the shape coefficient `r1(theta)` and a slope discontinuity the quintic carried into its first derivatives; linear extrapolation on the equidistant nodes is O(h^2) and is safe now that the root is converged to sub-micron instead of bracket accuracy.

### Oracle

Not a smoothness heuristic. The chart's defining equation is that the point returned for `(s, theta)` lies on the surface whose normalized poloidal flux belongs to `s`. The test reads that flux back through the independent `field_eq` path and compares, swept over `ns_cache` in {64, 72, 80, 90}:

| | TC24 before | TC24 after | EQDSK_I before | EQDSK_I after |
|---|---|---|---|---|
| max residual | 4.5e-5 … 5.1e-4 | 8.5e-7 … 1.2e-6 | 9.1e-6 … 4.1e-4 | 2.7e-6 … 3.0e-6 |

Flat at ~1e-6 for every node count after; scattered over two decades before. Threshold 5e-6. Verified failing on the pre-fix source and passing on the fixed one, on both equilibria, by stashing the source change. 27 related ctests pass.

### Note on `main`

`main` carries the identical bisection defect at `locate_by_normalized_flux` (`r_high * cos(theta_val)`), and does not have the axis-node code this branch introduces. The ray-root half should be ported there separately; happy to open that PR.