### PR TITLE
Bump Fortio for legacy HDF5 scalar compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ if(NOT TARGET fortio)
     FetchContent_Declare(
         fortio
         GIT_REPOSITORY https://github.com/lazy-fortran/fortio.git
-        GIT_TAG 85df537
+        GIT_TAG 9f684e33649c44044e44e1bbac1f16d318438d0e
     )
     FetchContent_MakeAvailable(fortio)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ if(NOT TARGET fortio)
     FetchContent_Declare(
         fortio
         GIT_REPOSITORY https://github.com/lazy-fortran/fortio.git
-        GIT_TAG 083c943ee0da5e996efc340a4d9a0375c6322bab
+        GIT_TAG 85df537
     )
     FetchContent_MakeAvailable(fortio)
 endif()

--- a/python/libneo/booz_xform_to_boozer_chartmap.py
+++ b/python/libneo/booz_xform_to_boozer_chartmap.py
@@ -254,9 +254,11 @@ def convert_boozmn_to_chartmap(
     bmnc_ext = extended_half(d["bmnc"])
     bmnc_s = make_interp_spline(s_half_ext, bmnc_ext, k=3, axis=0)(s)
     dbmnc = (bmnc_ext[2:-1] - bmnc_ext[1:-2]) / ds
-    dbmnc_s = make_interp_spline(
-        s_full[1:-1], dbmnc, k=3, axis=0
-    )(s)
+    # Differences of adjacent half-grid values are centered on the interior
+    # full-grid surfaces j=3..ns-2.  There are two fewer values than full
+    # surfaces because the supplied half grid starts at j=3 and ends at ns.
+    derivative_s = s_full[2:-1]
+    dbmnc_s = make_interp_spline(derivative_s, dbmnc, k=3, axis=0)(s)
 
     rk_Bmod = _fourier_eval(
         bmnc_s, d["ixm"], d["ixn"], theta_geom, zeta_geom, "cos"
@@ -284,9 +286,7 @@ def convert_boozmn_to_chartmap(
         bmns_ext = extended_half(d["bmns"])
         bmns_s = make_interp_spline(s_half_ext, bmns_ext, k=3, axis=0)(s)
         dbmns = (bmns_ext[2:-1] - bmns_ext[1:-2]) / ds
-        dbmns_s = make_interp_spline(
-            s_full[1:-1], dbmns, k=3, axis=0
-        )(s)
+        dbmns_s = make_interp_spline(derivative_s, dbmns, k=3, axis=0)(s)
         rk_Bmod += _fourier_eval(
             bmns_s, d["ixm"], d["ixn"], theta_geom, zeta_geom, "sin"
         )
@@ -314,9 +314,7 @@ def convert_boozmn_to_chartmap(
         values_ext = extended_half(values[:, None])[:, 0]
         value = make_interp_spline(s_half_ext, values_ext, k=3)(s)
         derivative_data = (values_ext[2:-1] - values_ext[1:-2]) / ds
-        derivative = make_interp_spline(
-            s_full[1:-1], derivative_data, k=3
-        )(s)
+        derivative = make_interp_spline(derivative_s, derivative_data, k=3)(s)
         return value, derivative
 
     rk_iota, _ = surface_and_derivative(iota_h)


### PR DESCRIPTION
Bump the Fortio FetchContent pin to the compatibility fix that accepts both rank-0 HDF5 integer scalars and the rank-1, length-one datasets emitted by pre-Fortio NEO-2.

The NEO-2 consumer campaign reproduced the compatibility failure; the Fortio fix has a complete local 28-test CTest pass.